### PR TITLE
Fix that the File instance passed to MetsHeaderScanner would not necessarily have the correct name

### DIFF
--- a/metadata/src/main/java/edu/unc/lib/dl/util/MetsHeaderScanner.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/util/MetsHeaderScanner.java
@@ -128,11 +128,11 @@ public class MetsHeaderScanner extends DefaultHandler {
 		super.endElement(uri, localName, qName);
 	}
 
-	public void scan(File f) throws Exception {
+	public void scan(File f, String filename) throws Exception {
 		@SuppressWarnings("resource")
 		InputStream toParse = null;
 		try {
-			if (f.getName().endsWith(".zip")) {
+			if (filename.endsWith(".zip")) {
 				log.debug("scanning for METS within a zip file");
 				@SuppressWarnings("resource")
 				ZipArchiveInputStream zis = new ZipArchiveInputStream(

--- a/sword-server/src/main/java/edu/unc/lib/dl/cdr/sword/server/deposit/CDRMETSDepositHandler.java
+++ b/sword-server/src/main/java/edu/unc/lib/dl/cdr/sword/server/deposit/CDRMETSDepositHandler.java
@@ -49,7 +49,7 @@ public class CDRMETSDepositHandler extends AbstractDepositHandler {
 		// extract info from METS header
 		MetsHeaderScanner scanner = new MetsHeaderScanner();
 		try {
-			scanner.scan(deposit.getFile());
+			scanner.scan(deposit.getFile(), deposit.getFilename());
 		} catch (Exception e1) {
 			throw new SwordError(ErrorURIRegistry.INGEST_EXCEPTION, 400, "Unable to parse your METS file: "+deposit.getFilename(), e1);
 		}

--- a/sword-server/src/main/java/edu/unc/lib/dl/cdr/sword/server/deposit/DSPACEMETSDepositHandler.java
+++ b/sword-server/src/main/java/edu/unc/lib/dl/cdr/sword/server/deposit/DSPACEMETSDepositHandler.java
@@ -49,7 +49,7 @@ public class DSPACEMETSDepositHandler extends AbstractDepositHandler {
 		// extract info from METS header
 		MetsHeaderScanner scanner = new MetsHeaderScanner();
 		try {
-			scanner.scan(deposit.getFile());
+			scanner.scan(deposit.getFile(), deposit.getFilename());
 		} catch (Exception e1) {
 			throw new SwordError(ErrorURIRegistry.INGEST_EXCEPTION, 400, "Unable to parse your METS file: "+deposit.getFilename(), e1);
 		}

--- a/sword-server/src/test/java/edu/unc/lib/dl/cdr/sword/server/deposit/CDRMETSDepositHandlerTest.java
+++ b/sword-server/src/test/java/edu/unc/lib/dl/cdr/sword/server/deposit/CDRMETSDepositHandlerTest.java
@@ -77,6 +77,30 @@ public class CDRMETSDepositHandlerTest {
 	
 	@SuppressWarnings("unchecked")
 	@Test
+	public void testDoDepositBagitNonZipFilePath() throws SwordError, IOException {
+		Deposit d = new Deposit();
+		File testPayload = tmpDir.newFile("simple.tmp");
+		FileUtils.copyFile(new File("src/test/resources/simple.zip"), testPayload);
+		d.setFile(testPayload);
+		d.setMd5("d2b88d292e2c47943231205ed36f6c94");
+		d.setFilename("simple.zip");
+		d.setMimeType("application/zip");
+		d.setSlug("metsbagittest");
+		d.setPackaging(PackagingType.METS_CDR.getUri());
+		Entry entry = Abdera.getInstance().getFactory().newEntry();
+		d.setEntry(entry);
+		
+		reset(depositStatusFactory);
+		
+		PID dest = new PID("uuid:destination");
+		metsDepositHandler.doDeposit(dest, d, PackagingType.METS_CDR, swordConfiguration,
+				"test-depositor", "test-owner");
+
+		verify(depositStatusFactory, atLeastOnce()).save(anyString(), anyMap());
+	}
+	
+	@SuppressWarnings("unchecked")
+	@Test
 	public void testDoDepositMETSXML() throws SwordError, IOException {
 		Deposit d = new Deposit();
 		File testPayload = tmpDir.newFile("METS.xml");


### PR DESCRIPTION
When depositing via SWORD from the forms app, the file passed to MetsHeaderScanner wasn't recognized as a zip file.
