### PR TITLE
Updated tests to perform copies using java 7 copy method and reset spring mocks

### DIFF
--- a/deposit/src/test/java/edu/unc/lib/deposit/integration/DepositSupervisorIT.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/integration/DepositSupervisorIT.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,23 +31,23 @@ import edu.unc.lib.dl.xml.JDOMNamespaceUtil;
 @ContextConfiguration(locations = { "/service-context.xml" })
 @DirtiesContext
 public class DepositSupervisorIT {
-	
+
 	private static boolean started = false;
-	
+
 	@Autowired
 	File depositsDirectory;
-	
+
 	@Autowired
 	DepositStatusFactory depositStatusFactory;
-	
+
 	@Autowired
 	JobStatusFactory jobStatusFactory;
-	
+
 	@Autowired
 	DepositSupervisor depositSupervisor;
-	
+
 	// TODO test a pile of deposits at once
-	
+
 	@Before
 	public void setup() {
 		if(!started) {
@@ -54,7 +55,7 @@ public class DepositSupervisorIT {
 			started = true;
 		}
 	}
-	
+
 	@Test
 	public void testWorkbenchZIP() throws ClassNotFoundException, InterruptedException {
 		DepositTestUtils.makeTestDir(depositsDirectory, "84f69180-3e40-4152-be80-a30c60c3f846", new File("src/test/resources/workbench.zip"));
@@ -81,7 +82,7 @@ public class DepositSupervisorIT {
 		depositStatusFactory.save(depositUUID, status);
 		Thread.sleep(1000*30);
 	}
-	
+
 	@Test
 	public void testCDRMETS() throws ClassNotFoundException, InterruptedException {
 		DepositTestUtils.makeTestDir(depositsDirectory, "bd5ff703-9c2e-466b-b4cc-15bbfd03c8ae", new File("src/test/resources/depositFileZipped.zip"));
@@ -108,7 +109,7 @@ public class DepositSupervisorIT {
 		depositStatusFactory.save(depositUUID, status);
 		Thread.sleep(1000*30);
 	}
-	
+
 	@Test
 	public void testCDRMETSwACL() throws ClassNotFoundException, InterruptedException, IOException, JDOMException {
 		File workingDir = new File(depositsDirectory, "fooff703-9c2e-466b-b4cc-15bbfd03c8ae");
@@ -116,7 +117,7 @@ public class DepositSupervisorIT {
 		workingDir.mkdirs();
 		File testMETS = new File("src/test/resources/accessControlsTest.cdr.xml");
 		File mets = new File(workingDir, "METS.xml");
-		FileUtils.copyFile(testMETS, mets);
+		Files.copy(testMETS.toPath(), mets.toPath());
 		String depositUUID = "fooff703-9c2e-466b-b4cc-15bbfd03c8ae";
 		depositStatusFactory.delete(depositUUID);
 		jobStatusFactory.deleteAll(depositUUID);
@@ -137,12 +138,12 @@ public class DepositSupervisorIT {
 		status.put("containerId","uuid:destination");
 		depositStatusFactory.save(depositUUID, status);
 		Thread.sleep(1000*30);
-		
+
 		File depositevents = new File(workingDir, "events/"+depositUUID+".xml");
 		Document doc = new SAXBuilder().build(depositevents);
 		@SuppressWarnings("rawtypes")
 		List events = doc.getRootElement().getChildren("event", JDOMNamespaceUtil.PREMIS_V2_NS);
 		assertEquals("Expected 5 PREMIS events for this ingest", 5, events.size());
 	}
-	
+
 }

--- a/deposit/src/test/java/edu/unc/lib/deposit/normalize/CDRMETS2N3BagJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/normalize/CDRMETS2N3BagJobTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.UUID;
 
 import net.greghaines.jesque.Job;
@@ -17,17 +18,16 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import edu.unc.lib.deposit.DepositTestUtils;
 import edu.unc.lib.deposit.work.SpringJobFactory;
 import edu.unc.lib.dl.util.DepositConstants;
-import edu.unc.lib.dl.util.FileUtils;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(locations = { "/service-context.xml" })
 public class CDRMETS2N3BagJobTest {
 	@Autowired
 	File depositsDirectory;
-	
+
 	@Autowired
 	SpringJobFactory springJobFactory = null;
-	
+
 	@Test
 	public void test() throws ClassNotFoundException {
 		String depositUUID = "bd5ff703-9c2e-466b-b4cc-15bbfd03c8ae";
@@ -36,11 +36,11 @@ public class CDRMETS2N3BagJobTest {
 		Object j = springJobFactory.materializeJob(job);
 		Runnable r = (Runnable)j;
 		r.run();
-		
+
 		File modelFile = new File(workDir, DepositConstants.MODEL_FILE);
 		assertTrue("N3 model file must exist after conversion", modelFile.exists());
 	}
-	
+
 	@Test
 	public void testAltMETSFilename() throws ClassNotFoundException {
 		String depositUUID = "bd5ff703-9c2e-466b-b4cc-15bbfd03c8ae";
@@ -51,11 +51,11 @@ public class CDRMETS2N3BagJobTest {
 		Object j = springJobFactory.materializeJob(job);
 		Runnable r = (Runnable)j;
 		r.run();
-		
+
 		File modelFile = new File(workDir, DepositConstants.MODEL_FILE);
 		assertTrue("N3 model file must exist after conversion", modelFile.exists());
 	}
-	
+
 	@Test
 	public void testAccessControlsMETSXML() throws ClassNotFoundException, IOException {
 		String depositUUID = "cdrff703-9c2e-466b-b4cc-15bbfd03c8ae";
@@ -63,13 +63,13 @@ public class CDRMETS2N3BagJobTest {
 		workDir.mkdirs();
 		File test = new File("src/test/resources/accessControlsTest.cdr.xml");
 		File metsPlace = new File(workDir, "METS.xml");
-		FileUtils.copyFile(test, metsPlace);
-		
+		Files.copy(test.toPath(), metsPlace.toPath());
+
 		Job job = new Job("CDRMETS2N3BagJob", UUID.randomUUID().toString(), depositUUID);
 		Object j = springJobFactory.materializeJob(job);
 		Runnable r = (Runnable)j;
 		r.run();
-		
+
 		File modelFile = new File(workDir, DepositConstants.MODEL_FILE);
 		assertTrue("N3 model file must exist after conversion", modelFile.exists());
 	}

--- a/persistence/src/test/java/edu/unc/lib/dl/services/DigitalObjectManagerImplTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/services/DigitalObjectManagerImplTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -66,7 +67,7 @@ import edu.unc.lib.dl.util.TripleStoreQueryService;
 public class DigitalObjectManagerImplTest {
 
 	@Resource
-	private DigitalObjectManagerImpl digitalObjectManagerImpl = null;
+	private final DigitalObjectManagerImpl digitalObjectManagerImpl = null;
 
 	@Resource
 	ManagementClient managementClient = null;
@@ -107,6 +108,10 @@ public class DigitalObjectManagerImplTest {
 	 */
 	@Before
 	public void setUp() throws Exception {
+		reset(managementClient);
+		reset(accessClient);
+		reset(tripleStoreQueryService);
+
 		this.getDigitalObjectManagerImpl().setAvailable(true, "available");
 		// setup default MD_CONTENTS stream
 		MIMETypedStream mts = mock(MIMETypedStream.class);


### PR DESCRIPTION
Using java 7 copy and resetting mocks coming from spring context between test methods to avoid them interfering with each other's counts
