### PR TITLE
Small deposit tweaks

### DIFF
--- a/deposit/src/main/resources/email_html.txt
+++ b/deposit/src/main/resources/email_html.txt
@@ -31,7 +31,8 @@
   <p>There was an error processing your deposit.</p> 
   <div style="background: yellow">{{errorMessage}}</div>
   {{/error}}
-  <p>For details, see the <a href="{{baseUrl}}/deposit/uuid:{{uuid}}">deposit record</a>.</p>
+  {{! TODO link to deposit record {{baseUrl}}/deposit/uuid:{{uuid}} }}
+  <p>For details, see the <a href="{{baseUrl}}/admin/statusMonitor">status monitor</a>.</p>
   <p>Thank you for contributing to the <a href="{{baseUrl}}">Carolina Digital Repository</a>, a service of the <a href="http://www.lib.unc.edu/">University of North Carolina at Chapel Hill Libraries</a>.</p>
 </body>
 </html>

--- a/deposit/src/main/resources/email_text.txt
+++ b/deposit/src/main/resources/email_text.txt
@@ -22,8 +22,9 @@ There was an error processing your deposit:
   {{errorMessage}}
 {{/error}}
 
-For details, see the deposit record:
-  {{baseUrl}}/deposit/uuid:{{uuid}}
+For details, see the status monitor:
+{{! TODO link to deposit record {{baseUrl}}/deposit/uuid:{{uuid}} }}
+  {{baseUrl}}/admin/statusMonitor
 
 Thank you for contributing to the Carolina Digital Repository, a service of the University of North Carolina at Chapel Hill Libraries.
 

--- a/puppet/modules/deposit/templates/home/deposit.properties.erb
+++ b/puppet/modules/deposit/templates/home/deposit.properties.erb
@@ -31,3 +31,9 @@ jms.port=<%= @jms_port %>
 # baseUrl=https://www.example.com
 
 fedora.stagesConfiguration=file:/opt/repository/stagesConfig.json
+
+# delay after which the clean up job runs
+cleanup.delay.seconds=172800
+
+# delay after clean up job when deposit status keys expire (172800 is 2 days)
+status.keys.expire.seconds=172800


### PR DESCRIPTION
Deposit emails now link to status monitor page, instead of fictional deposit record page
Deposit cleanup is configured in puppet with 2 day delay, then 2 days key expiration
