### PR TITLE
Updates for Fedora 3.8.x

### DIFF
--- a/fcrepo-cdr-fesl/pom.xml
+++ b/fcrepo-cdr-fesl/pom.xml
@@ -58,6 +58,12 @@
 			<version>${fcrepo.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>log4j-over-slf4j</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.fcrepo</groupId>
@@ -74,6 +80,10 @@
 					<artifactId>google-collections</artifactId>
 					<groupId>com.google.collections</groupId>
 				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>log4j-over-slf4j</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>
@@ -89,6 +99,12 @@
 			<version>${fcrepo.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>log4j-over-slf4j</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.fcrepo</groupId>
@@ -96,6 +112,12 @@
 			<version>${fcrepo.version}</version>
 			<type>jar</type>
 			<scope>compile</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>log4j-over-slf4j</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>edu.unc.lib.cdr</groupId>

--- a/fcrepo-cdr-fesl/src/main/java/edu/unc/lib/dl/security/CdrRIAttributeFinder.java
+++ b/fcrepo-cdr-fesl/src/main/java/edu/unc/lib/dl/security/CdrRIAttributeFinder.java
@@ -188,7 +188,7 @@ public class CdrRIAttributeFinder extends DesignatorAttributeFinderModule {
 			
 			if (value instanceof StringAttribute) {
 				StringAttribute attribute = (StringAttribute) value;
-				logger.debug("adding attribute: {}", attribute);
+				log.debug("adding attribute: {}", attribute);
 				groups.add(attribute.getValue());
 			}
 		}
@@ -225,7 +225,7 @@ public class CdrRIAttributeFinder extends DesignatorAttributeFinderModule {
 			
 			if (value instanceof StringAttribute) {
 				StringAttribute attribute = (StringAttribute) value;
-				logger.debug("returning attribute: {}", attribute);
+				log.debug("returning attribute: {}", attribute);
 				return attribute.getValue();
 			}
 		}

--- a/fcrepo-cdr-fesl/src/main/java/edu/unc/lib/dl/security/objecthandlers/AddRelationship.java
+++ b/fcrepo-cdr-fesl/src/main/java/edu/unc/lib/dl/security/objecthandlers/AddRelationship.java
@@ -25,6 +25,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.fcrepo.common.Constants;
+import org.fcrepo.server.security.RequestCtx;
 import org.fcrepo.server.security.xacml.pep.PEPException;
 import org.fcrepo.server.security.xacml.pep.ResourceAttributes;
 import org.fcrepo.server.security.xacml.pep.rest.filters.AbstractFilter;
@@ -32,9 +33,8 @@ import org.fcrepo.server.security.xacml.util.LogUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.xacml.attr.AnyURIAttribute;
-import com.sun.xacml.attr.AttributeValue;
-import com.sun.xacml.ctx.RequestCtx;
+import org.jboss.security.xacml.sunxacml.attr.AnyURIAttribute;
+import org.jboss.security.xacml.sunxacml.attr.AttributeValue;
 
 
 /**

--- a/fcrepo-cdr-fesl/src/main/java/edu/unc/lib/dl/security/objecthandlers/PurgeRelationship.java
+++ b/fcrepo-cdr-fesl/src/main/java/edu/unc/lib/dl/security/objecthandlers/PurgeRelationship.java
@@ -26,9 +26,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import com.sun.xacml.attr.AnyURIAttribute;
-import com.sun.xacml.attr.AttributeValue;
-import com.sun.xacml.ctx.RequestCtx;
+import org.jboss.security.xacml.sunxacml.attr.AnyURIAttribute;
+import org.jboss.security.xacml.sunxacml.attr.AttributeValue;
 
 
 import org.slf4j.Logger;
@@ -36,6 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import org.fcrepo.common.Constants;
 
+import org.fcrepo.server.security.RequestCtx;
 import org.fcrepo.server.security.xacml.pep.PEPException;
 import org.fcrepo.server.security.xacml.pep.ResourceAttributes;
 import org.fcrepo.server.security.xacml.pep.rest.filters.AbstractFilter;

--- a/fcrepo-cdr-fesl/src/main/java/edu/unc/lib/dl/security/wshandlers/AddRelationshipHandler.java
+++ b/fcrepo-cdr-fesl/src/main/java/edu/unc/lib/dl/security/wshandlers/AddRelationshipHandler.java
@@ -24,6 +24,7 @@ import javax.xml.ws.handler.soap.SOAPMessageContext;
 
 import org.apache.cxf.binding.soap.SoapFault;
 import org.fcrepo.common.Constants;
+import org.fcrepo.server.security.RequestCtx;
 import org.fcrepo.server.security.xacml.pep.ContextHandler;
 import org.fcrepo.server.security.xacml.pep.PEPException;
 import org.fcrepo.server.security.xacml.pep.ws.operations.AbstractOperationHandler;
@@ -32,9 +33,8 @@ import org.fcrepo.server.security.xacml.util.LogUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.xacml.attr.AnyURIAttribute;
-import com.sun.xacml.attr.AttributeValue;
-import com.sun.xacml.ctx.RequestCtx;
+import org.jboss.security.xacml.sunxacml.attr.AnyURIAttribute;
+import org.jboss.security.xacml.sunxacml.attr.AttributeValue;
 
 
 /**

--- a/fcrepo-cdr-fesl/src/main/java/edu/unc/lib/dl/security/wshandlers/PurgeRelationshipHandler.java
+++ b/fcrepo-cdr-fesl/src/main/java/edu/unc/lib/dl/security/wshandlers/PurgeRelationshipHandler.java
@@ -24,6 +24,7 @@ import javax.xml.ws.handler.soap.SOAPMessageContext;
 
 import org.apache.cxf.binding.soap.SoapFault;
 import org.fcrepo.common.Constants;
+import org.fcrepo.server.security.RequestCtx;
 import org.fcrepo.server.security.xacml.pep.ContextHandler;
 import org.fcrepo.server.security.xacml.pep.PEPException;
 import org.fcrepo.server.security.xacml.pep.ResourceAttributes;
@@ -33,9 +34,8 @@ import org.fcrepo.server.security.xacml.util.LogUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.xacml.attr.AnyURIAttribute;
-import com.sun.xacml.attr.AttributeValue;
-import com.sun.xacml.ctx.RequestCtx;
+import org.jboss.security.xacml.sunxacml.attr.AnyURIAttribute;
+import org.jboss.security.xacml.sunxacml.attr.AttributeValue;
 
 
 /**

--- a/fcrepo-irods-storage/pom.xml
+++ b/fcrepo-irods-storage/pom.xml
@@ -93,6 +93,12 @@
 			<groupId>org.fcrepo</groupId>
 			<artifactId>fcrepo-server</artifactId>
 			<version>${fcrepo.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>log4j-over-slf4j</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.irods.jargon</groupId>

--- a/fcrepo-irods-storage/src/main/java/fedorax/server/module/storage/IrodsExternalContentManager.java
+++ b/fcrepo-irods-storage/src/main/java/fedorax/server/module/storage/IrodsExternalContentManager.java
@@ -32,7 +32,7 @@ import javax.activation.MimetypesFileTypeMap;
 import javax.management.MBeanServer;
 import javax.management.MBeanServerFactory;
 
-import org.apache.commons.httpclient.Header;
+import org.apache.http.Header;
 
 import org.fcrepo.common.http.HttpInputStream;
 import org.fcrepo.common.http.WebClient;

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 	<properties>
 		<cdr.version>3.4-SNAPSHOT</cdr.version>
 		<spring.version>3.0.6.RELEASE</spring.version>
-		<fcrepo.version>3.6.2</fcrepo.version>
+		<fcrepo.version>3.8.0</fcrepo.version>
 		<spring.security.version>3.0.6.RELEASE</spring.security.version>
 		<spring.ws.version>2.0.1.RELEASE</spring.ws.version>
 		<spring.tiger.ws.version>1.5.9</spring.tiger.ws.version>


### PR DESCRIPTION
* Bump Fedora version
* Update import statements for new XACML package
* Use non-XML API for finding attributes
* Exclude log4j-over-slf4j to prevent infinite logger delegation loop problem