### PR TITLE
Full record XSLT updates

### DIFF
--- a/access/src/main/external/static/recordTransformations/modsToFullRecord.xsl
+++ b/access/src/main/external/static/recordTransformations/modsToFullRecord.xsl
@@ -7,10 +7,15 @@
 	Transforms a mods record into a table formatted according to the needs of the 
 	full record page in the CDR public UI.  
 	Author: Ben Pennell
-	Edited on 27 November 2014: Sonoe Nakasone
+	Edited on 2 December 2014: Sonoe Nakasone
 	 -->
 	<xsl:variable name="newline"><xsl:text>
-</xsl:text></xsl:variable>
+	</xsl:text></xsl:variable>
+		
+	<xsl:character-map name="angle-brackets">
+			<xsl:output-character character="&lt;" string="&lt;"/>
+			<xsl:output-character character="&gt;" string="&gt;"/>
+		</xsl:character-map>
 	<!-- mods:name -->
 	<xsl:template match="*[local-name() = 'name']" mode="brief">
 		<xsl:variable name="displayForm" select="./*[local-name() = 'displayForm']"/>
@@ -216,6 +221,8 @@
 	</xsl:template>
 	<!-- mods:originInfo mods:originInfo/place-->
 	<xsl:template name="modsOriginPlaces">
+		
+		
 		<xsl:variable name="place" select="*[local-name() = 'originInfo']/*[local-name() = 'place']"/>
 		<xsl:if test="boolean($place)">
 			<tr>
@@ -230,6 +237,8 @@
 				</td>
 			</tr>
 		</xsl:if>
+	
+		
 	</xsl:template>
 	<!-- Template for a simple name / value pair display -->
 	<xsl:template name="modsField">
@@ -277,7 +286,7 @@
 	
 	<xsl:template name="modsGroupedFieldWithType">
 		<xsl:param name="defaultLabel"/>
-		<xsl:param name="field"/>	
+		<xsl:param name="field"/>
 		<xsl:if test="boolean($field)">
 			<xsl:for-each-group select="$field" group-by="@displayLabel, .[not(@displayLabel)]/@type, local-name(.[not(@displayLabel) and not(@type)])[. != '']">
 				<xsl:variable name="groupKey" select="current-grouping-key()"/>
@@ -303,13 +312,20 @@
 						<xsl:for-each select="current-group()">
 							<xsl:choose>
 								<xsl:when test="boolean(text())">
-									<xsl:value-of select="text()"/><br/><xsl:value-of select="$newline"/>
+									<xsl:analyze-string select="$field" regex="\n">
+										<xsl:matching-substring>
+											<br/>
+										</xsl:matching-substring>
+										<xsl:non-matching-substring>
+											<xsl:value-of select="normalize-space(.)"/>
+										</xsl:non-matching-substring>
+									</xsl:analyze-string>
+									<br/><xsl:value-of select="$newline"/>
 								</xsl:when>
 								<xsl:otherwise>
 									<xsl:value-of select="./@*[local-name() = 'href']"/><br/><xsl:value-of select="$newline"/>
 								</xsl:otherwise>
 							</xsl:choose>
-							
 						</xsl:for-each>
 					</td>
 				</tr>
@@ -384,7 +400,7 @@
 						</xsl:when>
 						<xsl:otherwise>
 							<xsl:value-of select="concat(upper-case(substring($groupKey,1,1)), substring($groupKey,2))"/>
-							<xsl:if test="@usage.[not(@displayLabel)]">
+							<xsl:if test="@usage">
 								<xsl:text> language</xsl:text>
 							</xsl:if>
 						</xsl:otherwise>
@@ -727,7 +743,7 @@
 									</xsl:when>
 									
 									<xsl:when test="local-name()= 'text'">
-										<xsl:for-each select="./*"/>
+						
 										<xsl:choose>
 											<xsl:when test="boolean(@type)">
 												<xsl:choose>
@@ -841,7 +857,6 @@
 		</xsl:for-each-group>
 	</xsl:template>
 	
-
 	<xsl:template match="*[local-name() = 'mods']">
 		<xsl:variable name="name" select="*[local-name() = 'name']"/>
 		<xsl:variable name="titleInfo" select="*[local-name() = 'titleInfo']"/>
@@ -954,13 +969,17 @@
 			</table>
 		</xsl:if>
 		
-		<xsl:variable name="tableOfContents" select="*[local-name() = 'tableOfContents']"/>
+		
+		<xsl:variable name="tableOfContents" select="*[local-name() = 'tableOfContents']" />
+			
 		<xsl:if test="boolean($tableOfContents) and not ($tableOfContents[@shareable])">
+	
 			<table>
 				<xsl:call-template name="modsGroupedFieldWithType">
 					<xsl:with-param name="defaultLabel">Table of Contents</xsl:with-param>
 					<xsl:with-param name="field" select="$tableOfContents"/>
 				</xsl:call-template>
+				
 			</table>
 		</xsl:if>
 		

--- a/access/src/main/external/static/recordTransformations/modsToFullRecord.xsl
+++ b/access/src/main/external/static/recordTransformations/modsToFullRecord.xsl
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="2.0" 
-		xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-	<xsl:import href="languageNames.xsl" />
-	<xsl:output  method="xml" omit-xml-declaration="yes" indent="no"/>
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+	<xsl:import href="languageNames.xsl"/>
+	<xsl:import href="scriptNames.xsl"/>
+	<xsl:output method="xml" omit-xml-declaration="yes" indent="no"/>
 	<!-- 
 	Transforms a mods record into a table formatted according to the needs of the 
 	full record page in the CDR public UI.  
 	Author: Ben Pennell
+	Edited on 27 November 2014: Sonoe Nakasone
 	 -->
-	<xsl:variable name="newline"><xsl:text>&#10;</xsl:text></xsl:variable>
-
+	<xsl:variable name="newline"><xsl:text>
+</xsl:text></xsl:variable>
+<!-- mods:name -->
 	<xsl:template match="*[local-name() = 'name']" mode="brief">
 		<xsl:variable name="displayForm" select="./*[local-name() = 'displayForm']"/>
 		<xsl:variable name="givenName" select="./*[local-name() = 'namePart' and @type='given']"/>
@@ -63,10 +65,11 @@
 			<xsl:when test="boolean($givenName) and boolean($familyName)">
 				<xsl:value-of select="$familyName"/><xsl:text>, </xsl:text><xsl:value-of select="$givenName"/>
 				<xsl:if test="boolean($termsOfAddress)">
-					<xsl:text> </xsl:text><xsl:value-of select="$termsOfAddress"/>
+					<xsl:text>, </xsl:text><xsl:value-of select="$termsOfAddress"/>
 				</xsl:if>
+				
 				<xsl:if test="boolean($dateName)">
-					<xsl:text> </xsl:text><xsl:value-of select="$dateName"/>
+					<xsl:text>, </xsl:text><xsl:value-of select="$dateName"/>
 				</xsl:if>
 			</xsl:when>
 			<xsl:otherwise>
@@ -79,13 +82,13 @@
 			</xsl:otherwise>
 		</xsl:choose>
 		
-		<xsl:variable name="nameType" select="@type" />
+		<xsl:variable name="nameType" select="@type"/>
 		<xsl:if test="boolean($nameType)">
 			<xsl:text> (</xsl:text><xsl:value-of select="$nameType"/><xsl:text>)</xsl:text>
 		</xsl:if>
 		<br/><xsl:value-of select="$newline"/>
 		
-		<xsl:variable name="affiliation" select="*[local-name() = 'affiliation']" />
+		<xsl:variable name="affiliation" select="*[local-name() = 'affiliation']"/>
 		<xsl:if test="boolean($affiliation)">
 			<span>
 				<xsl:text>Affiliation:  </xsl:text>
@@ -95,21 +98,21 @@
 			</span>
 		</xsl:if>
 		
-		<xsl:variable name="description" select="*[local-name() = 'description']" />
+		<xsl:variable name="description" select="*[local-name() = 'description']"/>
 		<xsl:if test="boolean($description)">
 			<xsl:text>Description:  </xsl:text><xsl:value-of select="$description"/><br/><xsl:value-of select="$newline"/>
 		</xsl:if>
 	</xsl:template>
 
 	<xsl:template name="modsNames">
-		<xsl:for-each-group select="*[local-name() = 'name']" group-by="*[local-name() = 'role']/*[local-name() = 'roleTerm']/text(), local-name(.[./not(*[local-name() = 'role']/*[local-name() = 'roleTerm'])])[. != '']">
+		<xsl:for-each-group select="*[local-name() = 'name']" group-by="@displayLabel, .[not(@displayLabel)]/*[local-name() = 'role']/*[local-name() = 'roleTerm']/text(), local-name(.[not(@displayLabel)][./not(*[local-name() = 'role']/*[local-name() = 'roleTerm'])])[. != '']">
 			<xsl:variable name="groupKey" select="current-grouping-key()"/>
 			<tr>
 				
 				<th>
 					<xsl:choose>
 						<xsl:when test="$groupKey = local-name()">
-							<xsl:value-of>Contributor</xsl:value-of>
+							<xsl:value-of>Creator</xsl:value-of>
 						</xsl:when>
 						<xsl:otherwise>
 							<xsl:value-of select="concat(upper-case(substring($groupKey,1,1)), substring($groupKey,2))"/>
@@ -126,48 +129,48 @@
 			</tr><xsl:value-of select="$newline"/>
 		</xsl:for-each-group>
 	</xsl:template>
-
+<!-- mods:titleInfo -->
 	<xsl:template match="*[local-name() = 'titleInfo']" mode="brief">
-		<xsl:variable name="nonSort" select="*[local-name() = 'nonSort']" />
+		<xsl:variable name="nonSort" select="*[local-name() = 'nonSort']"/>
 		<xsl:if test="boolean($nonSort)">
 			<xsl:value-of select="$nonSort"/><xsl:text> </xsl:text>
 		</xsl:if>
 		
-		<xsl:variable name="title" select="*[local-name() = 'title']" />
+		<xsl:variable name="title" select="*[local-name() = 'title']"/>
 		<xsl:if test="boolean($title)">
 			<xsl:value-of select="$title"/>
 		</xsl:if>
 		
-		<xsl:variable name="subTitle" select="*[local-name() = 'subTitle']" />
+		<xsl:variable name="subTitle" select="*[local-name() = 'subTitle']"/>
 		<xsl:if test="boolean($subTitle)">
 			<xsl:text>: </xsl:text><xsl:value-of select="$subTitle"/>
 		</xsl:if>
 	</xsl:template>
 
 	<xsl:template match="*[local-name() = 'titleInfo']">
-		<xsl:variable name="nonSort" select="*[local-name() = 'nonSort']" />
+		<xsl:variable name="nonSort" select="*[local-name() = 'nonSort']"/>
 		<xsl:if test="boolean($nonSort)">
 			<xsl:value-of select="$nonSort"/><xsl:text> </xsl:text>
 		</xsl:if>
 		
