### PR TITLE
Fix for front-page "blank image" bug

### DIFF
--- a/access/src/main/external/static/front/peek.js
+++ b/access/src/main/external/static/front/peek.js
@@ -467,7 +467,7 @@ Column.prototype.shift = function() {
     
     for (var i = 0; i < this.items.length; i++) {
       if (this.getItemMeasurements(i).middle + offset > 0) {
-        this.setLayout({ top: Math.min(i + 1, this.items.length - 1), prune: Math.max(0, i + 1) });
+        this.setLayout({ top: Math.min(i + 1, this.items.length - 1), prune: i });
         break;
       }
     }


### PR DESCRIPTION
Fix that shifting would prune the only item in a column when there was just one item. Instead, prune zero items from such columns.

There is at least one item on the front page visualization which is fairly tall. When it appears and the visualization is not expanded, it can sometimes be the only item in its column. When the column was shifted, its top would be set to the first item, but we would also prune one item. This is a workaround which avoids pruning in that case.
