### PR TITLE
added menu items to "Download Manifest"

### DIFF
--- a/access/src/main/external/static/js/admin/src/BatchActionMenu.js
+++ b/access/src/main/external/static/js/admin/src/BatchActionMenu.js
@@ -127,7 +127,7 @@ define('BatchActionMenu', [ 'jquery', 'jquery-ui', 'contextMenu'],
 								document.location.href = serverUrl + "services/api/edit/fileinfo/" + metadata.id;
 								break;
 							case "copyid" :
-								window.prompt("Copy to clipboard: Ctrl+C, Enter", metadata.id);
+								window.prompt("Copy PID to clipboard", metadata.id);
 								break;
 						}
 					},

--- a/access/src/main/external/static/js/admin/src/ResultObjectActionMenu.js
+++ b/access/src/main/external/static/js/admin/src/ResultObjectActionMenu.js
@@ -197,7 +197,7 @@ define('ResultObjectActionMenu', [ 'jquery', 'jquery-ui', 'contextMenu'],
 						document.location.href = serverUrl + "services/api/edit/fileinfo/" + metadata.id;
 						break;
 					case "copyid" :
-						window.prompt("Copy to clipboard: Ctrl+C, Enter", metadata.id);
+						window.prompt("Copy PID to clipboard", metadata.id);
 						break;
 				}
 			},

--- a/access/src/main/external/static/js/cdr-admin.js
+++ b/access/src/main/external/static/js/cdr-admin.js
@@ -1178,7 +1178,7 @@ define('ActionEventHandler', [ 'jquery'], function($) {
 								document.location.href = serverUrl + "services/api/edit/fileinfo/" + metadata.id;
 								break;
 							case "copyid" :
-								window.prompt("Copy to clipboard: Ctrl+C, Enter", metadata.id);
+								window.prompt("Copy PID to clipboard", metadata.id);
 								break;
 						}
 					},
@@ -2545,7 +2545,7 @@ define('ParentResultObject', [ 'jquery', 'ResultObject'],
 						document.location.href = serverUrl + "services/api/edit/fileinfo/" + metadata.id;
 						break;
 					case "copyid" :
-						window.prompt("Copy to clipboard: Ctrl+C, Enter", metadata.id);
+						window.prompt("Copy PID to clipboard", metadata.id);
 						break;
 				}
 			},

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/ContainerDataFileChecksumsController.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/ContainerDataFileChecksumsController.java
@@ -72,7 +72,8 @@ public class ContainerDataFileChecksumsController {
 			if (server == null)
 				initializeSolrServer();
 			SolrQuery parameters = new SolrQuery();
-			parameters.setQuery("datastream:DATA_FILE|* "+"ancestorPath:*"+ClientUtils.escapeQueryChars(","+pid+",")+"*");
+			parameters.setQuery("contentModel:"+ClientUtils.escapeQueryChars("info:fedora/cdr-model:Simple")
+					+" ancestorPath:*"+ClientUtils.escapeQueryChars(","+pid+",")+"*");
 			parameters.addSort("filesizeTotal", ORDER.desc);
 			parameters.addField("title");
 			parameters.addField("id");
@@ -104,7 +105,7 @@ public class ContainerDataFileChecksumsController {
 		// title, pid, mimetype, length, checksum
 		String title = (String) map.get("title");
 		title = title.replaceAll(Pattern.quote("\""),
-				Matcher.quoteReplacement("\\\""));
+				Matcher.quoteReplacement("\"\""));
 		out.print('"');
 		out.print(title);
 		out.print('"');

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/ContainerManifestController.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/ContainerManifestController.java
@@ -167,7 +167,7 @@ public class ContainerManifestController {
 		out.print(pid);
 		out.print(',');
 		out.print('"');
-		title = title.replaceAll(Pattern.quote("\""), Matcher.quoteReplacement("\\\""));
+		title = title.replaceAll(Pattern.quote("\""), Matcher.quoteReplacement("\"\""));
 		out.print(title);
 		out.println('"');
 	}


### PR DESCRIPTION
added CSV downloaded manifest at "services/api/edit/manifest-csv/{pid}"
manifest generated from Solr, but data is marshalled locally in a big hashmap

needs to be prevented from running on Collections object (how?)
controller also includes a JSON endpoint of the same data (not downloaded) at "services/api/edit/manifest/{pid}"