-		<xsl:variable name="title" select="*[local-name() = 'title']" />
+		<xsl:variable name="title" select="*[local-name() = 'title']"/>
 		<xsl:if test="boolean($title)">
 			<xsl:value-of select="$title"/>
 		</xsl:if>
 		
-		<xsl:variable name="subTitle" select="*[local-name() = 'subTitle']" />
+		<xsl:variable name="subTitle" select="*[local-name() = 'subTitle']"/>
 		<xsl:if test="boolean($subTitle)">
 			<xsl:text>: </xsl:text><xsl:value-of select="$subTitle"/>
 		</xsl:if>
-		<br/><xsl:value-of select="$newline"/>
+		<xsl:value-of select="$newline"/>
 		
-		<xsl:variable name="partNumber" select="*[local-name() = 'partNumber']" />
+		<xsl:variable name="partNumber" select="*[local-name() = 'partNumber']"/>
 		<xsl:if test="boolean($partNumber)">
 			<xsl:for-each select="$partNumber">
 				<xsl:text>Part Number: </xsl:text><xsl:value-of select="."/><br/>
 			</xsl:for-each>
 		</xsl:if>
-		<xsl:variable name="partName" select="*[local-name() = 'partName']" />
+		<xsl:variable name="partName" select="*[local-name() = 'partName']"/>
 		<xsl:if test="boolean($partName)">
 			<xsl:for-each select="$partName">
 				<xsl:text>Part Name: </xsl:text><xsl:value-of select="."/><br/>
@@ -211,7 +214,7 @@
 			</tr>
 		</xsl:for-each-group>
 	</xsl:template>
-	
+<!-- mods:originInfo mods:originInfo/place-->
 	<xsl:template name="modsOriginPlaces">
 		<xsl:variable name="place" select="*[local-name() = 'originInfo']/*[local-name() = 'place']"/>
 		<xsl:if test="boolean($place)">
@@ -228,7 +231,7 @@
 			</tr>
 		</xsl:if>
 	</xsl:template>
-	
+<!-- ??? -->	
 	<xsl:template name="modsField">
 		<xsl:param name="label"/>
 		<xsl:param name="field"/>
@@ -271,7 +274,7 @@
 			</xsl:for-each-group>
 		</xsl:if>
 	</xsl:template>
-
+	
 	<xsl:template name="modsGroupedFieldWithType">
 		<xsl:param name="defaultLabel"/>
 		<xsl:param name="field"/>	
@@ -313,10 +316,9 @@
 			</xsl:for-each-group>
 		</xsl:if>
 	</xsl:template>
-	
+<!-- mods:originInfo dates -->	
 	<xsl:template name="modsOriginDates">
-		<xsl:for-each-group select="*[local-name() = 'originInfo']/*[contains(local-name(), 'date') or local-name() = 'copyrightDate']"
-				group-by="@displayLabel, local-name(.[not(@displayLabel)])[. != '']">
+		<xsl:for-each-group select="*[local-name() = 'originInfo']/*[contains(local-name(), 'date') or local-name() = 'copyrightDate']" group-by="@displayLabel, local-name(.[not(@displayLabel)])[. != '']">
 			<xsl:variable name="groupKey" select="current-grouping-key()"/>
 			
 			<tr>
@@ -350,20 +352,28 @@
 				</th><xsl:value-of select="$newline"/>
 				<td>
 					<xsl:for-each select="current-group()">
+						<xsl:if test="boolean(@point='start')">
+							<xsl:text>Start date: </xsl:text>
+						</xsl:if>
+						<xsl:if test="boolean(@point='end')">
+							<xsl:text>End date: </xsl:text>
+						</xsl:if>
 						<xsl:value-of select="text()"/>
-						<xsl:if test="boolean(@point)">
-							<xsl:text> (</xsl:text><xsl:value-of select="@point"/><xsl:text>)</xsl:text>
+						<xsl:if test="boolean(@qualifier)">
+							<xsl:text> (</xsl:text><xsl:value-of select="@qualifier"/><xsl:text>)</xsl:text>
 						</xsl:if>
 						<br/><xsl:value-of select="$newline"/>
 					</xsl:for-each>
+	
+						<br/><xsl:value-of select="$newline"/>
 				</td>
 			</tr>
 		
 		</xsl:for-each-group>
 	</xsl:template>
-
+<!-- mods:language -->
 	<xsl:template name="modsLanguages">
-		<xsl:for-each-group select="*[local-name() = 'language']" group-by="@displayLabel, local-name(.[not(@displayLabel)])[. != '']">
+		<xsl:for-each-group select="*[local-name() = 'language']" group-by="@displayLabel, .[not(@displayLabel)]/@usage, local-name(.[not(@displayLabel) and not(@usage)])[. != '']">
 			<xsl:variable name="groupKey" select="current-grouping-key()"/>
 			<tr>
 				<th>
@@ -373,6 +383,9 @@
 						</xsl:when>
 						<xsl:otherwise>
 							<xsl:value-of select="concat(upper-case(substring($groupKey,1,1)), substring($groupKey,2))"/>
+							<xsl:if test="@usage.[not(@displayLabel)]">
+								<xsl:text> language</xsl:text>
+							</xsl:if>
 						</xsl:otherwise>
 					</xsl:choose>
 				</th><xsl:value-of select="$newline"/>
@@ -383,79 +396,113 @@
 						<xsl:variable name="languages" select="*[local-name() = 'languageTerm']"/>
 						<xsl:if test="boolean($languages)">
 							<xsl:call-template name="getLanguageName">
-								<xsl:with-param name="languageNodes" select="$languages" />
+								<xsl:with-param name="languageNodes" select="$languages"/>
 							</xsl:call-template>
-							<br/><xsl:value-of select="$newline"/>
-						</xsl:if>
-						
-						<!-- Display script if available -->
-						<xsl:variable name="languageScripts" select="*[local-name() = 'scriptTerm']"/>
-						<xsl:if test="boolean($languageScripts)">
-							<xsl:text>Script:  </xsl:text>
-							<xsl:call-template name="getLanguageName">
-								<xsl:with-param name="languageNodes" select="$languageScripts" />
-							</xsl:call-template>
+								<xsl:if test="@objectPart">
+									<xsl:text> (</xsl:text>
+									<xsl:value-of select="@objectPart"/>
+									<xsl:text>)</xsl:text>
+								</xsl:if>
 							<br/><xsl:value-of select="$newline"/>
 						</xsl:if>
 					</xsl:for-each>
+						<!-- Display script if available -->
+					<xsl:for-each select="current-group()">
+						<xsl:variable name="languages" select="*[local-name() = 'scriptTerm']"/>
+						<xsl:if test="boolean($languages)">
+							<xsl:text>Script:  </xsl:text>
+							<xsl:call-template name="getScriptName">
+								<xsl:with-param name="scriptNodes" select="$languages"/>
+							</xsl:call-template>
+							<xsl:if test="@objectPart">
+								<xsl:text> (</xsl:text>
+								<xsl:value-of select="@objectPart"/>
+								<xsl:text>)</xsl:text>
+							</xsl:if>
+							<br/><xsl:value-of select="$newline"/>
+						</xsl:if>
+					</xsl:for-each>		
 				</td>
 			</tr>
 		</xsl:for-each-group>
 	</xsl:template>
-	
+	<!-- mods:subject -->
+	<xsl:template name="cartographics">
+		<xsl:value-of select="*[local-name() = 'scale']"/>
+			<xsl:if test="*[local-name() = 'projection']">
+				<xsl:if test="*[local-name() = 'scale']">
+					<xsl:text> ; </xsl:text> 
+				</xsl:if>
+				<xsl:value-of select="*[local-name() = 'projection']"/>
+			</xsl:if>
+		<xsl:if test="*[local-name() = 'coordinates']">
+			<xsl:text> </xsl:text>
+			(<xsl:value-of select="*[local-name() = 'coordinates']"/>).
+		</xsl:if>
+	</xsl:template>
 	<xsl:template name="modsSubjects">
-		<xsl:for-each-group select="*[local-name() = 'subject']" group-by="@displayLabel, local-name(.[not(@displayLabel)])[. != '']">
-			<xsl:variable name="groupKey" select="current-grouping-key()"/>
+			<xsl:for-each-group select="*[local-name() = 'subject']" group-by="@displayLabel, local-name(.[not(@displayLabel)])[. != '']">
+				<xsl:variable name="groupKey" select="current-grouping-key()"/>
+				<tr>
+					<th>
+						<xsl:choose>
+							<xsl:when test="$groupKey = local-name()">
+								<xsl:text>Subject</xsl:text>
+							</xsl:when>
+							<xsl:otherwise>
+								<xsl:value-of select="concat(upper-case(substring($groupKey,1,1)), substring($groupKey,2))"/>
+							</xsl:otherwise>
+						</xsl:choose>
+					</th><xsl:value-of select="$newline"/>
+					<td>
+						<xsl:for-each select="current-group()">
+							<xsl:for-each select="./*">
+								<br/><xsl:value-of select="$newline"/>
+								<!-- Render the second tier of children based on the element name of the first tier -->
+								<xsl:choose>
+									<xsl:when test="local-name() = 'name' or local-name() = 'titleInfo'">
+										<xsl:apply-templates select="." mode="brief"/>
+									</xsl:when>
+									<xsl:when test="local-name() = 'hierarchicalGeographic'">
+										<xsl:for-each select="./*">
+											<xsl:if test="position() != 1">
+												<xsl:text>, </xsl:text>
+											</xsl:if>
+											<xsl:value-of select="text()"/>
+										</xsl:for-each>			
+									</xsl:when>
+									<xsl:when test="local-name() = 'cartographics'">
+										<xsl:call-template name="cartographics"/>
+									</xsl:when>
+									<xsl:otherwise>
+										<xsl:value-of select="text()"/>
+									</xsl:otherwise>
+								</xsl:choose>
+							</xsl:for-each>
+							<br/><xsl:value-of select="$newline"/>
+						</xsl:for-each>
+					</td>
+				</tr>
+			</xsl:for-each-group>
+		</xsl:template>
+<!-- mods:abstract -->
+	<xsl:template name="modsAbstract">
+		<xsl:for-each select="*[local-name() = 'abstract']">
 			<tr>
 				<th>
-					<xsl:choose>
-						<xsl:when test="$groupKey = local-name()">
-							<xsl:text>Subject</xsl:text>
-						</xsl:when>
-						<xsl:otherwise>
-							<xsl:value-of select="concat(upper-case(substring($groupKey,1,1)), substring($groupKey,2))"/>
-						</xsl:otherwise>
-					</xsl:choose>
+						<xsl:if test="@type='Content advice'">
+							<xsl:value-of select="@type"/>
+						</xsl:if>
 				</th><xsl:value-of select="$newline"/>
 				<td>
