### PR TITLE
Requeuing deposits on a delay when Fedora becomes unavailable.

### DIFF
--- a/deposit/src/main/resources/service-context.xml
+++ b/deposit/src/main/resources/service-context.xml
@@ -74,6 +74,7 @@
 				<constructor-arg name="queues">
 					<util:list>
 						<value>PREPARE</value>
+						<value>DELAYED_PREPARE</value>
 					</util:list>
 				</constructor-arg>
 				<constructor-arg ref="jobFactory" />
@@ -85,6 +86,7 @@
 	<bean id="depositSupervisor" class="edu.unc.lib.deposit.work.DepositSupervisor">
 		<property name="jesqueConfig" ref="jesqueConfig"/>
 		<property name="cleanupDelaySeconds" value="${cleanup.delay.seconds:60}"/>
+		<property name="unavailableDelaySeconds" value="${unavailable.delay.seconds:60}"/>
 	</bean>
 
 	<bean id="jobFactory" class="edu.unc.lib.deposit.work.SpringJobFactory" />
@@ -102,6 +104,11 @@
 			value="${fedora.protocol:https}://${fedora.host:localhost}:${fedora.port:443}/${fedora.context:fedora}" />
 		<property name="username" value="${fedora.username}" />
 		<property name="password" value="${fedora.password}" />
+		<property name="interceptors">
+			<list>
+				<bean class="edu.unc.lib.dl.acl.filter.GroupsToHttpHeaderInterceptor" />
+			</list>
+		</property>
 	</bean>
 
 	<bean id="forwardedManagementClient" class="edu.unc.lib.dl.fedora.ManagementClient"

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/AuthorizationException.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/AuthorizationException.java
@@ -20,11 +20,32 @@ import org.springframework.ws.soap.client.SoapFaultClientException;
 public class AuthorizationException extends FedoraException {
 	private static final long serialVersionUID = 2177327948413175683L;
 
+	private AuthorizationErrorType type = AuthorizationErrorType.DENIED;
+
 	public AuthorizationException(String message) {
 		super(message);
 	}
-	
+
 	public AuthorizationException(SoapFaultClientException e) {
 		super(e);
+
+		String reason = e.getFaultStringOrReason();
+		if (reason.contains("NotApplicable")) {
+			type = AuthorizationErrorType.NOT_APPLICABLE;
+		} else if (reason.contains("Indeterminate")) {
+			type = AuthorizationErrorType.INDETERMINATE;
+		}
+	}
+
+	public AuthorizationErrorType getType() {
+		return type;
+	}
+
+	public void setType(AuthorizationErrorType type) {
+		this.type = type;
+	}
+
+	public static enum AuthorizationErrorType {
+		NOT_APPLICABLE, DENIED, INDETERMINATE
 	}
 }

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/FedoraTimeoutException.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/FedoraTimeoutException.java
@@ -26,6 +26,10 @@ public class FedoraTimeoutException extends ServiceException {
 	 */
 	private static final long serialVersionUID = -5509017474926163463L;
 
+	public FedoraTimeoutException(String desc) {
+		super(desc);
+	}
+
 	/**
 	 * @param cause
 	 */


### PR DESCRIPTION
Reinitializing web service connections to Fedora from clients when authorization fails because of a connection interruption
Ensuring groups are being forwarded when testing for files that have already been ingested while resuming deposits.
All delayed jobs going to separate DELAYED_PREPARE queue to prevent a key type error since delayed jobs are queued as a sorted list/skip list instead of a normal set.
