### PR TITLE
fixes for deposit of forms, and METS packages

### DIFF
--- a/deposit/src/main/java/edu/unc/lib/deposit/fcrepo3/MakeFOXML.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/fcrepo3/MakeFOXML.java
@@ -54,6 +54,7 @@ import edu.unc.lib.dl.util.ContentModelHelper.Relationship;
 import edu.unc.lib.dl.util.DepositConstants;
 import edu.unc.lib.dl.util.RedisWorkerConstants.DepositField;
 import edu.unc.lib.dl.xml.FOXMLJDOMUtil;
+import edu.unc.lib.dl.xml.JDOMNamespaceUtil;
 import edu.unc.lib.dl.xml.FOXMLJDOMUtil.ObjectProperty;
 
 /**
@@ -254,7 +255,7 @@ public class MakeFOXML extends AbstractDepositJob {
 		// Add ALT_IDS - original location URI
 		Statement origLoc = dsResource.getProperty(dprop(m, DepositRelationship.originalLocation));
 		if (origLoc != null) {
-			el.setAttribute("ALT_IDS", origLoc.getResource().getURI());
+			el.getChild("datastreamVersion", JDOMNamespaceUtil.FOXML_NS).setAttribute("ALT_IDS", origLoc.getResource().getURI());
 		}
 
 		// TODO add create time RDF dateTime property

--- a/deposit/src/main/java/edu/unc/lib/deposit/normalize/BioMedCentralExtrasJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/normalize/BioMedCentralExtrasJob.java
@@ -34,6 +34,7 @@ import edu.unc.lib.deposit.work.AbstractDepositJob;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.util.ContentModelHelper;
 import edu.unc.lib.dl.util.DepositConstants;
+import edu.unc.lib.dl.util.ContentModelHelper.DepositRelationship;
 import edu.unc.lib.dl.util.PremisEventLogger.Type;
 
 /**
@@ -143,14 +144,12 @@ public class BioMedCentralExtrasJob extends AbstractDepositJob {
 
 				// Label the supplemental files with values from the article xml
 				if (fileLC2supplementLabels != null) {
-					Property labelP = model.createProperty(label.getURI().toString());
-
 					for (NodeIterator children = aggregate.iterator(); children.hasNext();) {
 						Resource child = children.nextNode().asResource();
 						String location = child.getProperty(fileLocation).getString();
 						String filename = location.substring("data/".length()).toLowerCase();
 						if (fileLC2supplementLabels.containsKey(filename)) {
-							model.add(child, labelP, fileLC2supplementLabels.get(filename));
+							model.add(child, dprop(model, DepositRelationship.label), fileLC2supplementLabels.get(filename));
 						}
 					}
 				}

--- a/deposit/src/main/java/edu/unc/lib/deposit/normalize/CDRMETS2N3BagJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/normalize/CDRMETS2N3BagJob.java
@@ -41,7 +41,7 @@ public class CDRMETS2N3BagJob extends AbstractMETS2N3BagJob {
 		LOG.info("Extractor initialized");
 		extractor.addArrangement(model);
 		LOG.info("Extractor arrangement added");
-		extractor.helper.addFileAssociations(model, false);
+		extractor.helper.addFileAssociations(model, true);
 		LOG.info("Extractor file associations added");
 		extractor.addAccessControls(model);
 		LOG.info("Extractor access controls added");

--- a/deposit/src/main/java/edu/unc/lib/deposit/normalize/DSPACEMETS2N3BagJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/normalize/DSPACEMETS2N3BagJob.java
@@ -54,12 +54,12 @@ public class DSPACEMETS2N3BagJob extends AbstractMETS2N3BagJob {
 	@Override
 	public void runJob() {
 		// copy DSPACE METS into place.
-		try {
-			File payloadMets = new File(getDepositDirectory(), "data/mets.xml");
-			Files.copy(payloadMets.toPath(), new File(getDepositDirectory(), "mets.xml").toPath());
-		} catch (IOException e) {
-			throw new Error(e);
-		}
+//		try {
+//			File payloadMets = new File(getDepositDirectory(), "data/mets.xml");
+//			Files.copy(payloadMets.toPath(), new File(getDepositDirectory(), "mets.xml").toPath());
+//		} catch (IOException e) {
+//			throw new Error(e);
+//		}
 		validateMETS();
 		validateProfile(METSProfile.DSPACE_SIP);
 		Document mets = loadMETS();

--- a/deposit/src/main/java/edu/unc/lib/deposit/normalize/METSHelper.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/normalize/METSHelper.java
@@ -114,7 +114,7 @@ public class METSHelper {
 			String use = fileEl.getAttributeValue("USE"); // may be null
 			Element flocat = fileEl.getChild("FLocat", METS_NS);
 			String href = flocat.getAttributeValue("href", XLINK_NS);
-			if(prependDataPath) {
+			if(prependDataPath && !href.contains(":")) {
 				href = "data/"+href;
 			}
 			Resource object = m.createResource(pid);

--- a/deposit/src/main/java/edu/unc/lib/deposit/normalize/UnpackDepositJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/normalize/UnpackDepositJob.java
@@ -22,10 +22,9 @@ public class UnpackDepositJob extends AbstractDepositJob {
 		// unzip deposit file to directory
 		String filename = getDepositStatus().get(DepositField.fileName.name());
 		if (filename.toLowerCase().endsWith(".zip")) {
-			File depositFile = new File(getDepositDirectory(), "data/"
-					+ filename);
+			File depositFile = new File(getDataDirectory(), filename);
 			try {
-				ZipFileUtil.unzipToDir(depositFile, getDepositDirectory());
+				ZipFileUtil.unzipToDir(depositFile, getDataDirectory());
 			} catch (IOException e) {
 				throw new Error("Unable to unpack your deposit: " + getDepositPID().getUUID(), e);
 			}

--- a/metadata/src/main/java/edu/unc/lib/dl/util/MetsHeaderScanner.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/util/MetsHeaderScanner.java
@@ -128,11 +128,11 @@ public class MetsHeaderScanner extends DefaultHandler {
 		super.endElement(uri, localName, qName);
 	}
 
-	public void scan(File f) throws Exception {
+	public void scan(File f, String filename) throws Exception {
 		@SuppressWarnings("resource")
 		InputStream toParse = null;
 		try {
-			if (f.getName().endsWith(".zip")) {
+			if (filename.endsWith(".zip")) {
 				log.debug("scanning for METS within a zip file");
 				@SuppressWarnings("resource")
 				ZipArchiveInputStream zis = new ZipArchiveInputStream(

--- a/sword-server/src/main/java/edu/unc/lib/dl/cdr/sword/server/deposit/CDRMETSDepositHandler.java
+++ b/sword-server/src/main/java/edu/unc/lib/dl/cdr/sword/server/deposit/CDRMETSDepositHandler.java
@@ -49,7 +49,7 @@ public class CDRMETSDepositHandler extends AbstractDepositHandler {
 		// extract info from METS header
 		MetsHeaderScanner scanner = new MetsHeaderScanner();
 		try {
-			scanner.scan(deposit.getFile());
+			scanner.scan(deposit.getFile(), deposit.getFilename());
 		} catch (Exception e1) {
 			throw new SwordError(ErrorURIRegistry.INGEST_EXCEPTION, 400, "Unable to parse your METS file: "+deposit.getFilename(), e1);
 		}

--- a/sword-server/src/main/java/edu/unc/lib/dl/cdr/sword/server/deposit/DSPACEMETSDepositHandler.java
+++ b/sword-server/src/main/java/edu/unc/lib/dl/cdr/sword/server/deposit/DSPACEMETSDepositHandler.java
@@ -49,7 +49,7 @@ public class DSPACEMETSDepositHandler extends AbstractDepositHandler {
 		// extract info from METS header
 		MetsHeaderScanner scanner = new MetsHeaderScanner();
 		try {
-			scanner.scan(deposit.getFile());
+			scanner.scan(deposit.getFile(), deposit.getFilename());
 		} catch (Exception e1) {
 			throw new SwordError(ErrorURIRegistry.INGEST_EXCEPTION, 400, "Unable to parse your METS file: "+deposit.getFilename(), e1);
 		}

--- a/sword-server/src/test/java/edu/unc/lib/dl/cdr/sword/server/deposit/CDRMETSDepositHandlerTest.java
+++ b/sword-server/src/test/java/edu/unc/lib/dl/cdr/sword/server/deposit/CDRMETSDepositHandlerTest.java
@@ -77,6 +77,30 @@ public class CDRMETSDepositHandlerTest {
 	
 	@SuppressWarnings("unchecked")
 	@Test
+	public void testDoDepositBagitFilename() throws SwordError, IOException {
+		Deposit d = new Deposit();
+		File testPayload = tmpDir.newFile("simple.tmp");
+		FileUtils.copyFile(new File("src/test/resources/simple.zip"), testPayload);
+		d.setFile(testPayload);
+		d.setMd5("d2b88d292e2c47943231205ed36f6c94");
+		d.setFilename("simple.zip");
+		d.setMimeType("application/zip");
+		d.setSlug("metsbagittest");
+		d.setPackaging(PackagingType.METS_CDR.getUri());
+		Entry entry = Abdera.getInstance().getFactory().newEntry();
+		d.setEntry(entry);
+		
+		reset(depositStatusFactory);
+		
+		PID dest = new PID("uuid:destination");
+		metsDepositHandler.doDeposit(dest, d, PackagingType.METS_CDR, swordConfiguration,
+				"test-depositor", "test-owner");
+
+		verify(depositStatusFactory, atLeastOnce()).save(anyString(), anyMap());
+	}
+	
+	@SuppressWarnings("unchecked")
+	@Test
 	public void testDoDepositMETSXML() throws SwordError, IOException {
 		Deposit d = new Deposit();
 		File testPayload = tmpDir.newFile("METS.xml");


### PR DESCRIPTION
changed unpack location of ZIP SIP payload to data/
use filename from sword when deciding how to scan METS/ZIP
fixed location of ALT_IDS attribute
fixed location of BioMed supplied labels to fedora object properties