-					<xsl:for-each select="current-group()">
-						<!-- Decide which seperator to use between first tier subject children based on the authority of the subject -->
-						<xsl:variable name="seperator">
-							<xsl:choose>
-								<xsl:when test="@authority = 'lcsh'"><xsl:text> -- </xsl:text></xsl:when>
-								<xsl:otherwise><xsl:text> -- </xsl:text></xsl:otherwise>
-							</xsl:choose>
-						</xsl:variable>
-						
-						<xsl:for-each select="./*">
-							<xsl:if test="position() != 1">
-								<xsl:value-of select="$seperator"/>
-							</xsl:if>
-							<!-- Render the second tier of children based on the element name of the first tier -->
-							<xsl:choose>
-								<xsl:when test="local-name() = 'name' or local-name() = 'titleInfo'">
-									<xsl:apply-templates select="." mode="brief"/>
-								</xsl:when>
-								<xsl:when test="local-name() = 'hierarchicalGeographic' or local-name() = 'cartographics'">
-									<xsl:for-each select="./*">
-										<xsl:if test="position() != 1">
-											<xsl:text>, </xsl:text>
-										</xsl:if>
-										<xsl:value-of select="text()"/>
-									</xsl:for-each>			
-								</xsl:when>
-								<xsl:otherwise>
-									<xsl:value-of select="text()"/>
-								</xsl:otherwise>
-							</xsl:choose>
-						</xsl:for-each>
-						<br/><xsl:value-of select="$newline"/>
-					</xsl:for-each>
-				</td>
+					<xsl:if test="@type='Content advice'">
+						<xsl:value-of select="text()"/>
+					</xsl:if>
+				</td><xsl:value-of select="$newline"/>
 			</tr>
-		</xsl:for-each-group>
+		</xsl:for-each>
 	</xsl:template>
-	
+	<!-- mods:classification -->
 	<xsl:template name="modsClassifications">
 		<xsl:for-each-group select="*[local-name() = 'classification']" group-by="@displayLabel, local-name(.[not(@displayLabel)])[. != '']">
 			<xsl:variable name="groupKey" select="current-grouping-key()"/>
@@ -482,7 +529,7 @@
 			</tr>
 		</xsl:for-each-group>
 	</xsl:template>
-	
+<!-- mods:location -->
 	<xsl:template name="modsLocations">
 		<xsl:for-each-group select="*[local-name() = 'location']" group-by="@displayLabel, local-name(.[not(@displayLabel)])[. != '']">
 			<xsl:variable name="groupKey" select="current-grouping-key()"/>
@@ -500,9 +547,10 @@
 				<td>
 					<xsl:for-each select="current-group()">
 						<xsl:for-each select="./*[local-name() = 'url']|*[local-name() = 'uri']|./*[local-name() = 'physicalLocation']">
+							<xsl:value-of select="concat(upper-case(substring(@displayLabel,1,1)), substring(@displayLabel,2))"/><xsl:text>: </xsl:text>
 							<xsl:value-of select="text()"/>
 							<xsl:if test="local-name() = 'url'">
