### PR TITLE
If no premis event log is present on an object when attempting to write ...

### DIFF
--- a/persistence/src/main/java/edu/unc/lib/dl/services/DigitalObjectManagerImpl.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/services/DigitalObjectManagerImpl.java
@@ -204,7 +204,7 @@ public class DigitalObjectManagerImpl implements DigitalObjectManager {
 			parent = this.removeFromContainer(pid);
 
 			Element event = logger.logEvent(PremisEventLogger.Type.DELETION, "Deleted " + deleted.size()
-					+ "contained object(s).", container);
+					+ " contained object(s).", container);
 			PremisEventLogger.addDetailedOutcome(event, "success", "Message: " + message, null);
 			this.managementClient.writePremisEventsToFedoraObject(logger, container);
 


### PR DESCRIPTION
...a new event to it, then create a new MD_EVENTS datastream instead of failing