### PR TITLE
Prevent duplicate METS deposit, Jena transaction fix

### DIFF
--- a/admin/src/main/java/edu/unc/lib/dl/admin/controller/IngestController.java
+++ b/admin/src/main/java/edu/unc/lib/dl/admin/controller/IngestController.java
@@ -104,7 +104,7 @@ public class IngestController {
 			} else if (method.getStatusCode() == 401) {
 				// Unauthorized
 				result.put("error", "Not authorized to ingest to container " + pid);
-			} else if (method.getStatusCode() >= 500) {
+			} else if (method.getStatusCode() == 400 || method.getStatusCode() >= 500) {
 				// Server error, report it to the client
 				result.put("error", "A server error occurred while attempting to ingest \"" + ingestFile.getName()
 						+ "\" to " + pid);

--- a/deposit/src/main/java/edu/unc/lib/deposit/work/AbstractDepositJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/work/AbstractDepositJob.java
@@ -98,7 +98,10 @@ public abstract class AbstractDepositJob implements Runnable {
 	public final void run() {
 		try {
 			runJob();
-			commitModel();
+			commitModelChanges();
+		} catch(Throwable e) {
+			abortModelChanges();
+			throw e;
 		} finally {
 			closeModel();
 		}
@@ -236,9 +239,15 @@ public abstract class AbstractDepositJob implements Runnable {
 		return this.dataset.getDefaultModel();
 	}
 	
-	public void commitModel() {
+	public void commitModelChanges() {
 		if(this.dataset != null) {
 			this.dataset.commit();
+		}
+	}
+	
+	public void abortModelChanges() {
+		if(this.dataset != null) {
+			this.dataset.abort();
 		}
 	}
 	

--- a/deposit/src/test/java/edu/unc/lib/deposit/DepositGenerator.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/DepositGenerator.java
@@ -69,7 +69,9 @@ public class DepositGenerator {
 	}
 
 	public static void main(String[] args) throws IOException {
-		generate(2, 3, 5, "tag:count@cdr.lib.unc.edu,2014:/vagrant/"
+		// TODO make mintPIDs optional
+		// map arguments to a instance, then run that..
+		generate(2, 3, 5, "tag:vagrant@localhost,2014:/vagrant/"
 				+ testPatternTif.getName(), testPatternTif, true);
 	}
 

--- a/deposit/src/test/java/edu/unc/lib/deposit/normalize/BioMedCentralExtrasJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/normalize/BioMedCentralExtrasJobTest.java
@@ -79,7 +79,7 @@ public class BioMedCentralExtrasJobTest extends AbstractNormalizationJobTest {
 		Model m = job.getModel();
 		File testModel = new File("src/test/resources/aggregate-deposit.n3");
 		m.read(testModel.toURI().toURL().toString());
-		job.commitModel();
+		job.commitModelChanges();
 		job.closeModel();
 		
 		long start = System.currentTimeMillis();
@@ -129,7 +129,7 @@ public class BioMedCentralExtrasJobTest extends AbstractNormalizationJobTest {
 		Model m = job.getModel();
 		File testModel = new File("src/test/resources/aggregate-deposit.n3");
 		m.read(testModel.toURI().toURL().toString());
-		job.commitModel();
+		job.commitModelChanges();
 		job.closeModel();
 
 		job.getDescriptionDir().mkdir();

--- a/deposit/src/test/java/edu/unc/lib/deposit/normalize/VocabularyEnforcementJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/normalize/VocabularyEnforcementJobTest.java
@@ -79,7 +79,7 @@ public class VocabularyEnforcementJobTest extends AbstractNormalizationJobTest {
 		Bag depositBag = model.createBag(job.getDepositPID().getURI());
 		Resource mainResource = model.createResource(MAIN_RESOURCE);
 		depositBag.add(mainResource);
-		job.commitModel();
+		job.commitModelChanges();
 		job.closeModel();
 	}
 

--- a/sword-server/src/main/java/edu/unc/lib/dl/cdr/sword/server/deposit/AbstractDepositHandler.java
+++ b/sword-server/src/main/java/edu/unc/lib/dl/cdr/sword/server/deposit/AbstractDepositHandler.java
@@ -30,8 +30,7 @@ import org.swordapp.server.Deposit;
 import org.swordapp.server.DepositReceipt;
 import org.swordapp.server.SwordConfiguration;
 import org.swordapp.server.SwordError;
-
-import com.hp.hpl.jena.reasoner.rulesys.builtins.UriConcat;
+import org.swordapp.server.UriRegistry;
 
 import edu.unc.lib.dl.acl.util.GroupsThreadStore;
 import edu.unc.lib.dl.cdr.sword.server.SwordConfigurationImpl;
@@ -43,7 +42,6 @@ import edu.unc.lib.dl.util.PackagingType;
 import edu.unc.lib.dl.util.RedisWorkerConstants.DepositAction;
 import edu.unc.lib.dl.util.RedisWorkerConstants.DepositField;
 import edu.unc.lib.dl.util.RedisWorkerConstants.DepositState;
-import edu.unc.lib.dl.xml.NamespaceConstants;
 
 public abstract class AbstractDepositHandler implements DepositHandler {
 	private static final Logger log = LoggerFactory.getLogger(AbstractDepositHandler.class);
@@ -105,7 +103,7 @@ public abstract class AbstractDepositHandler implements DepositHandler {
 	protected void registerDeposit(PID depositPid, PID destination, Deposit deposit,
 			PackagingType type, String depositor, String owner, Map<String, String> extras) throws SwordError {
 		Map<String, String> chkstatus = this.depositStatusFactory.get(depositPid.getUUID());
-		if(chkstatus != null && !chkstatus.isEmpty()) throw new SwordError("http://cdr.lib.unc.edu/sword/error/duplicateDeposit", 400, "Duplicate request, repository already has deposit "+depositPid);
+		if(chkstatus != null && !chkstatus.isEmpty()) throw new SwordError(UriRegistry.ERROR_BAD_REQUEST, 400, "Duplicate request, repository already has deposit "+depositPid);
 		
 		Map<String, String> status = new HashMap<String, String>();
 		status.putAll(extras);

--- a/sword-server/src/main/java/edu/unc/lib/dl/cdr/sword/server/managers/CollectionDepositManagerImpl.java
+++ b/sword-server/src/main/java/edu/unc/lib/dl/cdr/sword/server/managers/CollectionDepositManagerImpl.java
@@ -83,6 +83,8 @@ public class CollectionDepositManagerImpl extends AbstractFedoraManager implemen
 			throw new SwordError(ErrorURIRegistry.INGEST_EXCEPTION, 500,
 					"An exception occurred while attempting to ingest package " + deposit.getFilename() + " of type "
 							+ deposit.getPackaging(), e);
+		} catch (SwordError e) {
+			throw e;
 		} catch (Exception e) {
 			throw new SwordError(ErrorURIRegistry.INGEST_EXCEPTION, 500,
 					"Unexpected exception occurred while attempting to perform a METS deposit", e);


### PR DESCRIPTION
Added Jena transaction abort, when a deposit job throws an error. Updated commit method name to match.

Removed some local strings from DepositGenerator

Prevented submission of duplicate METS ingests, with appropriate SWORD error handling:
- Added error handling for 400 Bad Request to IngestController (from upstream Sword servlet) this handles duplicate deposit requests
- Removed secondary wrapping of SwordError exceptions in another exception.