-								<xsl:for-each select="@access|@note|@displayLabel">
+								<xsl:for-each select="@access|@note">
 									<xsl:if test="position() = 1">
 										<xsl:text> (</xsl:text>
 									</xsl:if>
@@ -524,18 +572,31 @@
 			</tr>
 		</xsl:for-each-group>
 	</xsl:template>
-
+<!-- mods:physicalDescription -->
 	<xsl:template name="modsPhysicalDescription">
 		<xsl:for-each-group select="*[local-name() = 'physicalDescription']/*" group-by="@displayLabel, .[not(@displayLabel)]/@type, local-name(.[not(@displayLabel) and not(@type)])[. != '']">
 			<xsl:variable name="groupKey" select="current-grouping-key()"/>
 			<tr>
 				<th>
 					<xsl:choose>
+						<xsl:when test="$groupKey = 'form'">
+							<xsl:value-of>Form</xsl:value-of>
+						</xsl:when>
 						<xsl:when test="$groupKey = 'reformattingQuality'">
 							<xsl:value-of>Reformatting Quality</xsl:value-of>
 						</xsl:when>
 						<xsl:when test="$groupKey = 'internetMediaType'">
 							<xsl:value-of>Internet Media Type</xsl:value-of>
+						</xsl:when>
+						<xsl:when test="$groupKey = 'extent'">
+							<xsl:choose>
+								<xsl:when test="@unit">
+									<xsl:value-of select="concat(upper-case(substring(@unit,1,1)), substring(@unit,2))"/>
+								</xsl:when>
+								<xsl:otherwise>
+									<xsl:value-of>Extent</xsl:value-of>
+								</xsl:otherwise>
+							</xsl:choose>
 						</xsl:when>
 						<xsl:when test="$groupKey = 'digitalOrigin'">
 							<xsl:value-of>Digital Origin</xsl:value-of>
@@ -556,18 +617,26 @@
 			</tr>
 		</xsl:for-each-group>
 	</xsl:template>
-	
-	<xsl:template name="modsParts">
+<!-- mods:part -->
+	<xsl:template name="modsParts">		
 		<xsl:for-each-group select="*[local-name() = 'part']" group-by="@displayLabel, local-name(.[not(@displayLabel)])[. != '']">
 			<xsl:variable name="groupKey" select="current-grouping-key()"/>
 			<tr>
 				<xsl:variable name="partText" select="*[local-name() = 'text']"/>
-				<xsl:choose>
-					<xsl:when test="boolean($partText)">
-						<td><xsl:value-of select="$partText/text()"/></td>
-					</xsl:when>
-					<xsl:otherwise>
-						<th>
+				<th>
+					<xsl:choose>
+						<xsl:when test="boolean($partText)">
+							
+							<xsl:choose>
+								<xsl:when test="$partText/@displayLabel">
+									<xsl:value-of select="concat(upper-case(substring($partText/@displayLabel,1,1)), substring($partText/@displayLabel,2))"/>
+								</xsl:when>
+								<xsl:otherwise>
+									<xsl:value-of>Part</xsl:value-of>
+								</xsl:otherwise>
+							</xsl:choose>						
+						</xsl:when>
+						<xsl:otherwise>
 							<xsl:choose>
 								<xsl:when test="$groupKey = name()">
 									<xsl:text>Part</xsl:text>
@@ -576,16 +645,25 @@
 									<xsl:value-of select="concat(upper-case(substring($groupKey,1,1)), substring($groupKey,2))"/>
 								</xsl:otherwise>
 							</xsl:choose>
-						</th><xsl:value-of select="$newline"/>
-						<td>
+						</xsl:otherwise>
+					</xsl:choose>
+				</th><xsl:value-of select="$newline"/>
+				<!-- Above: if part/text is available, show only this subelement.  When @displayLabel is present it overrides "Part" label.  Below: If part/text is not available, show the rest of the subelements  -->
+				<td>
+					<xsl:choose>
+						<xsl:when test="boolean($partText)">
+							<xsl:value-of select="$partText/text()"/>
+						</xsl:when>
+						<xsl:otherwise>
 							<xsl:for-each select="current-group()">
+								<xsl:sort select="@order"/>
 								<xsl:for-each select="./*">
 									<xsl:choose>
 										<xsl:when test="local-name() = 'detail'">
 											<xsl:for-each select="./*">
 												<xsl:choose>
 													<xsl:when test="local-name() = 'number' and boolean(../@type)">
-														<xsl:value-of select="../@type"/><xsl:text>: </xsl:text><xsl:value-of select="text()"/>
+														<xsl:value-of select="concat(upper-case(substring(../@type,1,1)), substring(../@type,2))"/><xsl:text>: </xsl:text><xsl:value-of select="text()"/>
 													</xsl:when>
 													<xsl:otherwise>
 														<xsl:value-of select="concat(upper-case(substring(local-name(),1,1)), substring(local-name(),2))"/>
@@ -601,44 +679,97 @@
 													<xsl:when test="local-name() = 'start' or local-name() = 'end'">
 														<xsl:value-of select="concat(upper-case(substring(local-name(),1,1)), substring(local-name(),2))"/>
 														<xsl:text>: </xsl:text><xsl:value-of select="text()"/>
-														<xsl:if test="boolean(../@unit)">
-															<xsl:text> </xsl:text><xsl:value-of select="../@unit"/>
-														</xsl:if>
+														<!-- Commented out by SN, 11/20/2014>
+															<xsl:if test="boolean(../@unit)">
+															<xsl:text> </xsl:text>
+															<xsl:value-of select="../@unit"/>
+															</xsl:if>
+														-->
 													</xsl:when>
 													<xsl:when test="local-name() = 'total'">
-														<xsl:if test="boolean(../@unit)">
-															<xsl:value-of select="../@unit"/>
-															<xsl:text>: </xsl:text>
-														</xsl:if>
-														<xsl:value-of select="text()"/><xsl:text> total</xsl:text>
+														<xsl:choose>
+															<xsl:when test="../@unit">
+																<xsl:value-of select="concat(upper-case(substring(local-name(),1,1)), substring(local-name(),2)), ../@unit"/>
+																<xsl:text>: </xsl:text>
+															</xsl:when>
+															<xsl:otherwise>
+																<xsl:value-of select="concat(upper-case(substring(local-name(),1,1)), substring(local-name(),2))"/><!-- Sonoe note, 11/20/2014: I guess I could have also done <xsl:value-of>Total</xsl:value-of> or <xsl:text> -->
+																<xsl:text>: </xsl:text>
+															</xsl:otherwise>
+														</xsl:choose>
+														<xsl:value-of select="text()"/>
 													</xsl:when>
-													<xsl:otherwise>
+													
+													<xsl:when test="local-name() = 'list'">
+														<xsl:text>List: </xsl:text>
+														<xsl:value-of select="text()"/>
+													</xsl:when>
+													<!--  Original code for displaying list:
+														<xsl:otherwise>
 														<xsl:if test="boolean(../@unit)">
-															<xsl:value-of select="../@unit"/>
-															<xsl:text>: </xsl:text>
+														<xsl:value-of select="../@unit"/>
+														<xsl:text>: </xsl:text>
 														</xsl:if>
 														<xsl:value-of select="text()"/>
-													</xsl:otherwise>
+														</xsl:otherwise>
+													-->
 												</xsl:choose>
 												<br/><xsl:value-of select="$newline"/>
 											</xsl:for-each>
 										</xsl:when>
-										<xsl:otherwise>
+										
+										<xsl:when test="local-name()='date'">
+											<xsl:choose>
+												<xsl:when test="@point='start'">
+													<xsl:text>Start date: </xsl:text>
+													<xsl:value-of select="text()"/>
+													<xsl:if test="boolean(@qualifier)">
+														<xsl:text> (</xsl:text>
+														<xsl:value-of select="@qualifier"/>
+														<xsl:text>)</xsl:text>
+													</xsl:if>
+													<br/><xsl:value-of select="$newline"/>
+												</xsl:when>
+												<xsl:when test="@point='end'">
+													<xsl:text>End date: </xsl:text>
+													<xsl:value-of select="text()"/>
+													<xsl:if test="boolean(@qualifier)">
+														<xsl:text> (</xsl:text>
+														<xsl:value-of select="@qualifier"/>
+														<xsl:text>)</xsl:text>
+													</xsl:if>
+													<br/><xsl:value-of select="$newline"/>
+												</xsl:when>
+												<xsl:otherwise>
+													<xsl:text>Date: </xsl:text>
+													<xsl:value-of select="text()"/>
+													<xsl:if test="boolean(@qualifier)">
+														<xsl:text> (</xsl:text>
+														<xsl:value-of select="@qualifier"/>
+														<xsl:text>)</xsl:text>
+													</xsl:if>
+													<br/><xsl:value-of select="$newline"/>
+												</xsl:otherwise>
+											</xsl:choose>
+										</xsl:when>
+										<!-- Original code for displaying date:
+											<xsl:otherwise>
 											<xsl:value-of select="(@displayLabel,@type,local-name())[1]"/>
 											<xsl:text>: </xsl:text>
 											<xsl:value-of select="text()"/>
 											<br/><xsl:value-of select="$newline"/>
-										</xsl:otherwise>
+											</xsl:otherwise>
+										-->
 									</xsl:choose>
 								</xsl:for-each>
 							</xsl:for-each>
-						</td>					
-					</xsl:otherwise>
-				</xsl:choose>
+						</xsl:otherwise>						
+					</xsl:choose>
+				</td>
 			</tr>
 		</xsl:for-each-group>
 	</xsl:template>
-	
+<!-- mdos:relatedItem -->	
 	<!-- Related items can contain any kind of item, so just reusing the other templates and nesting in an extra table-->
 	<xsl:template name="modsRelatedItems">
 		<xsl:for-each-group select="*[local-name() = 'relatedItem']" group-by="@displayLabel, .[not(@displayLabel)]/@type, local-name(.[not(@displayLabel) and not(@type)])[. != '']">
@@ -660,62 +791,62 @@
 						<xsl:call-template name="modsTitles"/>
 						<xsl:call-template name="modsField">
 							<xsl:with-param name="label">Publisher</xsl:with-param>
-							<xsl:with-param name="field" select="*[local-name() = 'originInfo']/*[local-name() = 'publisher']" />
+							<xsl:with-param name="field" select="*[local-name() = 'originInfo']/*[local-name() = 'publisher']"/>
 						</xsl:call-template>
 						<xsl:call-template name="modsField">
 							<xsl:with-param name="label">Issuance</xsl:with-param>
-							<xsl:with-param name="field" select="*[local-name() = 'originInfo']/*[local-name() = 'issuance']" />
+							<xsl:with-param name="field" select="*[local-name() = 'originInfo']/*[local-name() = 'issuance']"/>
 						</xsl:call-template>
 						<xsl:call-template name="modsField">
 							<xsl:with-param name="label">Frequency</xsl:with-param>
-							<xsl:with-param name="field" select="*[local-name() = 'originInfo']/*[local-name() = 'frequency']" />
+							<xsl:with-param name="field" select="*[local-name() = 'originInfo']/*[local-name() = 'frequency']"/>
 						</xsl:call-template>
 						<xsl:call-template name="modsField">
 							<xsl:with-param name="label">Edition</xsl:with-param>
-							<xsl:with-param name="field" select="*[local-name() = 'originInfo']/*[local-name() = 'edition']" />
+							<xsl:with-param name="field" select="*[local-name() = 'originInfo']/*[local-name() = 'edition']"/>
 						</xsl:call-template>
 						<xsl:call-template name="modsOriginPlaces"/>
 						<xsl:call-template name="modsOriginDates"/>
 						
 						<xsl:call-template name="modsGroupedField">
 							<xsl:with-param name="defaultLabel">Type of Resource</xsl:with-param>
-							<xsl:with-param name="field" select="*[local-name() = 'typeOfResource']" />
+							<xsl:with-param name="field" select="*[local-name() = 'typeOfResource']"/>
 						</xsl:call-template>
 						
-						<xsl:call-template name="modsGroupedField">
+						<xsl:call-template name="modsGroupedFieldWithType">
 							<xsl:with-param name="defaultLabel">Genre</xsl:with-param>
-							<xsl:with-param name="field" select="*[local-name() = 'genre']" />
+							<xsl:with-param name="field" select="*[local-name() = 'genre']"/>
 						</xsl:call-template>
 						
 						<xsl:call-template name="modsLanguages"/>
 						
-						<xsl:call-template name="modsGroupedField">
+						<xsl:call-template name="modsGroupedFieldWithType">
 							<xsl:with-param name="defaultLabel">Table of Contents</xsl:with-param>
-							<xsl:with-param name="field" select="*[local-name() = 'tableOfContents']" />
 						</xsl:call-template>
 						
 						<xsl:call-template name="modsGroupedFieldWithType">
 							<xsl:with-param name="defaultLabel">Target Audience</xsl:with-param>
-							<xsl:with-param name="field" select="*[local-name() = 'targetAudience']" />
+							<xsl:with-param name="field" select="*[local-name() = 'targetAudience']"/>
 						</xsl:call-template>
 						
 						<xsl:call-template name="modsGroupedFieldWithType">
 							<xsl:with-param name="defaultLabel">Note</xsl:with-param>
-							<xsl:with-param name="field" select="*[local-name() = 'note']" />
+							<xsl:with-param name="field" select="*[local-name() = 'note']"/>
 						</xsl:call-template>
 						
 						<xsl:call-template name="modsGroupedFieldWithType">
 							<xsl:with-param name="defaultLabel">Identifier</xsl:with-param>
-							<xsl:with-param name="field" select="*[local-name() = 'identifier']" />
+							<xsl:with-param name="field" select="*[local-name() = 'identifier']"/>
 						</xsl:call-template>
 						
 						<xsl:call-template name="modsSubjects"/>
 						<xsl:call-template name="modsClassifications"/>
+						<xsl:call-template name="modsAbstract"/>
 						<xsl:call-template name="modsLocations"/>
 						
 						<xsl:call-template name="modsGroupedFieldWithType">
 							<xsl:with-param name="defaultLabel">Access Conditions</xsl:with-param>
-							<xsl:with-param name="field" select="*[local-name() = 'accessCondition']" />
+							<xsl:with-param name="field" select="*[local-name() = 'accessCondition']"/>
 						</xsl:call-template>
 						<xsl:call-template name="modsParts"/>
 					</table>
@@ -747,27 +878,29 @@
 		<xsl:variable name="genre" select="*[local-name() = 'genre']"/>
 		<xsl:variable name="identifier" select="*[local-name() = 'identifier']"/>
 		<xsl:variable name="classification" select="*[local-name() = 'classification']"/>
+		<xsl:variable name="abstract" select="*[local-name() = 'abstract']"/>
 		<xsl:variable name="targetAudience" select="*[local-name() = 'targetAudience']"/>
 		
-		<xsl:if test="boolean($language) or boolean($typeOfResource) or boolean($genre) or boolean($identifier) or boolean($classification) or boolean($targetAudience)">
+		<xsl:if test="boolean($language) or boolean($typeOfResource) or boolean($genre) or boolean($identifier) or boolean($classification) or boolean($targetAudience) or boolean ($abstract)">
 			<table>
 				<xsl:call-template name="modsLanguages"/>
 				<xsl:call-template name="modsGroupedField">
 					<xsl:with-param name="defaultLabel">Type of Resource</xsl:with-param>
-					<xsl:with-param name="field" select="$typeOfResource" />
+					<xsl:with-param name="field" select="$typeOfResource"/>
 				</xsl:call-template>
-				<xsl:call-template name="modsGroupedField">
+				<xsl:call-template name="modsGroupedFieldWithType">
 					<xsl:with-param name="defaultLabel">Genre</xsl:with-param>
-					<xsl:with-param name="field" select="$genre" />
+					<xsl:with-param name="field" select="$genre"/>
 				</xsl:call-template>
 				<xsl:call-template name="modsGroupedFieldWithType">
 					<xsl:with-param name="defaultLabel">Identifier</xsl:with-param>
-					<xsl:with-param name="field" select="$identifier" />
+					<xsl:with-param name="field" select="$identifier"/>
 				</xsl:call-template>
 				<xsl:call-template name="modsClassifications"/>
+				<xsl:call-template name="modsAbstract"/>
 				<xsl:call-template name="modsGroupedFieldWithType">
 					<xsl:with-param name="defaultLabel">Target Audience</xsl:with-param>
-					<xsl:with-param name="field" select="$targetAudience" />
+					<xsl:with-param name="field" select="$targetAudience"/>
 				</xsl:call-template>
 			</table>
 		</xsl:if>
@@ -784,19 +917,19 @@
 			<table>
 				<xsl:call-template name="modsField">
 					<xsl:with-param name="label">Publisher</xsl:with-param>
-					<xsl:with-param name="field" select="$publisher" />
+					<xsl:with-param name="field" select="$publisher"/>
 				</xsl:call-template>
 				<xsl:call-template name="modsField">
 					<xsl:with-param name="label">Issuance</xsl:with-param>
-					<xsl:with-param name="field" select="$issuance" />
+					<xsl:with-param name="field" select="$issuance"/>
 				</xsl:call-template>
 				<xsl:call-template name="modsField">
 					<xsl:with-param name="label">Frequency</xsl:with-param>
-					<xsl:with-param name="field" select="$frequency" />
+					<xsl:with-param name="field" select="$frequency"/>
 				</xsl:call-template>
 				<xsl:call-template name="modsField">
 					<xsl:with-param name="label">Edition</xsl:with-param>
-					<xsl:with-param name="field" select="$edition" />
+					<xsl:with-param name="field" select="$edition"/>
 				</xsl:call-template>
 				<xsl:call-template name="modsOriginPlaces"/>
 				<xsl:call-template name="modsOriginDates"/>
@@ -822,27 +955,27 @@
 			<table>
 				<xsl:call-template name="modsGroupedFieldWithType">
 					<xsl:with-param name="defaultLabel">Note</xsl:with-param>
-					<xsl:with-param name="field" select="$note" />
+					<xsl:with-param name="field" select="$note"/>
 				</xsl:call-template>
 				<xsl:call-template name="modsGroupedFieldWithType">
 					<xsl:with-param name="defaultLabel">Access Conditions</xsl:with-param>
-					<xsl:with-param name="field" select="$accessCondition" />
+					<xsl:with-param name="field" select="$accessCondition"/>
 				</xsl:call-template>
 				<xsl:call-template name="modsGroupedFieldWithType">
 					<xsl:with-param name="defaultLabel">Rights Holder</xsl:with-param>
-					<xsl:with-param name="field" select="$rightsHolder" />
+					<xsl:with-param name="field" select="$rightsHolder"/>
 				</xsl:call-template>
 			</table>
 		</xsl:if>
 		
 		<xsl:variable name="tableOfContents" select="*[local-name() = 'tableOfContents']"/>
-		<xsl:if test="boolean($tableOfContents)">
-			<table>
-				<xsl:call-template name="modsGroupedField">
-					<xsl:with-param name="defaultLabel">Table of Contents</xsl:with-param>
-					<xsl:with-param name="field" select="$tableOfContents" />
-				</xsl:call-template>
-			</table>
+		<xsl:if test="boolean($tableOfContents) and not ($tableOfContents[@shareable])">
+				<table>
+					<xsl:call-template name="modsGroupedFieldWithType">
+						<xsl:with-param name="defaultLabel">Table of Contents</xsl:with-param>
+						<xsl:with-param name="field" select="$tableOfContents"/>
+					</xsl:call-template>
+				</table>
 		</xsl:if>
 		
 		<xsl:variable name="relatedItem" select="*[local-name() = 'relatedItem']"/>

--- a/access/src/main/external/static/recordTransformations/modsToFullRecord.xsl
+++ b/access/src/main/external/static/recordTransformations/modsToFullRecord.xsl
@@ -214,7 +214,7 @@
 			</tr>
 		</xsl:for-each-group>
 	</xsl:template>
-<!-- mods:originInfo mods:originInfo/place-->
+	<!-- mods:originInfo mods:originInfo/place-->
 	<xsl:template name="modsOriginPlaces">
 		<xsl:variable name="place" select="*[local-name() = 'originInfo']/*[local-name() = 'place']"/>
 		<xsl:if test="boolean($place)">
@@ -231,7 +231,7 @@
 			</tr>
 		</xsl:if>
 	</xsl:template>
-<!-- ??? -->	
+	<!-- Template for a simple name / value pair display -->
 	<xsl:template name="modsField">
 		<xsl:param name="label"/>
 		<xsl:param name="field"/>
@@ -365,13 +365,14 @@
 						<br/><xsl:value-of select="$newline"/>
 					</xsl:for-each>
 	
-						<br/><xsl:value-of select="$newline"/>
+					<br/><xsl:value-of select="$newline"/>
 				</td>
 			</tr>
 		
 		</xsl:for-each-group>
 	</xsl:template>
-<!-- mods:language -->
+
+	<!-- mods:language -->
 	<xsl:template name="modsLanguages">
 		<xsl:for-each-group select="*[local-name() = 'language']" group-by="@displayLabel, .[not(@displayLabel)]/@usage, local-name(.[not(@displayLabel) and not(@usage)])[. != '']">
 			<xsl:variable name="groupKey" select="current-grouping-key()"/>
@@ -429,70 +430,71 @@
 	<!-- mods:subject -->
 	<xsl:template name="cartographics">
 		<xsl:value-of select="*[local-name() = 'scale']"/>
-			<xsl:if test="*[local-name() = 'projection']">
-				<xsl:if test="*[local-name() = 'scale']">
-					<xsl:text> ; </xsl:text> 
-				</xsl:if>
-				<xsl:value-of select="*[local-name() = 'projection']"/>
+		<xsl:if test="*[local-name() = 'projection']">
+			<xsl:if test="*[local-name() = 'scale']">
+				<xsl:text> ; </xsl:text> 
 			</xsl:if>
+			<xsl:value-of select="*[local-name() = 'projection']"/>
+		</xsl:if>
 		<xsl:if test="*[local-name() = 'coordinates']">
 			<xsl:text> </xsl:text>
 			(<xsl:value-of select="*[local-name() = 'coordinates']"/>).
 		</xsl:if>
 	</xsl:template>
 	<xsl:template name="modsSubjects">
-			<xsl:for-each-group select="*[local-name() = 'subject']" group-by="@displayLabel, local-name(.[not(@displayLabel)])[. != '']">
-				<xsl:variable name="groupKey" select="current-grouping-key()"/>
-				<tr>
-					<th>
-						<xsl:choose>
-							<xsl:when test="$groupKey = local-name()">
-								<xsl:text>Subject</xsl:text>
-							</xsl:when>
-							<xsl:otherwise>
-								<xsl:value-of select="concat(upper-case(substring($groupKey,1,1)), substring($groupKey,2))"/>
-							</xsl:otherwise>
-						</xsl:choose>
-					</th><xsl:value-of select="$newline"/>
-					<td>
-						<xsl:for-each select="current-group()">
-							<xsl:for-each select="./*">
-								<br/><xsl:value-of select="$newline"/>
-								<!-- Render the second tier of children based on the element name of the first tier -->
-								<xsl:choose>
-									<xsl:when test="local-name() = 'name' or local-name() = 'titleInfo'">
-										<xsl:apply-templates select="." mode="brief"/>
-									</xsl:when>
-									<xsl:when test="local-name() = 'hierarchicalGeographic'">
-										<xsl:for-each select="./*">
-											<xsl:if test="position() != 1">
-												<xsl:text>, </xsl:text>
-											</xsl:if>
-											<xsl:value-of select="text()"/>
-										</xsl:for-each>			
-									</xsl:when>
-									<xsl:when test="local-name() = 'cartographics'">
-										<xsl:call-template name="cartographics"/>
-									</xsl:when>
-									<xsl:otherwise>
-										<xsl:value-of select="text()"/>
-									</xsl:otherwise>
-								</xsl:choose>
-							</xsl:for-each>
+		<xsl:for-each-group select="*[local-name() = 'subject']" group-by="@displayLabel, local-name(.[not(@displayLabel)])[. != '']">
+			<xsl:variable name="groupKey" select="current-grouping-key()"/>
+			<tr>
+				<th>
+					<xsl:choose>
+						<xsl:when test="$groupKey = local-name()">
+							<xsl:text>Subject</xsl:text>
+						</xsl:when>
+						<xsl:otherwise>
+							<xsl:value-of select="concat(upper-case(substring($groupKey,1,1)), substring($groupKey,2))"/>
+						</xsl:otherwise>
+					</xsl:choose>
+				</th><xsl:value-of select="$newline"/>
+				<td>
+					<xsl:for-each select="current-group()">
+						<xsl:for-each select="./*">
 							<br/><xsl:value-of select="$newline"/>
+							<!-- Render the second tier of children based on the element name of the first tier -->
+							<xsl:choose>
+								<xsl:when test="local-name() = 'name' or local-name() = 'titleInfo'">
+									<xsl:apply-templates select="." mode="brief"/>
+								</xsl:when>
+								<xsl:when test="local-name() = 'hierarchicalGeographic'">
+									<xsl:for-each select="./*">
+										<xsl:if test="position() != 1">
+											<xsl:text>, </xsl:text>
+										</xsl:if>
+										<xsl:value-of select="text()"/>
+									</xsl:for-each>			
+								</xsl:when>
+								<xsl:when test="local-name() = 'cartographics'">
+									<xsl:call-template name="cartographics"/>
+								</xsl:when>
+								<xsl:otherwise>
+									<xsl:value-of select="text()"/>
+								</xsl:otherwise>
+							</xsl:choose>
 						</xsl:for-each>
-					</td>
-				</tr>
-			</xsl:for-each-group>
-		</xsl:template>
-<!-- mods:abstract -->
+						<br/><xsl:value-of select="$newline"/>
+					</xsl:for-each>
+				</td>
+			</tr>
+		</xsl:for-each-group>
+	</xsl:template>
+
+	<!-- mods:abstract -->
 	<xsl:template name="modsAbstract">
 		<xsl:for-each select="*[local-name() = 'abstract']">
 			<tr>
 				<th>
-						<xsl:if test="@type='Content advice'">
-							<xsl:value-of select="@type"/>
-						</xsl:if>
+					<xsl:if test="@type='Content advice'">
+						<xsl:value-of select="@type"/>
+					</xsl:if>
 				</th><xsl:value-of select="$newline"/>
 				<td>
 					<xsl:if test="@type='Content advice'">
@@ -529,7 +531,8 @@
 			</tr>
 		</xsl:for-each-group>
 	</xsl:template>
-<!-- mods:location -->
+
+	<!-- mods:location -->
 	<xsl:template name="modsLocations">
 		<xsl:for-each-group select="*[local-name() = 'location']" group-by="@displayLabel, local-name(.[not(@displayLabel)])[. != '']">
 			<xsl:variable name="groupKey" select="current-grouping-key()"/>
@@ -572,7 +575,8 @@
 			</tr>
 		</xsl:for-each-group>
 	</xsl:template>
-<!-- mods:physicalDescription -->
+
+	<!-- mods:physicalDescription -->
 	<xsl:template name="modsPhysicalDescription">
 		<xsl:for-each-group select="*[local-name() = 'physicalDescription']/*" group-by="@displayLabel, .[not(@displayLabel)]/@type, local-name(.[not(@displayLabel) and not(@type)])[. != '']">
 			<xsl:variable name="groupKey" select="current-grouping-key()"/>
@@ -617,12 +621,14 @@
 			</tr>
 		</xsl:for-each-group>
 	</xsl:template>
-<!-- mods:part -->
+
+	<!-- mods:part -->
 	<xsl:template name="modsParts">		
 		<xsl:for-each-group select="*[local-name() = 'part']" group-by="@displayLabel, local-name(.[not(@displayLabel)])[. != '']">
 			<xsl:variable name="groupKey" select="current-grouping-key()"/>
 			<tr>
 				<xsl:variable name="partText" select="*[local-name() = 'text']"/>
+				<!-- if part/text is available, show only this subelement.  When @displayLabel is present it overrides "Part" label. -->
 				<th>
 					<xsl:choose>
 						<xsl:when test="boolean($partText)">
@@ -638,7 +644,7 @@
 						</xsl:when>
 						<xsl:otherwise>
 							<xsl:choose>
-								<xsl:when test="$groupKey = name()">
+								<xsl:when test="$groupKey = local-name()">
 									<xsl:text>Part</xsl:text>
 								</xsl:when>
 								<xsl:otherwise>
@@ -648,7 +654,7 @@
 						</xsl:otherwise>
 					</xsl:choose>
 				</th><xsl:value-of select="$newline"/>
-				<!-- Above: if part/text is available, show only this subelement.  When @displayLabel is present it overrides "Part" label.  Below: If part/text is not available, show the rest of the subelements  -->
+				<!-- If part/text is not available, show the rest of the subelements  -->
 				<td>
 					<xsl:choose>
 						<xsl:when test="boolean($partText)">
@@ -679,12 +685,6 @@
 													<xsl:when test="local-name() = 'start' or local-name() = 'end'">
 														<xsl:value-of select="concat(upper-case(substring(local-name(),1,1)), substring(local-name(),2))"/>
 														<xsl:text>: </xsl:text><xsl:value-of select="text()"/>
-														<!-- Commented out by SN, 11/20/2014>
-															<xsl:if test="boolean(../@unit)">
-															<xsl:text> </xsl:text>
-															<xsl:value-of select="../@unit"/>
-															</xsl:if>
-														-->
 													</xsl:when>
 													<xsl:when test="local-name() = 'total'">
 														<xsl:choose>
@@ -693,7 +693,7 @@
 																<xsl:text>: </xsl:text>
 															</xsl:when>
 															<xsl:otherwise>
-																<xsl:value-of select="concat(upper-case(substring(local-name(),1,1)), substring(local-name(),2))"/><!-- Sonoe note, 11/20/2014: I guess I could have also done <xsl:value-of>Total</xsl:value-of> or <xsl:text> -->
+																<xsl:value-of select="concat(upper-case(substring(local-name(),1,1)), substring(local-name(),2))"/>
 																<xsl:text>: </xsl:text>
 															</xsl:otherwise>
 														</xsl:choose>
@@ -704,15 +704,6 @@
 														<xsl:text>List: </xsl:text>
 														<xsl:value-of select="text()"/>
 													</xsl:when>
-													<!--  Original code for displaying list:
-														<xsl:otherwise>
-														<xsl:if test="boolean(../@unit)">
-														<xsl:value-of select="../@unit"/>
-														<xsl:text>: </xsl:text>
-														</xsl:if>
-														<xsl:value-of select="text()"/>
-														</xsl:otherwise>
-													-->
 												</xsl:choose>
 												<br/><xsl:value-of select="$newline"/>
 											</xsl:for-each>
@@ -752,14 +743,6 @@
 												</xsl:otherwise>
 											</xsl:choose>
 										</xsl:when>
-										<!-- Original code for displaying date:
-											<xsl:otherwise>
-											<xsl:value-of select="(@displayLabel,@type,local-name())[1]"/>
-											<xsl:text>: </xsl:text>
-											<xsl:value-of select="text()"/>
-											<br/><xsl:value-of select="$newline"/>
-											</xsl:otherwise>
-										-->
 									</xsl:choose>
 								</xsl:for-each>
 							</xsl:for-each>
@@ -769,7 +752,8 @@
 			</tr>
 		</xsl:for-each-group>
 	</xsl:template>
-<!-- mdos:relatedItem -->	
+	
+	<!-- mods:relatedItem -->	
 	<!-- Related items can contain any kind of item, so just reusing the other templates and nesting in an extra table-->
 	<xsl:template name="modsRelatedItems">
 		<xsl:for-each-group select="*[local-name() = 'relatedItem']" group-by="@displayLabel, .[not(@displayLabel)]/@type, local-name(.[not(@displayLabel) and not(@type)])[. != '']">
@@ -970,12 +954,12 @@
 		
 		<xsl:variable name="tableOfContents" select="*[local-name() = 'tableOfContents']"/>
 		<xsl:if test="boolean($tableOfContents) and not ($tableOfContents[@shareable])">
-				<table>
-					<xsl:call-template name="modsGroupedFieldWithType">
-						<xsl:with-param name="defaultLabel">Table of Contents</xsl:with-param>
-						<xsl:with-param name="field" select="$tableOfContents"/>
-					</xsl:call-template>
-				</table>
+			<table>
+				<xsl:call-template name="modsGroupedFieldWithType">
+					<xsl:with-param name="defaultLabel">Table of Contents</xsl:with-param>
+					<xsl:with-param name="field" select="$tableOfContents"/>
+				</xsl:call-template>
+			</table>
 		</xsl:if>
 		
 		<xsl:variable name="relatedItem" select="*[local-name() = 'relatedItem']"/>

--- a/access/src/main/external/static/recordTransformations/modsToFullRecord.xsl
+++ b/access/src/main/external/static/recordTransformations/modsToFullRecord.xsl
@@ -11,7 +11,7 @@
 	 -->
 	<xsl:variable name="newline"><xsl:text>
 </xsl:text></xsl:variable>
-<!-- mods:name -->
+	<!-- mods:name -->
 	<xsl:template match="*[local-name() = 'name']" mode="brief">
 		<xsl:variable name="displayForm" select="./*[local-name() = 'displayForm']"/>
 		<xsl:variable name="givenName" select="./*[local-name() = 'namePart' and @type='given']"/>
@@ -129,7 +129,7 @@
 			</tr><xsl:value-of select="$newline"/>
 		</xsl:for-each-group>
 	</xsl:template>
-<!-- mods:titleInfo -->
+	<!-- mods:titleInfo -->
 	<xsl:template match="*[local-name() = 'titleInfo']" mode="brief">
 		<xsl:variable name="nonSort" select="*[local-name() = 'nonSort']"/>
 		<xsl:if test="boolean($nonSort)">
@@ -490,11 +490,10 @@
 	<!-- mods:abstract -->
 	<xsl:template name="modsAbstract">
 		<xsl:for-each select="*[local-name() = 'abstract']">
+			<xsl:if test="@type='Content advice'">
 			<tr>
 				<th>
-					<xsl:if test="@type='Content advice'">
 						<xsl:value-of select="@type"/>
-					</xsl:if>
 				</th><xsl:value-of select="$newline"/>
 				<td>
 					<xsl:if test="@type='Content advice'">
@@ -502,6 +501,7 @@
 					</xsl:if>
 				</td><xsl:value-of select="$newline"/>
 			</tr>
+			</xsl:if>
 		</xsl:for-each>
 	</xsl:template>
 	<!-- mods:classification -->
@@ -550,7 +550,9 @@
 				<td>
 					<xsl:for-each select="current-group()">
 						<xsl:for-each select="./*[local-name() = 'url']|*[local-name() = 'uri']|./*[local-name() = 'physicalLocation']">
-							<xsl:value-of select="concat(upper-case(substring(@displayLabel,1,1)), substring(@displayLabel,2))"/><xsl:text>: </xsl:text>
+							<xsl:if test="@displayLabel">
+								<xsl:value-of select="concat(upper-case(substring(@displayLabel,1,1)), substring(@displayLabel,2))"/><xsl:text>: </xsl:text>
+							</xsl:if>
 							<xsl:value-of select="text()"/>
 							<xsl:if test="local-name() = 'url'">
 								<xsl:for-each select="@access|@note">
@@ -627,127 +629,127 @@
 		<xsl:for-each-group select="*[local-name() = 'part']" group-by="@displayLabel, local-name(.[not(@displayLabel)])[. != '']">
 			<xsl:variable name="groupKey" select="current-grouping-key()"/>
 			<tr>
-				<xsl:variable name="partText" select="*[local-name() = 'text']"/>
 				<!-- if part/text is available, show only this subelement.  When @displayLabel is present it overrides "Part" label. -->
 				<th>
 					<xsl:choose>
-						<xsl:when test="boolean($partText)">
-							
-							<xsl:choose>
-								<xsl:when test="$partText/@displayLabel">
-									<xsl:value-of select="concat(upper-case(substring($partText/@displayLabel,1,1)), substring($partText/@displayLabel,2))"/>
-								</xsl:when>
-								<xsl:otherwise>
-									<xsl:value-of>Part</xsl:value-of>
-								</xsl:otherwise>
-							</xsl:choose>						
+						<xsl:when test="$groupKey = local-name()">
+							<xsl:text>Part</xsl:text>
 						</xsl:when>
 						<xsl:otherwise>
-							<xsl:choose>
-								<xsl:when test="$groupKey = local-name()">
-									<xsl:text>Part</xsl:text>
-								</xsl:when>
-								<xsl:otherwise>
-									<xsl:value-of select="concat(upper-case(substring($groupKey,1,1)), substring($groupKey,2))"/>
-								</xsl:otherwise>
-							</xsl:choose>
+							<xsl:value-of select="concat(upper-case(substring($groupKey,1,1)), substring($groupKey,2))"/>
 						</xsl:otherwise>
 					</xsl:choose>
 				</th><xsl:value-of select="$newline"/>
 				<!-- If part/text is not available, show the rest of the subelements  -->
 				<td>
-					<xsl:choose>
-						<xsl:when test="boolean($partText)">
-							<xsl:value-of select="$partText/text()"/>
-						</xsl:when>
-						<xsl:otherwise>
-							<xsl:for-each select="current-group()">
-								<xsl:sort select="@order"/>
-								<xsl:for-each select="./*">
-									<xsl:choose>
-										<xsl:when test="local-name() = 'detail'">
-											<xsl:for-each select="./*">
+					<xsl:for-each select="current-group()">
+						<xsl:sort select="@order"/>
+						<xsl:for-each select="./*">
+								<xsl:choose>
+									<xsl:when test="local-name() = 'detail'">
+										<xsl:for-each select="./*">
+											<xsl:choose>
+												<xsl:when test="local-name() = 'number' and boolean(../@type)">
+													<xsl:value-of select="concat(upper-case(substring(../@type,1,1)), substring(../@type,2))"/><xsl:text>: </xsl:text><xsl:value-of select="text()"/>
+												</xsl:when>
+												<xsl:otherwise>
+													<xsl:value-of select="concat(upper-case(substring(local-name(),1,1)), substring(local-name(),2))"/>
+													<xsl:text>: </xsl:text><xsl:value-of select="text()"/>
+												</xsl:otherwise>
+											</xsl:choose>
+											<br/><xsl:value-of select="$newline"/>
+										</xsl:for-each>
+									</xsl:when>
+									
+									<xsl:when test="local-name() = 'extent'">
+										<xsl:for-each select="./*">
+											<xsl:choose>
+												<xsl:when test="local-name() = 'start' or local-name() = 'end'">
+													<xsl:value-of select="concat(upper-case(substring(local-name(),1,1)), substring(local-name(),2))"/>
+													<xsl:text>: </xsl:text><xsl:value-of select="text()"/>
+												</xsl:when>
+												
+												<xsl:when test="local-name() = 'total'">
+													<xsl:choose>
+														<xsl:when test="../@unit">
+															<xsl:value-of select="concat(upper-case(substring(local-name(),1,1)), substring(local-name(),2)), ../@unit"/>
+															<xsl:text>: </xsl:text>
+														</xsl:when>
+														<xsl:otherwise>
+															<xsl:value-of select="concat(upper-case(substring(local-name(),1,1)), substring(local-name(),2))"/>
+															<xsl:text>: </xsl:text>
+														</xsl:otherwise>
+													</xsl:choose>
+													<xsl:value-of select="text()"/>
+												</xsl:when>
+												<xsl:when test="local-name() = 'list'">
+													<xsl:text>List: </xsl:text>
+													<xsl:value-of select="text()"/>
+												</xsl:when>
+											</xsl:choose>
+											<br/><xsl:value-of select="$newline"/>
+										</xsl:for-each>
+									</xsl:when>
+										
+									<xsl:when test="local-name()='date'">
+										<xsl:choose>
+											<xsl:when test="@point='start'">
+												<xsl:text>Start date: </xsl:text>
+												<xsl:value-of select="text()"/>
+												<xsl:if test="boolean(@qualifier)">
+													<xsl:text> (</xsl:text>
+													<xsl:value-of select="@qualifier"/>
+													<xsl:text>)</xsl:text>
+												</xsl:if>
+												<br/><xsl:value-of select="$newline"/>
+											</xsl:when>
+											<xsl:when test="@point='end'">
+												<xsl:text>End date: </xsl:text>
+												<xsl:value-of select="text()"/>
+												<xsl:if test="boolean(@qualifier)">
+													<xsl:text> (</xsl:text>
+													<xsl:value-of select="@qualifier"/>
+													<xsl:text>)</xsl:text>
+												</xsl:if>
+												<br/><xsl:value-of select="$newline"/>
+											</xsl:when>
+											<xsl:otherwise>
+												<xsl:text>Date: </xsl:text>
+												<xsl:value-of select="text()"/>
+												<xsl:if test="boolean(@qualifier)">
+													<xsl:text> (</xsl:text>
+													<xsl:value-of select="@qualifier"/>
+													<xsl:text>)</xsl:text>
+												</xsl:if>
+												<br/><xsl:value-of select="$newline"/>
+											</xsl:otherwise>
+										</xsl:choose>
+									</xsl:when>
+									
+									<xsl:when test="local-name()= 'text'">
+										<xsl:for-each select="./*"/>
+										<xsl:choose>
+											<xsl:when test="boolean(@type)">
 												<xsl:choose>
-													<xsl:when test="local-name() = 'number' and boolean(../@type)">
-														<xsl:value-of select="concat(upper-case(substring(../@type,1,1)), substring(../@type,2))"/><xsl:text>: </xsl:text><xsl:value-of select="text()"/>
+													<xsl:when test="boolean(@displayLabel)">
+														<xsl:value-of select="concat(upper-case(substring(@displayLabel,1,1)), substring(@displayLabel,2))"/>
+													<xsl:text>: </xsl:text><xsl:value-of select="text()"/>
 													</xsl:when>
 													<xsl:otherwise>
-														<xsl:value-of select="concat(upper-case(substring(local-name(),1,1)), substring(local-name(),2))"/>
+														<xsl:value-of select="concat(upper-case(substring(@type,1,1)), substring(@type,2))"/>
 														<xsl:text>: </xsl:text><xsl:value-of select="text()"/>
 													</xsl:otherwise>
 												</xsl:choose>
-												<br/><xsl:value-of select="$newline"/>
-											</xsl:for-each>
-										</xsl:when>
-										<xsl:when test="local-name() = 'extent'">
-											<xsl:for-each select="./*">
-												<xsl:choose>
-													<xsl:when test="local-name() = 'start' or local-name() = 'end'">
-														<xsl:value-of select="concat(upper-case(substring(local-name(),1,1)), substring(local-name(),2))"/>
-														<xsl:text>: </xsl:text><xsl:value-of select="text()"/>
-													</xsl:when>
-													<xsl:when test="local-name() = 'total'">
-														<xsl:choose>
-															<xsl:when test="../@unit">
-																<xsl:value-of select="concat(upper-case(substring(local-name(),1,1)), substring(local-name(),2)), ../@unit"/>
-																<xsl:text>: </xsl:text>
-															</xsl:when>
-															<xsl:otherwise>
-																<xsl:value-of select="concat(upper-case(substring(local-name(),1,1)), substring(local-name(),2))"/>
-																<xsl:text>: </xsl:text>
-															</xsl:otherwise>
-														</xsl:choose>
-														<xsl:value-of select="text()"/>
-													</xsl:when>
-													
-													<xsl:when test="local-name() = 'list'">
-														<xsl:text>List: </xsl:text>
-														<xsl:value-of select="text()"/>
-													</xsl:when>
-												</xsl:choose>
-												<br/><xsl:value-of select="$newline"/>
-											</xsl:for-each>
-										</xsl:when>
-										
-										<xsl:when test="local-name()='date'">
-											<xsl:choose>
-												<xsl:when test="@point='start'">
-													<xsl:text>Start date: </xsl:text>
-													<xsl:value-of select="text()"/>
-													<xsl:if test="boolean(@qualifier)">
-														<xsl:text> (</xsl:text>
-														<xsl:value-of select="@qualifier"/>
-														<xsl:text>)</xsl:text>
-													</xsl:if>
-													<br/><xsl:value-of select="$newline"/>
-												</xsl:when>
-												<xsl:when test="@point='end'">
-													<xsl:text>End date: </xsl:text>
-													<xsl:value-of select="text()"/>
-													<xsl:if test="boolean(@qualifier)">
-														<xsl:text> (</xsl:text>
-														<xsl:value-of select="@qualifier"/>
-														<xsl:text>)</xsl:text>
-													</xsl:if>
-													<br/><xsl:value-of select="$newline"/>
-												</xsl:when>
-												<xsl:otherwise>
-													<xsl:text>Date: </xsl:text>
-													<xsl:value-of select="text()"/>
-													<xsl:if test="boolean(@qualifier)">
-														<xsl:text> (</xsl:text>
-														<xsl:value-of select="@qualifier"/>
-														<xsl:text>)</xsl:text>
-													</xsl:if>
-													<br/><xsl:value-of select="$newline"/>
-												</xsl:otherwise>
-											</xsl:choose>
-										</xsl:when>
-									</xsl:choose>
-								</xsl:for-each>
+											</xsl:when>
+											<xsl:otherwise>
+												<xsl:value-of select="text()"/>
+											</xsl:otherwise>
+										</xsl:choose>
+										<br/><xsl:value-of select="$newline"/>
+									</xsl:when>
+								</xsl:choose>
 							</xsl:for-each>
-						</xsl:otherwise>						
-					</xsl:choose>
+						</xsl:for-each>						
 				</td>
 			</tr>
 		</xsl:for-each-group>

--- a/access/src/main/external/static/recordTransformations/scriptNames.xsl
+++ b/access/src/main/external/static/recordTransformations/scriptNames.xsl
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+	<xsl:output method="xml" omit-xml-declaration="yes" indent="no"/>
+
+	<xsl:template name="getScriptName">
+		<xsl:param name="scriptNodes"/>
+		<xsl:for-each-group select="$scriptNodes" group-by="@type='code', .[not(@type='code')]/@type='text', local-name(.[not(@type='code') and not(@type='text')])[. != '']">
+			<xsl:variable name="groupKey" select="current-grouping-key()"/>
+	
+		<xsl:choose>
+			<xsl:when test="boolean($scriptNodes[@type='text'])">
+				<xsl:for-each select="$scriptNodes[@type='text']">
+					<xsl:if test="position() != 1">
+							<xsl:text>; </xsl:text>
+					</xsl:if>
+					<xsl:value-of select="text()"/>
+				</xsl:for-each>
+			</xsl:when>
+			<xsl:when test="boolean($scriptNodes[@type = 'code' and @authority='iso15924'])">		
+
+					<xsl:call-template name="getISO15924Name">
+						<xsl:with-param name="scriptCode" select="$scriptNodes[@type = 'code' and @authority='iso15924']/text()"/>
+					</xsl:call-template>
+				
+			</xsl:when>
+			<xsl:otherwise>
+				<xsl:call-template name="getISO15924Name">
+					<xsl:with-param name="scriptCode" select="$scriptNodes/text()"/>
+				</xsl:call-template>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:for-each-group>
+	</xsl:template>
+
+	<xsl:template name="getISO15924Name">
+		<xsl:param name="scriptCode"/>
+		<xsl:choose>
+		    <xsl:when test="$scriptCode = 'Adlm'">Adlam</xsl:when>
+		    <xsl:when test="$scriptCode = 'Afak'">Afaka</xsl:when>
+		    <xsl:when test="$scriptCode = 'Aghb'">Caucasian Albanian</xsl:when>
+		    <xsl:when test="$scriptCode = 'Ahom'">Ahom, Tai Ahom</xsl:when>
+		    <xsl:when test="$scriptCode = 'Arab'">Arabic</xsl:when>
+		    <xsl:when test="$scriptCode = 'Aran'">Arabic (Nastaliq variant)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Armi'">Imperial Aramaic</xsl:when>
+		    <xsl:when test="$scriptCode = 'Armn'">Armenian</xsl:when>
+		    <xsl:when test="$scriptCode = 'Avst'">Avestan</xsl:when>
+		    <xsl:when test="$scriptCode = 'Bali'">Balinese</xsl:when>
+		    <xsl:when test="$scriptCode = 'Bamu'">Bamum</xsl:when>
+		    <xsl:when test="$scriptCode = 'Bass'">Bassa Vah</xsl:when>
+		    <xsl:when test="$scriptCode = 'Batk'">Batak</xsl:when>
+		    <xsl:when test="$scriptCode = 'Beng'">Bengali</xsl:when>
+		    <xsl:when test="$scriptCode = 'Blis'">Blissymbols</xsl:when>
+		    <xsl:when test="$scriptCode = 'Bopo'">Bopomofo</xsl:when>
+		    <xsl:when test="$scriptCode = 'Brah'">Brahmi</xsl:when>
+		    <xsl:when test="$scriptCode = 'Brai'">Braille</xsl:when>
+		    <xsl:when test="$scriptCode = 'Bugi'">Buginese</xsl:when>
+		    <xsl:when test="$scriptCode = 'Buhd'">Buhid</xsl:when>
+		    <xsl:when test="$scriptCode = 'Cakm'">Chakma</xsl:when>
+		    <xsl:when test="$scriptCode = 'Cans'">Unified Canadian Aboriginal Syllabics</xsl:when>
+		    <xsl:when test="$scriptCode = 'Cari'">Carian</xsl:when>
+		    <xsl:when test="$scriptCode = 'Cham'">Cham</xsl:when>
+		    <xsl:when test="$scriptCode = 'Cher'">Cherokee</xsl:when>
+		    <xsl:when test="$scriptCode = 'Cirt'">Cirth</xsl:when>
+		    <xsl:when test="$scriptCode = 'Copt'">Coptic</xsl:when>
+		    <xsl:when test="$scriptCode = 'Cprt'">Cypriot</xsl:when>
+		    <xsl:when test="$scriptCode = 'Cyrl'">Cyrillic</xsl:when>
+		    <xsl:when test="$scriptCode = 'Cyrs'">Cyrillic (Old Church Slavonic variant)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Deva'">Devanagari (Nagari)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Dsrt'">Deseret (Mormon)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Dupl'">Duployan shorthand, Duployan stenography</xsl:when>
+		    <xsl:when test="$scriptCode = 'Egyd'">Egyptian demotic</xsl:when>
+		    <xsl:when test="$scriptCode = 'Egyh'">Egyptian hieratic</xsl:when>
+		    <xsl:when test="$scriptCode = 'Egyp'">Egyptian hieroglyphs</xsl:when>
+		    <xsl:when test="$scriptCode = 'Elba'">Elbasan</xsl:when>
+		    <xsl:when test="$scriptCode = 'Ethi'">Ethiopic (Ge?ez)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Geok'">Khutsuri (Asomtavruli and Nuskhuri)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Geor'">Georgian (Mkhedruli)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Glag'">Glagolitic</xsl:when>
+		    <xsl:when test="$scriptCode = 'Goth'">Gothic</xsl:when>
+		    <xsl:when test="$scriptCode = 'Gran'">Grantha</xsl:when>
+		    <xsl:when test="$scriptCode = 'Grek'">Greek</xsl:when>
+		    <xsl:when test="$scriptCode = 'Gujr'">Gujarati</xsl:when>
+		    <xsl:when test="$scriptCode = 'Guru'">Gurmukhi</xsl:when>
+		    <xsl:when test="$scriptCode = 'Hang'">Hangul (Hang?l, Hangeul)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Hani'">Han (Hanzi, Kanji, Hanja)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Hano'">Hanunoo (Hanunóo)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Hans'">Han (Simplified variant)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Hant'">Han (Traditional variant)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Hatr'">Hatran</xsl:when>
+		    <xsl:when test="$scriptCode = 'Hebr'">Hebrew</xsl:when>
+		    <xsl:when test="$scriptCode = 'Hira'">Hiragana</xsl:when>
+		    <xsl:when test="$scriptCode = 'Hluw'">Anatolian Hieroglyphs (Luwian Hieroglyphs, Hittite Hieroglyphs)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Hmng'">Pahawh Hmong</xsl:when>
+		    <xsl:when test="$scriptCode = 'Hrkt'">Japanese syllabaries (alias for Hiragana + Katakana)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Hung'">Old Hungarian (Hungarian Runic)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Inds'">Indus (Harappan)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Ital'">Old Italic (Etruscan, Oscan, etc.)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Java'">Javanese</xsl:when>
+		    <xsl:when test="$scriptCode = 'Jpan'">Japanese (alias for Han + Hiragana + Katakana)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Jurc'">Jurchen</xsl:when>
+		    <xsl:when test="$scriptCode = 'Kali'">Kayah Li</xsl:when>
+		    <xsl:when test="$scriptCode = 'Kana'">Katakana</xsl:when>
+		    <xsl:when test="$scriptCode = 'Khar'">Kharoshthi</xsl:when>
+		    <xsl:when test="$scriptCode = 'Khmr'">Khmer</xsl:when>
+		    <xsl:when test="$scriptCode = 'Khoj'">Khojki</xsl:when>
+		    <xsl:when test="$scriptCode = 'Kitl'">Khitan large script</xsl:when>
+		    <xsl:when test="$scriptCode = 'Kits'">Khitan small script</xsl:when>
+		    <xsl:when test="$scriptCode = 'Knda'">Kannada</xsl:when>
+		    <xsl:when test="$scriptCode = 'Kore'">Korean (alias for Hangul + Han)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Kpel'">Kpelle</xsl:when>
+		    <xsl:when test="$scriptCode = 'Kthi'">Kaithi</xsl:when>
+		    <xsl:when test="$scriptCode = 'Lana'">Tai Tham (Lanna)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Laoo'">Lao</xsl:when>
+		    <xsl:when test="$scriptCode = 'Latf'">Latin (Fraktur variant)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Latg'">Latin (Gaelic variant)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Latn'">Latin</xsl:when>
+		    <xsl:when test="$scriptCode = 'Lepc'">Lepcha (Róng)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Limb'">Limbu</xsl:when>
+		    <xsl:when test="$scriptCode = 'Lina'">Linear A</xsl:when>
+		    <xsl:when test="$scriptCode = 'Linb'">Linear B</xsl:when>
+		    <xsl:when test="$scriptCode = 'Lisu'">Lisu (Fraser)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Loma'">Loma</xsl:when>
+		    <xsl:when test="$scriptCode = 'Lyci'">Lycian</xsl:when>
+		    <xsl:when test="$scriptCode = 'Lydi'">Lydian</xsl:when>
+		    <xsl:when test="$scriptCode = 'Mahj'">Mahajani</xsl:when>
+		    <xsl:when test="$scriptCode = 'Mand'">Mandaic, Mandaean</xsl:when>
+		    <xsl:when test="$scriptCode = 'Mani'">Manichaean</xsl:when>
+		    <xsl:when test="$scriptCode = 'Marc'">Marchen</xsl:when>
+		    <xsl:when test="$scriptCode = 'Maya'">Mayan hieroglyphs</xsl:when>
+		    <xsl:when test="$scriptCode = 'Mend'">Mende Kikakui</xsl:when>
+		    <xsl:when test="$scriptCode = 'Merc'">Meroitic Cursive</xsl:when>
+		    <xsl:when test="$scriptCode = 'Mero'">Meroitic Hieroglyphs</xsl:when>
+		    <xsl:when test="$scriptCode = 'Mlym'">Malayalam</xsl:when>
+		    <xsl:when test="$scriptCode = 'Modi'">Modi, Mo??</xsl:when>
+		    <xsl:when test="$scriptCode = 'Mong'">Mongolian</xsl:when>
+		    <xsl:when test="$scriptCode = 'Moon'">Moon (Moon code, Moon script, Moon type)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Mroo'">Mro, Mru</xsl:when>
+		    <xsl:when test="$scriptCode = 'Mtei'">Meitei Mayek (Meithei, Meetei)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Mult'">Multani</xsl:when>
+		    <xsl:when test="$scriptCode = 'Mymr'">Myanmar (Burmese)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Narb'">Old North Arabian (Ancient North Arabian)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Nbat'">Nabataean</xsl:when>
+		    <xsl:when test="$scriptCode = 'Nkgb'">Nakhi Geba ('Na-'Khi ²Gg?-¹baw, Naxi Geba)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Nkoo'">N’Ko</xsl:when>
+		    <xsl:when test="$scriptCode = 'Nshu'">Nüshu</xsl:when>
+		    <xsl:when test="$scriptCode = 'Ogam'">Ogham</xsl:when>
+		    <xsl:when test="$scriptCode = 'Olck'">Ol Chiki (Ol Cemet’, Ol, Santali)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Orkh'">Old Turkic, Orkhon Runic</xsl:when>
+		    <xsl:when test="$scriptCode = 'Orya'">Oriya</xsl:when>
+		    <xsl:when test="$scriptCode = 'Osge'">Osage</xsl:when>
+		    <xsl:when test="$scriptCode = 'Osma'">Osmanya</xsl:when>
+		    <xsl:when test="$scriptCode = 'Palm'">Palmyrene</xsl:when>
+		    <xsl:when test="$scriptCode = 'Pauc'">Pau Cin Hau</xsl:when>
+		    <xsl:when test="$scriptCode = 'Perm'">Old Permic</xsl:when>
+		    <xsl:when test="$scriptCode = 'Phag'">Phags-pa</xsl:when>
+		    <xsl:when test="$scriptCode = 'Phli'">Inscriptional Pahlavi</xsl:when>
+		    <xsl:when test="$scriptCode = 'Phlp'">Psalter Pahlavi</xsl:when>
+		    <xsl:when test="$scriptCode = 'Phlv'">Book Pahlavi</xsl:when>
+		    <xsl:when test="$scriptCode = 'Phnx'">Phoenician</xsl:when>
+		    <xsl:when test="$scriptCode = 'Plrd'">Miao (Pollard)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Prti'">Inscriptional Parthian</xsl:when>
+		    <xsl:when test="$scriptCode = 'Qaaa'">Reserved for private use (start)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Qabx'">Reserved for private use (end)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Rjng'">Rejang (Redjang, Kaganga)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Roro'">Rongorongo</xsl:when>
+		    <xsl:when test="$scriptCode = 'Runr'">Runic</xsl:when>
+		    <xsl:when test="$scriptCode = 'Samr'">Samaritan</xsl:when>
+		    <xsl:when test="$scriptCode = 'Sara'">Sarati</xsl:when>
+		    <xsl:when test="$scriptCode = 'Sarb'">Old South Arabian</xsl:when>
+		    <xsl:when test="$scriptCode = 'Saur'">Saurashtra</xsl:when>
+		    <xsl:when test="$scriptCode = 'Sgnw'">SignWriting</xsl:when>
+		    <xsl:when test="$scriptCode = 'Shaw'">Shavian (Shaw)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Shrd'">Sharada, ??rad?</xsl:when>
+		    <xsl:when test="$scriptCode = 'Sidd'">Siddham, Siddha?, Siddham?t?k?</xsl:when>
+		    <xsl:when test="$scriptCode = 'Sind'">Khudawadi, Sindhi</xsl:when>
+		    <xsl:when test="$scriptCode = 'Sinh'">Sinhala</xsl:when>
+		    <xsl:when test="$scriptCode = 'Sora'">Sora Sompeng</xsl:when>
+		    <xsl:when test="$scriptCode = 'Sund'">Sundanese</xsl:when>
+		    <xsl:when test="$scriptCode = 'Sylo'">Syloti Nagri</xsl:when>
+		    <xsl:when test="$scriptCode = 'Syrc'">Syriac</xsl:when>
+		    <xsl:when test="$scriptCode = 'Syre'">Syriac (Estrangelo variant)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Syrj'">Syriac (Western variant)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Syrn'">Syriac (Eastern variant)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Tagb'">Tagbanwa</xsl:when>
+		    <xsl:when test="$scriptCode = 'Takr'">Takri, ??kr?, ???kr?</xsl:when>
+		    <xsl:when test="$scriptCode = 'Tale'">Tai Le</xsl:when>
+		    <xsl:when test="$scriptCode = 'Talu'">New Tai Lue</xsl:when>
+		    <xsl:when test="$scriptCode = 'Taml'">Tamil</xsl:when>
+		    <xsl:when test="$scriptCode = 'Tang'">Tangut</xsl:when>
+		    <xsl:when test="$scriptCode = 'Tavt'">Tai Viet</xsl:when>
+		    <xsl:when test="$scriptCode = 'Telu'">Telugu</xsl:when>
+		    <xsl:when test="$scriptCode = 'Teng'">Tengwar</xsl:when>
+		    <xsl:when test="$scriptCode = 'Tfng'">Tifinagh (Berber)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Tglg'">Tagalog (Baybayin, Alibata)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Thaa'">Thaana</xsl:when>
+		    <xsl:when test="$scriptCode = 'Thai'">Thai</xsl:when>
+		    <xsl:when test="$scriptCode = 'Tibt'">Tibetan</xsl:when>
+		    <xsl:when test="$scriptCode = 'Tirh'">Tirhuta</xsl:when>
+		    <xsl:when test="$scriptCode = 'Ugar'">Ugaritic</xsl:when>
+		    <xsl:when test="$scriptCode = 'Vaii'">Vai</xsl:when>
+		    <xsl:when test="$scriptCode = 'Visp'">Visible Speech</xsl:when>
+		    <xsl:when test="$scriptCode = 'Wara'">Warang Citi (Varang Kshiti)</xsl:when>
+		    <xsl:when test="$scriptCode = 'Wole'">Woleai</xsl:when>
+		    <xsl:when test="$scriptCode = 'Xpeo'">Old Persian</xsl:when>
+		    <xsl:when test="$scriptCode = 'Xsux'">Cuneiform, Sumero-Akkadian</xsl:when>
+		    <xsl:when test="$scriptCode = 'Yiii'">Yi</xsl:when>
+		    <xsl:when test="$scriptCode = 'Zinh'">Code for inherited script</xsl:when>
+		    <xsl:when test="$scriptCode = 'Zmth'">Mathematical notation</xsl:when>
+		    <xsl:when test="$scriptCode = 'Zsym'">Symbols</xsl:when>
+		    <xsl:when test="$scriptCode = 'Zxxx'">Code for unwritten documents</xsl:when>
+		    <xsl:when test="$scriptCode = 'Zyyy'">Code for undetermined script</xsl:when>
+		    <xsl:when test="$scriptCode = 'Zzzz'">Code for uncoded script</xsl:when>
+			<xsl:otherwise><xsl:value-of select="$scriptCode"/></xsl:otherwise>
+		</xsl:choose>
+	</xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
Updates to the full record page xslt, which expand support for additional tags, better support for languages and scripts, reformats various fields.  It also removes all instances of frontin'.