### PR TITLE
Fedora JMS listener for forwarding messages to listener jobs added to fcrepo-clients

### DIFF
--- a/fcrepo-clients/pom.xml
+++ b/fcrepo-clients/pom.xml
@@ -92,6 +92,11 @@
 			<version>3.1</version>
 		</dependency>
 		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.0.1</version>
+		</dependency>
+		<dependency>
 			<groupId>javax.xml.bind</groupId>
 			<artifactId>jaxb-api</artifactId>
 			<version>2.1</version>

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/JobForwardingJMSListener.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/JobForwardingJMSListener.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.fedora;
+
+import java.io.StringReader;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.jms.Message;
+import javax.jms.MessageListener;
+import javax.jms.TextMessage;
+
+import org.jdom.Document;
+import org.jdom.input.SAXBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Listener for Fedora JMS queue/topic which interprets the incoming text messages and forwards relevant message data on
+ * to all registered listener jobs
+ *
+ * @author bbpennel
+ * @date Mar 17, 2014
+ */
+public class JobForwardingJMSListener implements MessageListener {
+
+	private static final Logger log = LoggerFactory.getLogger(JobForwardingJMSListener.class);
+
+	private final List<ListenerJob> listenerJobs;
+
+	public JobForwardingJMSListener() {
+		// This construct is particularly suited for large ingests, where the list of listeners changes slowly.
+		listenerJobs = new CopyOnWriteArrayList<ListenerJob>();
+	}
+
+	public void registerListener(ListenerJob listener) {
+		listenerJobs.add(listener);
+	}
+
+	public void unregisterListener(ListenerJob listener) {
+		listenerJobs.remove(listener);
+	}
+
+	@Override
+	public void onMessage(Message message) {
+
+		log.debug("Received message");
+
+		// If no jobs are listening, ignore the message
+		if (listenerJobs.size() == 0)
+			return;
+
+		if (message instanceof TextMessage) {
+			try {
+				TextMessage msg = (TextMessage) message;
+
+				String messageBody = msg.getText();
+				Document msgDoc = new SAXBuilder().build(new StringReader(messageBody));
+
+				log.debug("Message contents:\n{}", messageBody);
+
+				// This does not need to be synchronized because it is using CopyOnWriteArrayList
+				for (ListenerJob listener : listenerJobs) {
+					listener.onEvent(msgDoc);
+				}
+
+			} catch (Exception e) {
+				log.error("onMessage failed", e);
+			}
+		} else {
+			throw new IllegalArgumentException("Message must be of type TextMessage");
+		}
+	}
+}

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/ListenerJob.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/ListenerJob.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.fedora;
+
+import org.jdom.Document;
+
+/**
+ * @author bbpennel
+ * @date Mar 18, 2014
+ */
+public interface ListenerJob {
+
+	public void onEvent(Document message);
+
+}

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/fedora/JobForwardingJMSListenerTest.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/fedora/JobForwardingJMSListenerTest.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.fedora;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.io.InputStream;
+
+import javax.jms.Message;
+import javax.jms.TextMessage;
+
+import org.apache.commons.io.IOUtils;
+import org.jdom.Document;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+/**
+ * @author bbpennel
+ * @date Mar 18, 2014
+ */
+public class JobForwardingJMSListenerTest {
+
+	@Mock
+	private TextMessage msg;
+	@Mock
+	private ListenerJob job1;
+	@Mock
+	private ListenerJob job2;
+
+	private JobForwardingJMSListener listener;
+
+	@Before
+	public void setup() throws Exception {
+		initMocks(this);
+
+		listener = new JobForwardingJMSListener();
+
+		InputStream inStream = this.getClass().getResourceAsStream("/ingestMessage.xml");
+		String messageBody = IOUtils.toString(inStream);
+
+		when(msg.getText()).thenReturn(messageBody);
+
+	}
+
+	@Test
+	public void testOnMessageNoListeners() throws Exception {
+
+		listener.onMessage(msg);
+
+		verify(msg, never()).getText();
+
+	}
+
+	@Test
+	public void testOnMessage() throws Exception {
+
+		listener.registerListener(job1);
+		listener.registerListener(job2);
+
+		listener.onMessage(msg);
+
+		verify(msg).getText();
+
+		verify(job1).onEvent(any(Document.class));
+		verify(job2).onEvent(any(Document.class));
+
+	}
+
+	@Test
+	public void testOnMessageUnregister() throws Exception {
+
+		listener.registerListener(job1);
+		listener.unregisterListener(job1);
+
+		listener.onMessage(msg);
+
+		verify(msg, never()).getText();
+
+		verify(job1, never()).onEvent(any(Document.class));
+
+	}
+
+	@Test
+	public void testOnMessageUnregisterMultipleMessages() throws Exception {
+
+		listener.registerListener(job1);
+		listener.registerListener(job2);
+
+		listener.onMessage(msg);
+
+		listener.unregisterListener(job1);
+
+		listener.onMessage(msg);
+
+		verify(msg, times(2)).getText();
+
+		verify(job1).onEvent(any(Document.class));
+		verify(job2, times(2)).onEvent(any(Document.class));
+
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testOnMessageNotText() throws Exception {
+
+		listener.registerListener(job1);
+
+		Message badMessage = mock(Message.class);
+
+		try {
+			listener.onMessage(badMessage);
+		} finally {
+			verify(job1, never()).onEvent(any(Document.class));
+		}
+
+	}
+}

--- a/fcrepo-clients/src/test/resources/ingestMessage.xml
+++ b/fcrepo-clients/src/test/resources/ingestMessage.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="http://www.w3.org/2005/Atom" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:fedora-types="http://www.fedora.info/definitions/1/0/types/">
+  <id>urn:uuid:68b8d82e-c107-4082-ab7d-b799bd8f16ba</id>
+  <updated>2014-03-23T16:13:07.126Z</updated>
+  <author>
+    <name>admin</name>
+    <uri>http://localhost/fedora</uri>
+  </author>
+  <title type="text">ingest</title>
+  <category term="uuid:pid" scheme="fedora-types:pid" label="xsd:string"></category>
+  <category term="MD5" scheme="fedora-types:checksumType" label="xsd:string"></category>
+  <category term="null" scheme="fedora-types:checksum" label="xsd:string"></category>
+  <category term="Object ingested" scheme="fedora-types:logMessage" label="xsd:string"></category>
+  <summary type="text">uuid:pid</summary>
+  <content type="text">2014-03-23T16:13:07.126Z</content>
+  <category term="3.4.3-SNAPSHOT" scheme="info:fedora/fedora-system:def/view#version"></category>
+  <category term="info:fedora/fedora-system:ATOM-APIM-1.0" scheme="http://www.fedora.info/definitions/1/0/types/formatURI"></category>
+</entry>


### PR DESCRIPTION
commons-io added to fcrepo-clients to support the test.  It was already present in the deposit module via the bagit library.
