### PR TITLE
Remove unused and conflicting "thumbnail" class from front page collection list

### DIFF
--- a/access/src/main/webapp/WEB-INF/jsp/frontPage.jsp
+++ b/access/src/main/webapp/WEB-INF/jsp/frontPage.jsp
@@ -98,31 +98,31 @@
 
 			<table>
 		      <tr>
-		        <td class="thumbnail"><a href="record/uuid:bded4944-f033-4015-af0f-3d39595f4d30"><img src="/static/front/aapaa.jpg"></a></td>
+		        <td><a href="record/uuid:bded4944-f033-4015-af0f-3d39595f4d30"><img src="/static/front/aapaa.jpg"></a></td>
 		        <td class="title"><a href="record/uuid:bded4944-f033-4015-af0f-3d39595f4d30">African American Performance Art Archive</a></td>
 		
-		        <td class="thumbnail"><a href="record/uuid:1add9fbc-f5c4-49a8-848e-96a52e3ade9c"><img src="/static/front/azoria.jpg"></a></td>
+		        <td><a href="record/uuid:1add9fbc-f5c4-49a8-848e-96a52e3ade9c"><img src="/static/front/azoria.jpg"></a></td>
 		        <td class="title"><a href="record/uuid:1add9fbc-f5c4-49a8-848e-96a52e3ade9c">Azoria Project Archive</a></td>
 		      </tr>
 		      <tr>
-		        <td class="thumbnail"><a href="record/uuid:dfebbdf7-3361-4097-9fa4-7001ab6fcc11"><img src="/static/front/bmc.png"></a></td>
+		        <td><a href="record/uuid:dfebbdf7-3361-4097-9fa4-7001ab6fcc11"><img src="/static/front/bmc.png"></a></td>
 		        <td class="title"><a href="record/uuid:dfebbdf7-3361-4097-9fa4-7001ab6fcc11">BioMed Central</a></td>
 		
-		        <td class="thumbnail"><a href="record/uuid:cbbc2cc1-c538-4e28-b567-55db61b7942e"><img src="/static/front/cpj.png"></a></td>
+		        <td><a href="record/uuid:cbbc2cc1-c538-4e28-b567-55db61b7942e"><img src="/static/front/cpj.png"></a></td>
 		        <td class="title"><a href="record/uuid:cbbc2cc1-c538-4e28-b567-55db61b7942e">Carolina Planning Journal</a></td>
 		      </tr>
 		      <tr>
-		        <td class="thumbnail"><a href="record/uuid:a012aad2-1ab1-43b2-b5ab-0e14740e5e07"><img src="/static/front/etds.png"></a></td>
+		        <td><a href="record/uuid:a012aad2-1ab1-43b2-b5ab-0e14740e5e07"><img src="/static/front/etds.png"></a></td>
 		        <td class="title"><a href="record/uuid:a012aad2-1ab1-43b2-b5ab-0e14740e5e07">Electronic Theses and Dissertations</a></td>
 		
-		        <td class="thumbnail"><a href="record/uuid:9ef8d1c5-14a1-4ed3-b0c0-6da67fa5f6d9"><img src="/static/front/popl.png"></a></td>
+		        <td><a href="record/uuid:9ef8d1c5-14a1-4ed3-b0c0-6da67fa5f6d9"><img src="/static/front/popl.png"></a></td>
 		        <td class="title"><a href="record/uuid:9ef8d1c5-14a1-4ed3-b0c0-6da67fa5f6d9">Program on Public Life</a></td>
 		      </tr>
 		      <tr>
-		        <td class="thumbnail"><a href="record/uuid:8ae56bbc-400e-496d-af4b-3c585e20dba1"><img src="/static/front/rla.png"></a></td>
+		        <td><a href="record/uuid:8ae56bbc-400e-496d-af4b-3c585e20dba1"><img src="/static/front/rla.png"></a></td>
 		        <td class="title"><a href="record/uuid:8ae56bbc-400e-496d-af4b-3c585e20dba1">Research Laboratories of Archaeology</a></td>
 		
-		        <td class="thumbnail"><a href="record/uuid:5e4b2719-bb71-45ec-be63-5d018b6f5aab"><img src="/static/front/sfc.png"></a></td>
+		        <td><a href="record/uuid:5e4b2719-bb71-45ec-be63-5d018b6f5aab"><img src="/static/front/sfc.png"></a></td>
 		        <td class="title"><a href="record/uuid:5e4b2719-bb71-45ec-be63-5d018b6f5aab">Southern Folklife Collection Digital Files</a></td>
 		      </tr>
 		    </table>


### PR DESCRIPTION
Part of the front page layout was using the "thumbnail" class, but not for any actual styles. This conflicted with the new thumbnail/placeholder CSS.