### PR TITLE
Checking that a record exists in solr before performing a partial update...

### DIFF
--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/solr/SolrUpdateEnhancement.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/solr/SolrUpdateEnhancement.java
@@ -22,6 +22,7 @@ import static edu.unc.lib.dl.util.IndexingActionType.UPDATE_FULL_TEXT;
 
 import java.util.List;
 
+import org.apache.solr.client.solrj.SolrServerException;
 import org.jdom.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,6 +36,7 @@ import edu.unc.lib.dl.cdr.services.techmd.TechnicalMetadataEnhancementService;
 import edu.unc.lib.dl.cdr.services.text.FullTextEnhancementService;
 import edu.unc.lib.dl.data.ingest.solr.SolrUpdateRequest;
 import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.search.solr.service.SolrSearchService;
 import edu.unc.lib.dl.util.IndexingActionType;
 
 /**
@@ -47,6 +49,8 @@ public class SolrUpdateEnhancement extends Enhancement<Element> {
 	SolrUpdateEnhancementService service = null;
 	EnhancementMessage message;
 
+	private final SolrSearchService searchService;
+
 	@Override
 	public Element call() throws EnhancementException {
 		Element result = null;
@@ -54,25 +58,38 @@ public class SolrUpdateEnhancement extends Enhancement<Element> {
 
 		IndexingActionType action = ADD;
 
-		List<String> completedServices = message.getCompletedServices();
-		//Perform a single item update
-		if (completedServices.contains(FullTextEnhancementService.class.getName())) {
-			action = UPDATE_FULL_TEXT;
-		} else if (completedServices.contains(TechnicalMetadataEnhancementService.class.getName())
-				|| completedServices.contains(ImageEnhancementService.class.getName())
-				|| completedServices.contains(ThumbnailEnhancementService.class.getName())) {
+		try {
+			List<String> completedServices = message.getCompletedServices();
+			// Perform a single item update
+			if (completedServices.contains(FullTextEnhancementService.class.getName())) {
+				action = UPDATE_FULL_TEXT;
+			} else if (completedServices.contains(TechnicalMetadataEnhancementService.class.getName())
+					|| completedServices.contains(ImageEnhancementService.class.getName())
+					|| completedServices.contains(ThumbnailEnhancementService.class.getName())) {
 
-			action = UPDATE_DATASTREAMS;
+				action = UPDATE_DATASTREAMS;
 
-			// Check if this object is the default web object for another item, and update that item's datastreams if so
-			List<PID> dwoFor = service.getTripleStoreQueryService().
-					fetchByPredicateAndLiteral(defaultWebObject.toString(), pid);
-			if (dwoFor != null && dwoFor.size() > 0) {
-				for (PID dwoPID : dwoFor) {
-					service.getMessageDirector().direct(
-							new SolrUpdateRequest(dwoPID.getPid(), UPDATE_DATASTREAMS));
+				// Check if this object is the default web object for another item, and update that item's datastreams if so
+				List<PID> dwoFor = service.getTripleStoreQueryService().fetchByPredicateAndLiteral(
+						defaultWebObject.toString(), pid);
+				if (dwoFor != null && dwoFor.size() > 0) {
+					for (PID dwoPID : dwoFor) {
+						if (searchService.exists(dwoPID.getPid())) {
+							service.getMessageDirector().direct(new SolrUpdateRequest(dwoPID.getPid(), UPDATE_DATASTREAMS));
+						}
+					}
 				}
 			}
+
+			long start = System.currentTimeMillis();
+			// Make sure the record is in solr before trying to do a partial update
+			if (!action.equals(ADD) && !searchService.exists(pid.getPid())) {
+				LOG.debug("Partial update for {} is not applicable, reverting to full update", pid.getPid());
+				action = ADD;
+			}
+			LOG.info("Checked for record in {}", (System.currentTimeMillis() - start));
+		} catch (SolrServerException e) {
+			LOG.error("Failed to check for the existense of {}", pid.getPid(), e);
 		}
 
 		SolrUpdateRequest updateRequest = new SolrUpdateRequest(pid.getPid(), action);
@@ -85,5 +102,6 @@ public class SolrUpdateEnhancement extends Enhancement<Element> {
 		super(message.getPid());
 		this.service = service;
 		this.message = message;
+		this.searchService = service.getSolrSearchService();
 	}
 }


### PR DESCRIPTION
... via SolrUpdateEnhancement to prevent invalid records being pushed to solr.  Split pushing out to solr into two separate ConcurrentUpdateSolrServer streams, so that partial updates would not affect normal adds.
