### PR TITLE
Include more readable information in status monitor "error log" section

### DIFF
--- a/access/src/main/external/static/css/admin/status_monitor.css
+++ b/access/src/main/external/static/css/admin/status_monitor.css
@@ -162,6 +162,10 @@
 	color: #222;
 }
 
+.status_details pre.stacktrace {
+	white-space: pre;
+	font-family: monospace;
+}
 
 
 /** Jobs table */

--- a/access/src/main/external/static/templates/admin/statusMonitor/depositMonitorJobDetails.html
+++ b/access/src/main/external/static/templates/admin/statusMonitor/depositMonitorJobDetails.html
@@ -55,8 +55,10 @@
 	if (data.finishedTime) { %>
 		<p><label>Finished:</label> <%= dateFormat(new Date(data.finishedTime)) %></p>
 	<% } %>
-	
+	 
 	<% if (data.errorMessage) { %>
-		<h3>Error Log</h3><pre class='stacktrace'> <%= data.errorMessage %></pre>
+		<h3>Error Log</h3>
+    <p><%= data.errorMessage %></p>
+    <pre class="stacktrace"><%= data.stackTrace %></pre>
 	<% } %>
 </div>

--- a/metadata/src/main/java/edu/unc/lib/dl/util/RedisWorkerConstants.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/util/RedisWorkerConstants.java
@@ -13,7 +13,7 @@ public class RedisWorkerConstants {
 		fileName, depositMethod, containerId, payLoadOctets, createTime, startTime,
 		endTime, ingestedOctets, ingestedObjects, directory, lock, submitTime, depositorEmail, 
 		packagingType, metsProfile, metsType, permissionGroups, depositMd5, depositSlug, errorMessage, 
-		excludeDepositRecord, stagingFolderURI, publishObjects;
+		stackTrace, excludeDepositRecord, stagingFolderURI, publishObjects;
 	}
 
 	public static enum JobField {


### PR DESCRIPTION
- Don't print an exception's message twice. Instead, just print the exception's message. If there is no message, print the class name.
- Set a new "stackTrace" key on deposit status hashes with the stack trace from the exception.
- Display the stack trace in the status monitor (with monospaced font)
