### PR TITLE
Move operation refactor

### DIFF
--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/ManagementClient.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/ManagementClient.java
@@ -596,14 +596,14 @@ public class ManagementClient extends WebServiceTemplate {
 		return timestamp;
 	}
 
-	public void modifyDatastream(PID pid, String dsid, String message, List<String> altids,
-			String label, String lastModifiedDate, Document content) throws FedoraException {
+	public void modifyDatastream(PID pid, String dsid, String message,
+			String lastModifiedDate, Document content) throws FedoraException {
 		byte[] dsBytes = ClientUtils.serializeXML(content);
-		modifyDatastream(pid, dsid, message, altids, label, lastModifiedDate, dsBytes);
+		modifyDatastream(pid, dsid, message, lastModifiedDate, dsBytes);
 	}
 
-	public void modifyDatastream(PID pid, String dsid, String message, List<String> altids,
-			String label, String lastModifiedDate, byte[] content) throws FedoraException {
+	public void modifyDatastream(PID pid, String dsid, String message,
+			String lastModifiedDate, byte[] content) throws FedoraException {
 
 		PutMethod method = new PutMethod(this.getFedoraContextUrl() + "/objects/" + pid.getPid() + "/datastreams/" + dsid);
 		method.setRequestEntity(new ByteArrayRequestEntity(content));
@@ -614,9 +614,6 @@ public class ManagementClient extends WebServiceTemplate {
 		}
 		if (lastModifiedDate != null) {
 			params.setParameter("lastModifiedDate", lastModifiedDate);
-		}
-		if (label != null) {
-			params.setParameter("dsLabel", label);
 		}
 
 		try {

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/ManagementClient.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/ManagementClient.java
@@ -34,8 +34,10 @@ import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
 import org.apache.commons.httpclient.UsernamePasswordCredentials;
+import org.apache.commons.httpclient.methods.ByteArrayRequestEntity;
 import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.methods.PostMethod;
+import org.apache.commons.httpclient.methods.PutMethod;
 import org.apache.commons.httpclient.methods.multipart.ByteArrayPartSource;
 import org.apache.commons.httpclient.methods.multipart.FilePart;
 import org.apache.commons.httpclient.methods.multipart.MultipartRequestEntity;
@@ -49,7 +51,6 @@ import org.jdom2.input.SAXBuilder;
 import org.jdom2.output.XMLOutputter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.oxm.jaxb.Jaxb2Marshaller;
 import org.springframework.ws.WebServiceMessage;
 import org.springframework.ws.client.WebServiceFaultException;
@@ -593,6 +594,40 @@ public class ManagementClient extends WebServiceTemplate {
 		String timestamp = this.modifyDatastreamByValue(pid, dsid, force, message, altids, label, "text/xml", null,
 				ChecksumType.MD5, data);
 		return timestamp;
+	}
+
+	public void modifyDatastream(PID pid, String dsid, String message, List<String> altids,
+			String label, String lastModifiedDate, Document content) throws FedoraException {
+		byte[] dsBytes = ClientUtils.serializeXML(content);
+		modifyDatastream(pid, dsid, message, altids, label, lastModifiedDate, dsBytes);
+	}
+
+	public void modifyDatastream(PID pid, String dsid, String message, List<String> altids,
+			String label, String lastModifiedDate, byte[] content) throws FedoraException {
+
+		PutMethod method = new PutMethod(this.getFedoraContextUrl() + "/objects/" + pid.getPid() + "/datastreams/" + dsid);
+		method.setRequestEntity(new ByteArrayRequestEntity(content));
+
+		HttpMethodParams params = method.getParams();
+		if (message != null) {
+			params.setParameter("logMessage", message);
+		}
+		if (lastModifiedDate != null) {
+			params.setParameter("lastModifiedDate", lastModifiedDate);
+		}
+		if (label != null) {
+			params.setParameter("dsLabel", label);
+		}
+
+		try {
+			int response = httpClient.executeMethod(method);
+			if (response == 409) {
+				throw new OptimisticLockException("Datastream " + dsid + " on object " + pid
+						+ " has been modified more recently than the specified last modified date");
+			}
+		} catch (IOException e) {
+			throw new ServiceException("Failed to modify datastream " + dsid + " on object " + pid, e);
+		}
 	}
 
 	public String modifyObject(PID pid, String label, String ownerid, State state, String message)

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/OptimisticLockException.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/OptimisticLockException.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.fedora;
+
+/**
+ * @author bbpennel
+ * @date Feb 4, 2015
+ */
+public class OptimisticLockException extends FedoraException {
+
+	private static final long serialVersionUID = 1L;
+
+	public OptimisticLockException(String message) {
+		super(message);
+	}
+
+}

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/util/TripleStoreQueryService.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/util/TripleStoreQueryService.java
@@ -316,6 +316,15 @@ public interface TripleStoreQueryService {
 	public abstract List<String> listDisseminators(PID pid);
 
 	/**
+	 * Returns true if the object has the specified disseminator
+	 *
+	 * @param pid
+	 * @param dsName
+	 * @return
+	 */
+	public abstract boolean hasDisseminator(PID pid, String dsName);
+
+	/**
 	 * Gets datastreams that are cdr:sourceData for the object or its surrogate.
 	 *
 	 * @param pid

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/util/TripleStoreQueryServiceMulgaraImpl.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/util/TripleStoreQueryServiceMulgaraImpl.java
@@ -1361,6 +1361,23 @@ public class TripleStoreQueryServiceMulgaraImpl implements
 	}
 
 	@Override
+	public boolean hasDisseminator(PID pid, String dsName) {
+		String query = String.format("select $pid from <%1$s>"
+				+ " where $pid <%3$s> <%4$s>"
+				+ " and $pid <http://mulgara.org/mulgara#is> <%2$s>;",
+				this.getResourceIndexModelUri(), pid.getURI(),
+				ContentModelHelper.FedoraProperty.disseminates.getURI(),
+				pid.getURI() + "/" + dsName);
+		List<List<String>> response = this.lookupStrings(query);
+		if (!response.isEmpty()) {
+			if (response.size() > 0) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
 	public Map<String, String> fetchDisseminatorMimetypes(PID pid) {
 		Map<String, String> result = new HashMap<String, String>();
 		String query = String.format("select $ds $mimetype from <%1$s>"

--- a/metadata/src/main/java/edu/unc/lib/dl/util/ContentModelHelper.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/util/ContentModelHelper.java
@@ -194,7 +194,7 @@ public class ContentModelHelper {
 				throw x;
 			}
 		}
-		
+
 		// FIXME: should other kinds of properties use this fragment/namespace/uri pattern?
 
 		public String getFragment() {
@@ -279,7 +279,7 @@ public class ContentModelHelper {
 	public static enum Relationship {
 		contains(JDOMNamespaceUtil.CDR_NS, "contains"), member(JDOMNamespaceUtil.CDR_NS, "member"), owner(
 				JDOMNamespaceUtil.CDR_NS, "owner"), originalDeposit(JDOMNamespaceUtil.CDR_NS, "originalDeposit"), depositedBy(
-				JDOMNamespaceUtil.CDR_NS, "depositedBy");
+				JDOMNamespaceUtil.CDR_NS, "depositedBy"), removedChild(JDOMNamespaceUtil.CDR_NS, "removedChild");
 		private URI uri;
 		private Namespace namespace;
 

--- a/metadata/src/main/java/edu/unc/lib/dl/util/DateTimeUtil.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/util/DateTimeUtil.java
@@ -109,4 +109,10 @@ public class DateTimeUtil {
 		DateTime dateTime = new DateTime(date);
 		return utcFormatter.print(dateTime);
 	}
+
+	public static String getCurrentUTCTime() {
+		DateTime now = new DateTime();
+		DateTime utcTime = now.toDateTime(DateTimeZone.UTC);
+		return utcTime.toString();
+	}
 }

--- a/metadata/src/main/java/edu/unc/lib/dl/util/DateTimeUtil.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/util/DateTimeUtil.java
@@ -109,10 +109,4 @@ public class DateTimeUtil {
 		DateTime dateTime = new DateTime(date);
 		return utcFormatter.print(dateTime);
 	}
-
-	public static String getCurrentUTCTime() {
-		DateTime now = new DateTime();
-		DateTime utcTime = now.toDateTime(DateTimeZone.UTC);
-		return utcTime.toString();
-	}
 }

--- a/metadata/src/main/java/edu/unc/lib/dl/xml/JDOMQueryUtil.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/xml/JDOMQueryUtil.java
@@ -17,19 +17,23 @@ package edu.unc.lib.dl.xml;
 
 import java.text.ParseException;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.jdom2.Element;
 import org.jdom2.Namespace;
 
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.util.ContentModelHelper.Relationship;
 import edu.unc.lib.dl.util.DateTimeUtil;
 
 public class JDOMQueryUtil {
-	
+
 	public static Element getElementByAttribute(List<?> elements, String attribute, String value) {
 		return getElementByAttribute(elements, attribute, null, value);
 	}
-	
+
 	public static Element getElementByAttribute(List<?> elements, String attribute, Namespace attributeNS, String value) {
 		for (Object elementObj : elements) {
 			Element element = (Element) elementObj;
@@ -40,7 +44,7 @@ public class JDOMQueryUtil {
 		}
 		return null;
 	}
-	
+
 	public static Element getChildByAttribute(Element parent, String childName, Namespace namespace, String attribute, String value) {
 		List<?> elements;
 		if (childName != null) {
@@ -52,7 +56,7 @@ public class JDOMQueryUtil {
 		}
 		return getElementByAttribute(elements, attribute, value);
 	}
-	
+
 	public static Date parseISO6392bDateChild(Element parent, String childName, Namespace namespace) {
 		String dateString = parent.getChildText(childName, namespace);
 		if (dateString != null) {
@@ -65,5 +69,22 @@ public class JDOMQueryUtil {
 			}
 		}
 		return null;
+	}
+
+	/**
+	 * Returns a set of object PIDs retrieved from the provided RDF datastream
+	 *
+	 * @param rdfRoot
+	 * @param relation
+	 * @return
+	 */
+	public static Set<PID> getRelationSet(Element rdfRoot, Relationship relation) {
+		List<Element> containsEls = rdfRoot.getChild("Description", JDOMNamespaceUtil.RDF_NS).getChildren(
+				relation.name(), relation.getNamespace());
+		Set<PID> children = new HashSet<>();
+		for (Element containsEl : containsEls) {
+			children.add(new PID(containsEl.getAttributeValue("resource", JDOMNamespaceUtil.RDF_NS)));
+		}
+		return children;
 	}
 }

--- a/persistence/src/main/java/edu/unc/lib/dl/services/DigitalObjectManager.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/services/DigitalObjectManager.java
@@ -125,10 +125,10 @@ public interface DigitalObjectManager {
 	 */
 	public abstract String addOrReplaceDatastream(PID pid, Datastream datastream, File content, String mimetype,
 			String user, String message) throws UpdateException;
-	
+
 	public abstract String addOrReplaceDatastream(PID pid, Datastream datastream, String label, File content,
-			String mimetype, String user, String message) throws UpdateException; 
-	
+			String mimetype, String user, String message) throws UpdateException;
+
 	/**
 	 * Moves the specified objects from their current containers to another existing container. The destination path must
 	 * correspond to a object having the Container model. Note that the List may include PIDs from a variety of different
@@ -148,6 +148,16 @@ public interface DigitalObjectManager {
 	public abstract void move(List<PID> moving, PID destination, String user, String message)
 			throws IngestException;
 
+	/**
+	 * Attempts to rollback a failed move operation by returning part way moved objects to their original source
+	 * container and cleaning up removal markers
+	 *
+	 * @param source
+	 * @param moving
+	 * @throws IngestException
+	 */
+	public void rollbackMove(PID source, List<PID> moving) throws IngestException;
+
 	public abstract boolean isAvailable();
 
 	/**
@@ -161,6 +171,6 @@ public interface DigitalObjectManager {
 	 */
 	public abstract PID createContainer(String name, PID parent, Model extraModel, String user,
 			byte[] mods) throws IngestException;
-	
+
 
 }

--- a/persistence/src/main/java/edu/unc/lib/dl/services/DigitalObjectManagerImpl.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/services/DigitalObjectManagerImpl.java
@@ -750,6 +750,7 @@ public class DigitalObjectManagerImpl implements DigitalObjectManager {
 	 * @param moving
 	 * @throws IngestException
 	 */
+	@Override
 	public void rollbackMove(PID source, List<PID> moving) throws IngestException {
 
 		try {
@@ -781,6 +782,11 @@ public class DigitalObjectManagerImpl implements DigitalObjectManager {
 
 			// Clean up the tombstones
 			cleanupRemovedChildren(source, moving);
+
+			// Send out notification message that the rollback operation completed
+			if (getOperationsMessageSender() != null) {
+				getOperationsMessageSender().sendMoveOperation("cdr", destinationMap.keySet(), source, moving, reordered);
+			}
 
 		} catch (FedoraException e) {
 			log.error("Failed to automatically rollback move operation on source {}", source, e);

--- a/persistence/src/main/java/edu/unc/lib/dl/services/DigitalObjectManagerImpl.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/services/DigitalObjectManagerImpl.java
@@ -863,7 +863,7 @@ public class DigitalObjectManagerImpl implements DigitalObjectManager {
 				}
 
 				managementClient.modifyDatastream(container, RELS_EXT.getName(),
-						"Removing moved children", null, null, relsExtResp.getLastModified(), relsExt);
+						"Removing moved children", relsExtResp.getLastModified(), relsExt);
 				break removeRelsExt;
 			} catch (OptimisticLockException e) {
 				log.debug("Unable to update RELS-EXT for {}, retrying", container, e);
@@ -886,7 +886,7 @@ public class DigitalObjectManagerImpl implements DigitalObjectManager {
 					}
 
 					managementClient.modifyDatastream(container, MD_CONTENTS.getName(),
-							"Removing " + children.size() + " moved children", null, null,
+							"Removing " + children.size() + " moved children",
 							mdContents.getLastModified(), mdContents.getDocument());
 				}
 				break removeMDContents;
@@ -942,7 +942,7 @@ public class DigitalObjectManagerImpl implements DigitalObjectManager {
 				}
 
 				// Push changes out to the container container
-				managementClient.modifyDatastream(container, RELS_EXT.getName(), "Adding moved children", null, null,
+				managementClient.modifyDatastream(container, RELS_EXT.getName(), "Adding moved children",
 						relsExtResp.getLastModified(), relsExt);
 				break updateRelsExt;
 			} catch (OptimisticLockException e) {
@@ -966,7 +966,7 @@ public class DigitalObjectManagerImpl implements DigitalObjectManager {
 					}
 
 					managementClient.modifyDatastream(container, MD_CONTENTS.getName(), "Adding " + moving.size()
-							+ " moved children", null, null, mdContentsResp.getLastModified(), mdContents);
+							+ " moved children", mdContentsResp.getLastModified(), mdContents);
 				}
 				break updateMDContents;
 			} catch (OptimisticLockException e) {
@@ -1013,7 +1013,7 @@ public class DigitalObjectManagerImpl implements DigitalObjectManager {
 					log.info("RELS-EXT after cleaning up children in {}:\n{}", container, outputter.outputString(relsExt));
 				}
 
-				managementClient.modifyDatastream(container, RELS_EXT.getName(), "Cleaning up moved children", null, null,
+				managementClient.modifyDatastream(container, RELS_EXT.getName(), "Cleaning up moved children",
 						relsExtResp.getLastModified(), relsExt);
 				break updateRelsExt;
 			} catch (OptimisticLockException e) {

--- a/persistence/src/main/java/edu/unc/lib/dl/util/ContainerContentsHelper.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/util/ContainerContentsHelper.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 
@@ -36,9 +37,9 @@ import edu.unc.lib.dl.xml.JDOMNamespaceUtil;
 /**
  * A set of functions that are useful for reading, interpreting and writing the container contents XML stream.
  * (MD_CONTENTS)
- * 
+ *
  * @author count0
- * 
+ *
  */
 public class ContainerContentsHelper {
 	private static final Log log = LogFactory.getLog(ContainerContentsHelper.class);
@@ -46,9 +47,9 @@ public class ContainerContentsHelper {
 	/**
 	 * Adds new children to the content index. If there is an order specified for a new child, then it will insert the
 	 * child at the specified position. Any existing children after the specified position will be shifted if neccessary.
-	 * 
+	 *
 	 * @param reordered
-	 * 
+	 *
 	 * @param oldContents
 	 *           bytes for the old XML CONTENTS stream
 	 * @param topPid
@@ -197,6 +198,23 @@ public class ContainerContentsHelper {
 			}
 		}
 		parentDiv.removeContent(remove);
+		return oldXML;
+	}
+
+	public static Document remove(Document oldXML, Collection<PID> children) {
+		Element parentDiv = oldXML.getRootElement().getChild("div", JDOMNamespaceUtil.METS_NS);
+		List<Element> childDivs = parentDiv.getChildren();
+		Iterator<Element> childIt = childDivs.iterator();
+
+		while (childIt.hasNext()) {
+			Element child = childIt.next();
+			PID childPID = new PID(child.getAttributeValue("ID"));
+
+			if (children.contains(childPID)) {
+				childIt.remove();
+			}
+		}
+
 		return oldXML;
 	}
 

--- a/persistence/src/test/java/edu/unc/lib/dl/services/DigitalObjectManagerMoveTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/services/DigitalObjectManagerMoveTest.java
@@ -1,0 +1,377 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.services;
+
+import static edu.unc.lib.dl.util.ContentModelHelper.Datastream.MD_CONTENTS;
+import static edu.unc.lib.dl.util.ContentModelHelper.Datastream.RELS_EXT;
+import static edu.unc.lib.dl.util.ContentModelHelper.Model.CONTAINER;
+import static edu.unc.lib.dl.util.ContentModelHelper.Relationship.contains;
+import static edu.unc.lib.dl.util.ContentModelHelper.Relationship.removedChild;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.annotation.Resource;
+
+import org.apache.commons.io.IOUtils;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.output.XMLOutputter;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatcher;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import edu.unc.lib.dl.fedora.AccessClient;
+import edu.unc.lib.dl.fedora.ManagementClient;
+import edu.unc.lib.dl.fedora.OptimisticLockException;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.fedora.types.MIMETypedStream;
+import edu.unc.lib.dl.ingest.IngestException;
+import edu.unc.lib.dl.util.ContentModelHelper.Relationship;
+import edu.unc.lib.dl.util.TripleStoreQueryService;
+import edu.unc.lib.dl.xml.JDOMNamespaceUtil;
+
+/**
+ * @author bbpennel
+ * @date Jan 30, 2015
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(locations = { "/service-context.xml" })
+public class DigitalObjectManagerMoveTest {
+
+	@Resource
+	private final DigitalObjectManagerImpl digitalMan = null;
+
+	@Resource
+	private final ManagementClient managementClient = null;
+
+	@Resource
+	private final AccessClient accessClient = null;
+
+	@Resource
+	private final TripleStoreQueryService tripleStoreQueryService = null;
+
+	private PID destPID;
+
+	private final PID source1PID = new PID("uuid:source1");
+	private final PID source2PID = new PID("uuid:source2");
+
+	@Before
+	public void setUp() throws Exception {
+		reset(managementClient);
+		reset(accessClient);
+		reset(tripleStoreQueryService);
+
+		digitalMan.setAvailable(true, "available");
+
+		destPID = new PID("uuid:destination");
+
+		when(tripleStoreQueryService.lookupRepositoryAncestorPids(destPID)).thenReturn(
+				Arrays.asList(new PID("uuid:Collections"), new PID("uuid:collection")));
+
+		when(tripleStoreQueryService.lookupContentModels(destPID)).thenReturn(Arrays.asList(CONTAINER.getURI()));
+		when(tripleStoreQueryService.hasDisseminator(any(PID.class), eq(RELS_EXT.getName()))).thenReturn(true);
+
+		InputStream relsExtStream2 = this.getClass().getResourceAsStream("/fedora/containerRELSEXT2.xml");
+		MIMETypedStream mts2 = mock(MIMETypedStream.class);
+		when(mts2.getStream()).thenReturn(IOUtils.toByteArray(relsExtStream2));
+		when(accessClient.getDatastreamDissemination(eq(destPID), eq(RELS_EXT.getName()), anyString())).thenReturn(
+				mts2);
+	}
+
+	@Test(expected = IngestException.class)
+	public void moveParentIntoChildTest() throws Exception {
+		List<PID> moving = Arrays.asList(new PID("uuid:child1"), new PID("uuid:collection"));
+		digitalMan.move(moving, destPID, "user", "");
+	}
+
+	@Test(expected = IngestException.class)
+	public void destinationDoesNotExistTest() throws Exception {
+		when(tripleStoreQueryService.lookupRepositoryAncestorPids(destPID)).thenReturn(null);
+
+		List<PID> moving = Arrays.asList(new PID("uuid:child1"), new PID("uuid:child2"));
+		digitalMan.move(moving, destPID, "user", "");
+	}
+
+	public static class PairedMatcher extends ArgumentMatcher<Document> {
+		public Document lastMatchedDoc;
+
+		@Override
+		public boolean matches(Object argument) {
+			lastMatchedDoc = (Document) argument;
+			return true;
+		}
+	}
+
+	public static class PairedAnswer implements Answer<MIMETypedStream> {
+
+		public PairedAnswer(MIMETypedStream startingValue, PairedMatcher matcher) {
+			this.startingValue = startingValue;
+			this.matcher = matcher;
+		}
+
+		private final MIMETypedStream startingValue;
+		private final PairedMatcher matcher;
+
+		@Override
+		public MIMETypedStream answer(InvocationOnMock invocation) throws Throwable {
+			if (matcher.lastMatchedDoc == null)
+				return startingValue;
+
+			XMLOutputter outputter = new XMLOutputter(org.jdom2.output.Format.getPrettyFormat());
+			String docString = outputter.outputString(matcher.lastMatchedDoc);
+			MIMETypedStream mts = mock(MIMETypedStream.class);
+			when(mts.getStream()).thenReturn(docString.getBytes());
+			return mts;
+		}
+	}
+
+	private void makeMatcherPair(String relsPath, PID targetPID) throws Exception {
+		PairedMatcher sourceRelsExtMatcher = new PairedMatcher();
+		InputStream relsExtStream = this.getClass().getResourceAsStream(relsPath);
+		MIMETypedStream mts = mock(MIMETypedStream.class);
+		when(mts.getStream()).thenReturn(IOUtils.toByteArray(relsExtStream));
+		PairedAnswer sourceRelsExtAnswer = new PairedAnswer(mts, sourceRelsExtMatcher);
+
+		doNothing().when(managementClient)
+				.modifyDatastream(eq(targetPID), eq(RELS_EXT.getName()), anyString(),
+				anyListOf(String.class),
+						anyString(), anyString(), argThat(sourceRelsExtMatcher));
+
+		when(accessClient.getDatastreamDissemination(eq(targetPID), eq(RELS_EXT.getName()), anyString())).thenAnswer(
+				sourceRelsExtAnswer);
+	}
+
+	@Test
+	public void oneSourceTest() throws Exception {
+
+		makeMatcherPair("/fedora/containerRELSEXT1.xml", source1PID);
+
+		List<PID> moving = Arrays.asList(new PID("uuid:child1"), new PID("uuid:child5"));
+
+		when(tripleStoreQueryService.fetchContainer(any(PID.class))).thenReturn(source1PID);
+
+		digitalMan.move(moving, destPID, "user", "");
+
+		verify(accessClient, times(2)).getDatastreamDissemination(eq(source1PID), eq(RELS_EXT.getName()), anyString());
+
+		ArgumentCaptor<Document> sourceRelsExtUpdateCaptor = ArgumentCaptor.forClass(Document.class);
+
+		verify(managementClient, times(2)).modifyDatastream(eq(source1PID), eq(RELS_EXT.getName()), anyString(),
+				anyListOf(String.class), anyString(), anyString(), sourceRelsExtUpdateCaptor.capture());
+
+		List<Document> sourceRelsAnswers = sourceRelsExtUpdateCaptor.getAllValues();
+		// Check the state of the source after removal but before cleanup
+		Document sourceRelsExt = sourceRelsAnswers.get(0);
+		Set<PID> children = getRelationSet(sourceRelsExt.getRootElement(), contains);
+		assertEquals("Incorrect number of children in source container after move", 10, children.size());
+
+		Set<PID> removed = getRelationSet(sourceRelsExt.getRootElement(), removedChild);
+		assertEquals("Moved child gravestones not correctly set in source container", 2, removed.size());
+
+		// Check that tombstones were cleaned up by the end of the operation
+		Document cleanRelsExt = sourceRelsAnswers.get(1);
+		children = getRelationSet(cleanRelsExt.getRootElement(), contains);
+		assertEquals("Incorrect number of children in source container after cleanup", 10, children.size());
+
+		removed = getRelationSet(cleanRelsExt.getRootElement(), removedChild);
+		assertEquals("Child tombstones not cleaned up", 0, removed.size());
+
+		// Verify that the destination had the moved children added to it
+		verify(accessClient).getDatastreamDissemination(eq(destPID), eq(RELS_EXT.getName()), anyString());
+		ArgumentCaptor<Document> destRelsExtUpdateCaptor = ArgumentCaptor.forClass(Document.class);
+		verify(managementClient).modifyDatastream(eq(destPID), eq(RELS_EXT.getName()), anyString(),
+				anyListOf(String.class), anyString(), anyString(), destRelsExtUpdateCaptor.capture());
+		assertFalse("Moved children were still present in source", children.containsAll(moving));
+
+		Document destRelsExt = destRelsExtUpdateCaptor.getValue();
+		children = getRelationSet(destRelsExt.getRootElement(), contains);
+		assertEquals("Incorrect number of children in destination container after moved", 9, children.size());
+		assertTrue("Moved children were not present in destination", children.containsAll(moving));
+	}
+
+	private void makeDatastream(String contentPath, String datastream, PID pid) throws Exception {
+		when(tripleStoreQueryService.hasDisseminator(eq(pid), eq(datastream))).thenReturn(true);
+		InputStream mdContentsStream = this.getClass().getResourceAsStream(contentPath);
+		MIMETypedStream mts = mock(MIMETypedStream.class);
+		when(mts.getStream()).thenReturn(IOUtils.toByteArray(mdContentsStream));
+		when(accessClient.getDatastreamDissemination(eq(pid), eq(datastream), anyString())).thenReturn(mts);
+	}
+
+	@Test
+	public void oneSourceWithMDContents() throws Exception {
+		makeDatastream("/fedora/mdContents1.xml", MD_CONTENTS.getName(), source1PID);
+
+		oneSourceTest();
+
+		verify(managementClient).modifyDatastream(eq(source1PID), eq(MD_CONTENTS.getName()), anyString(),
+				anyListOf(String.class), anyString(), anyString(), any(Document.class));
+	}
+
+	@Test
+	public void oneSourceLockFailTest() throws Exception {
+		makeDatastream("/fedora/mdContents1.xml", MD_CONTENTS.getName(), source1PID);
+
+		PairedMatcher sourceRelsExtMatcher = new PairedMatcher();
+		InputStream relsExtStream = this.getClass().getResourceAsStream("/fedora/containerRELSEXT1.xml");
+		MIMETypedStream mts = mock(MIMETypedStream.class);
+		when(mts.getStream()).thenReturn(IOUtils.toByteArray(relsExtStream));
+		PairedAnswer sourceRelsExtAnswer = new PairedAnswer(mts, sourceRelsExtMatcher);
+
+		// Throw locking exception on first attempt to rewrite source RELS-EXT
+		doThrow(new OptimisticLockException(""))
+				.doNothing()
+				.when(managementClient)
+				.modifyDatastream(eq(source1PID), eq(RELS_EXT.getName()), anyString(), anyListOf(String.class),
+						anyString(), anyString(), argThat(sourceRelsExtMatcher));
+
+		doThrow(new OptimisticLockException(""))
+				.doNothing()
+				.when(managementClient)
+				.modifyDatastream(eq(destPID), eq(RELS_EXT.getName()), anyString(), anyListOf(String.class), anyString(),
+						anyString(), any(Document.class));
+
+		doThrow(new OptimisticLockException(""))
+				.doNothing()
+				.when(managementClient)
+				.modifyDatastream(eq(source1PID), eq(MD_CONTENTS.getName()), anyString(), anyListOf(String.class),
+						anyString(), anyString(), any(Document.class));
+
+		when(accessClient.getDatastreamDissemination(eq(source1PID), eq(RELS_EXT.getName()), anyString()))
+				.thenAnswer(sourceRelsExtAnswer);
+
+		List<PID> moving = Arrays.asList(new PID("uuid:child1"), new PID("uuid:child5"));
+
+		when(tripleStoreQueryService.fetchContainer(any(PID.class))).thenReturn(source1PID);
+
+		digitalMan.move(moving, destPID, "user", "");
+
+		verify(accessClient, times(3)).getDatastreamDissemination(eq(source1PID), eq(RELS_EXT.getName()), anyString());
+
+		ArgumentCaptor<Document> sourceRelsExtUpdateCaptor = ArgumentCaptor.forClass(Document.class);
+
+		verify(managementClient, times(3)).modifyDatastream(eq(source1PID), eq(RELS_EXT.getName()), anyString(),
+				anyListOf(String.class), anyString(), anyString(), sourceRelsExtUpdateCaptor.capture());
+
+		List<Document> sourceRelsAnswers = sourceRelsExtUpdateCaptor.getAllValues();
+
+		// Verify that the initial source RELS-EXT update is repeated after failure
+		Document sourceRelsExt = sourceRelsAnswers.get(0);
+		Set<PID> removed = getRelationSet(sourceRelsExt.getRootElement(), removedChild);
+		assertEquals("Child tombstones should still be present", 2, removed.size());
+		sourceRelsExt = sourceRelsAnswers.get(1);
+		removed = getRelationSet(sourceRelsExt.getRootElement(), removedChild);
+		assertEquals("Child tombstones should still be present on second try", 2, removed.size());
+
+		// Check that tombstones were cleaned up by the end of the operation
+		Document cleanRelsExt = sourceRelsAnswers.get(2);
+		Set<PID> children = getRelationSet(cleanRelsExt.getRootElement(), contains);
+		assertEquals("Incorrect number of children in source container after cleanup", 10, children.size());
+
+		removed = getRelationSet(cleanRelsExt.getRootElement(), removedChild);
+		assertEquals("Child tombstones not cleaned up", 0, removed.size());
+
+		// Verify that the destination had the moved children added to it
+		ArgumentCaptor<Document> destRelsExtUpdateCaptor = ArgumentCaptor.forClass(Document.class);
+		verify(managementClient, times(2)).modifyDatastream(eq(destPID), eq(RELS_EXT.getName()), anyString(),
+				anyListOf(String.class), anyString(), anyString(), destRelsExtUpdateCaptor.capture());
+
+		Document destRelsExt = destRelsExtUpdateCaptor.getValue();
+		children = getRelationSet(destRelsExt.getRootElement(), contains);
+		assertEquals("Incorrect number of children in destination container after moved", 9, children.size());
+		assertTrue("Moved children were not present in destination", children.containsAll(moving));
+
+		verify(managementClient, times(2)).modifyDatastream(eq(source1PID), eq(MD_CONTENTS.getName()), anyString(),
+				anyListOf(String.class), anyString(), anyString(), any(Document.class));
+	}
+
+	@Test
+	public void multiSourceTest() throws Exception {
+		List<PID> moving = Arrays.asList(new PID("uuid:child1"), new PID("uuid:child32"));
+
+		makeMatcherPair("/fedora/containerRELSEXT1.xml", source1PID);
+		makeMatcherPair("/fedora/containerRELSEXT3.xml", source2PID);
+
+		when(tripleStoreQueryService.fetchContainer(eq(new PID("uuid:child1")))).thenReturn(source1PID);
+		when(tripleStoreQueryService.fetchContainer(eq(new PID("uuid:child32")))).thenReturn(source2PID);
+
+		digitalMan.move(moving, destPID, "user", "");
+
+		verify(accessClient, times(2)).getDatastreamDissemination(eq(source1PID), eq(RELS_EXT.getName()), anyString());
+		verify(accessClient, times(2)).getDatastreamDissemination(eq(source2PID), eq(RELS_EXT.getName()), anyString());
+
+		ArgumentCaptor<Document> source1RelsExtUpdateCaptor = ArgumentCaptor.forClass(Document.class);
+		verify(managementClient, times(2)).modifyDatastream(eq(source1PID), eq(RELS_EXT.getName()), anyString(),
+				anyListOf(String.class), anyString(), anyString(), source1RelsExtUpdateCaptor.capture());
+
+		// Check that the first source was updated
+		Document clean1RelsExt = source1RelsExtUpdateCaptor.getValue();
+		Set<PID> children = getRelationSet(clean1RelsExt.getRootElement(), contains);
+		assertEquals("Incorrect number of children in source 1 after cleanup", 11, children.size());
+
+		// Check that the second source was updated
+		ArgumentCaptor<Document> source2RelsExtUpdateCaptor = ArgumentCaptor.forClass(Document.class);
+		verify(managementClient, times(2)).modifyDatastream(eq(source2PID), eq(RELS_EXT.getName()), anyString(),
+				anyListOf(String.class), anyString(), anyString(), source2RelsExtUpdateCaptor.capture());
+		Document clean2RelsExt = source2RelsExtUpdateCaptor.getValue();
+		children = getRelationSet(clean2RelsExt.getRootElement(), contains);
+		assertEquals("Incorrect number of children in source 2 after cleanup", 1, children.size());
+
+		// Check that items from both source 1 and 2 ended up in the destination.
+		ArgumentCaptor<Document> destRelsExtUpdateCaptor = ArgumentCaptor.forClass(Document.class);
+		verify(managementClient).modifyDatastream(eq(destPID), eq(RELS_EXT.getName()), anyString(),
+				anyListOf(String.class), anyString(), anyString(), destRelsExtUpdateCaptor.capture());
+
+		Document destRelsExt = destRelsExtUpdateCaptor.getValue();
+		children = getRelationSet(destRelsExt.getRootElement(), contains);
+		assertEquals("Incorrect number of children in destination container after moved", 9, children.size());
+		assertTrue("Moved children were not present in destination", children.containsAll(moving));
+	}
+
+	private Set<PID> getRelationSet(Element rdfRoot, Relationship relation) {
+		List<Element> containsEls = rdfRoot.getChild("Description", JDOMNamespaceUtil.RDF_NS).getChildren(
+				relation.name(), relation.getNamespace());
+		Set<PID> children = new HashSet<>();
+		for (Element containsEl : containsEls) {
+			children.add(new PID(containsEl.getAttributeValue("resource", JDOMNamespaceUtil.RDF_NS)));
+		}
+		return children;
+	}
+}

--- a/persistence/src/test/java/edu/unc/lib/dl/services/DigitalObjectManagerMoveTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/services/DigitalObjectManagerMoveTest.java
@@ -191,8 +191,7 @@ public class DigitalObjectManagerMoveTest {
 
 		doNothing().when(managementClient)
 				.modifyDatastream(eq(targetPID), eq(RELS_EXT.getName()), anyString(),
-				anyListOf(String.class),
-						anyString(), anyString(), argThat(sourceRelsExtMatcher));
+				anyString(), argThat(sourceRelsExtMatcher));
 
 		when(accessClient.getDatastreamDissemination(eq(targetPID), eq(RELS_EXT.getName()), anyString())).thenAnswer(
 				sourceRelsExtAnswer);
@@ -214,7 +213,7 @@ public class DigitalObjectManagerMoveTest {
 		ArgumentCaptor<Document> sourceRelsExtUpdateCaptor = ArgumentCaptor.forClass(Document.class);
 
 		verify(managementClient, times(2)).modifyDatastream(eq(source1PID), eq(RELS_EXT.getName()), anyString(),
-				anyListOf(String.class), anyString(), anyString(), sourceRelsExtUpdateCaptor.capture());
+				anyString(), sourceRelsExtUpdateCaptor.capture());
 
 		List<Document> sourceRelsAnswers = sourceRelsExtUpdateCaptor.getAllValues();
 		// Check the state of the source after removal but before cleanup
@@ -237,7 +236,7 @@ public class DigitalObjectManagerMoveTest {
 		verify(accessClient).getDatastreamDissemination(eq(destPID), eq(RELS_EXT.getName()), anyString());
 		ArgumentCaptor<Document> destRelsExtUpdateCaptor = ArgumentCaptor.forClass(Document.class);
 		verify(managementClient).modifyDatastream(eq(destPID), eq(RELS_EXT.getName()), anyString(),
-				anyListOf(String.class), anyString(), anyString(), destRelsExtUpdateCaptor.capture());
+				anyString(), destRelsExtUpdateCaptor.capture());
 		assertFalse("Moved children were still present in source", children.containsAll(moving));
 
 		Document destRelsExt = destRelsExtUpdateCaptor.getValue();
@@ -262,7 +261,7 @@ public class DigitalObjectManagerMoveTest {
 		oneSourceTest();
 
 		verify(managementClient).modifyDatastream(eq(source1PID), eq(MD_CONTENTS.getName()), anyString(),
-				anyListOf(String.class), anyString(), anyString(), any(Document.class));
+				anyString(), any(Document.class));
 	}
 
 	@Test
@@ -280,20 +279,20 @@ public class DigitalObjectManagerMoveTest {
 		doThrow(new OptimisticLockException(""))
 				.doNothing()
 				.when(managementClient)
-				.modifyDatastream(eq(source1PID), eq(RELS_EXT.getName()), anyString(), anyListOf(String.class),
-						anyString(), anyString(), argThat(sourceRelsExtMatcher));
+				.modifyDatastream(eq(source1PID), eq(RELS_EXT.getName()), anyString(), anyString(),
+						argThat(sourceRelsExtMatcher));
 
 		doThrow(new OptimisticLockException(""))
 				.doNothing()
 				.when(managementClient)
-				.modifyDatastream(eq(destPID), eq(RELS_EXT.getName()), anyString(), anyListOf(String.class), anyString(),
-						anyString(), any(Document.class));
+				.modifyDatastream(eq(destPID), eq(RELS_EXT.getName()), anyString(), anyString(),
+						any(Document.class));
 
 		doThrow(new OptimisticLockException(""))
 				.doNothing()
 				.when(managementClient)
-				.modifyDatastream(eq(source1PID), eq(MD_CONTENTS.getName()), anyString(), anyListOf(String.class),
-						anyString(), anyString(), any(Document.class));
+				.modifyDatastream(eq(source1PID), eq(MD_CONTENTS.getName()), anyString(), anyString(),
+						any(Document.class));
 
 		when(accessClient.getDatastreamDissemination(eq(source1PID), eq(RELS_EXT.getName()), anyString()))
 				.thenAnswer(sourceRelsExtAnswer);
@@ -309,7 +308,7 @@ public class DigitalObjectManagerMoveTest {
 		ArgumentCaptor<Document> sourceRelsExtUpdateCaptor = ArgumentCaptor.forClass(Document.class);
 
 		verify(managementClient, times(3)).modifyDatastream(eq(source1PID), eq(RELS_EXT.getName()), anyString(),
-				anyListOf(String.class), anyString(), anyString(), sourceRelsExtUpdateCaptor.capture());
+				anyString(), sourceRelsExtUpdateCaptor.capture());
 
 		List<Document> sourceRelsAnswers = sourceRelsExtUpdateCaptor.getAllValues();
 
@@ -332,7 +331,7 @@ public class DigitalObjectManagerMoveTest {
 		// Verify that the destination had the moved children added to it
 		ArgumentCaptor<Document> destRelsExtUpdateCaptor = ArgumentCaptor.forClass(Document.class);
 		verify(managementClient, times(2)).modifyDatastream(eq(destPID), eq(RELS_EXT.getName()), anyString(),
-				anyListOf(String.class), anyString(), anyString(), destRelsExtUpdateCaptor.capture());
+				anyString(), destRelsExtUpdateCaptor.capture());
 
 		Document destRelsExt = destRelsExtUpdateCaptor.getValue();
 		children = JDOMQueryUtil.getRelationSet(destRelsExt.getRootElement(), contains);
@@ -340,8 +339,7 @@ public class DigitalObjectManagerMoveTest {
 		assertTrue("Moved children were not present in destination", children.containsAll(moving));
 
 		verify(managementClient, times(2)).modifyDatastream(eq(source1PID), eq(MD_CONTENTS.getName()),
-				anyString(),
-				anyListOf(String.class), anyString(), anyString(), any(Document.class));
+				anyString(), anyString(), any(Document.class));
 	}
 
 	@Test
@@ -361,7 +359,7 @@ public class DigitalObjectManagerMoveTest {
 
 		ArgumentCaptor<Document> source1RelsExtUpdateCaptor = ArgumentCaptor.forClass(Document.class);
 		verify(managementClient, times(2)).modifyDatastream(eq(source1PID), eq(RELS_EXT.getName()), anyString(),
-				anyListOf(String.class), anyString(), anyString(), source1RelsExtUpdateCaptor.capture());
+				anyString(), source1RelsExtUpdateCaptor.capture());
 
 		// Check that the first source was updated
 		Document clean1RelsExt = source1RelsExtUpdateCaptor.getValue();
@@ -371,7 +369,7 @@ public class DigitalObjectManagerMoveTest {
 		// Check that the second source was updated
 		ArgumentCaptor<Document> source2RelsExtUpdateCaptor = ArgumentCaptor.forClass(Document.class);
 		verify(managementClient, times(2)).modifyDatastream(eq(source2PID), eq(RELS_EXT.getName()), anyString(),
-				anyListOf(String.class), anyString(), anyString(), source2RelsExtUpdateCaptor.capture());
+				anyString(), source2RelsExtUpdateCaptor.capture());
 		Document clean2RelsExt = source2RelsExtUpdateCaptor.getValue();
 		children = JDOMQueryUtil.getRelationSet(clean2RelsExt.getRootElement(), contains);
 		assertEquals("Incorrect number of children in source 2 after cleanup", 1, children.size());
@@ -379,7 +377,7 @@ public class DigitalObjectManagerMoveTest {
 		// Check that items from both source 1 and 2 ended up in the destination.
 		ArgumentCaptor<Document> destRelsExtUpdateCaptor = ArgumentCaptor.forClass(Document.class);
 		verify(managementClient).modifyDatastream(eq(destPID), eq(RELS_EXT.getName()), anyString(),
-				anyListOf(String.class), anyString(), anyString(), destRelsExtUpdateCaptor.capture());
+				anyString(), destRelsExtUpdateCaptor.capture());
 
 		Document destRelsExt = destRelsExtUpdateCaptor.getValue();
 		children = JDOMQueryUtil.getRelationSet(destRelsExt.getRootElement(), contains);
@@ -398,7 +396,7 @@ public class DigitalObjectManagerMoveTest {
 
 		// Verify that it doesn't try to change anything when there are no leftover tombstones
 		verify(managementClient, never()).modifyDatastream(eq(destPID), eq(RELS_EXT.getName()), anyString(),
-				anyListOf(String.class), anyString(), anyString(), any(Document.class));
+				anyString(), any(Document.class));
 	}
 
 	@Test
@@ -423,7 +421,7 @@ public class DigitalObjectManagerMoveTest {
 
 		// There should have been three updates to the source RELS-EXT, the initial, rollback the moved, and cleanup
 		verify(managementClient, times(3)).modifyDatastream(eq(source1PID), eq(RELS_EXT.getName()), anyString(),
-				anyListOf(String.class), anyString(), anyString(), sourceRelsExtUpdateCaptor.capture());
+				anyString(), sourceRelsExtUpdateCaptor.capture());
 
 		List<Document> sourceRelsAnswers = sourceRelsExtUpdateCaptor.getAllValues();
 		// Check the state of the source after removal but before cleanup
@@ -475,7 +473,7 @@ public class DigitalObjectManagerMoveTest {
 
 		// There should have been three updates to the source RELS-EXT, the initial, rollback the moved, and cleanup
 		verify(managementClient, times(3)).modifyDatastream(eq(source1PID), eq(RELS_EXT.getName()), anyString(),
-				anyListOf(String.class), anyString(), anyString(), sourceRelsExtUpdateCaptor.capture());
+				anyString(), sourceRelsExtUpdateCaptor.capture());
 
 		List<Document> sourceRelsAnswers = sourceRelsExtUpdateCaptor.getAllValues();
 		// Check the state of the source after removal but before cleanup
@@ -496,7 +494,7 @@ public class DigitalObjectManagerMoveTest {
 
 		ArgumentCaptor<Document> destRelsExtUpdateCaptor = ArgumentCaptor.forClass(Document.class);
 		verify(managementClient, times(2)).modifyDatastream(eq(destPID), eq(RELS_EXT.getName()), anyString(),
-				anyListOf(String.class), anyString(), anyString(), destRelsExtUpdateCaptor.capture());
+				anyString(), destRelsExtUpdateCaptor.capture());
 
 		List<Document> destRelsAnswers = destRelsExtUpdateCaptor.getAllValues();
 		// Check the state of the source after removal but before cleanup

--- a/persistence/src/test/resources/fedora/containerRELSEXT1.xml
+++ b/persistence/src/test/resources/fedora/containerRELSEXT1.xml
@@ -1,0 +1,26 @@
+
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+
+<rdf:Description rdf:about="info:fedora/uuid:container1">
+	<allowIndexing xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#">yes</allowIndexing>
+	<contains xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#" rdf:resource="info:fedora/uuid:child1"></contains>
+	<contains xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#" rdf:resource="info:fedora/uuid:child2"></contains>
+	<contains xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#" rdf:resource="info:fedora/uuid:child3"></contains>
+	<contains xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#" rdf:resource="info:fedora/uuid:child4"></contains>
+	<contains xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#" rdf:resource="info:fedora/uuid:child5"></contains>
+	<contains xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#" rdf:resource="info:fedora/uuid:child6"></contains>
+	<contains xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#" rdf:resource="info:fedora/uuid:child7"></contains>
+	<contains xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#" rdf:resource="info:fedora/uuid:child8"></contains>
+	<contains xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#" rdf:resource="info:fedora/uuid:child9"></contains>
+	<contains xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#" rdf:resource="info:fedora/uuid:child10"></contains>
+	<contains xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#" rdf:resource="info:fedora/uuid:child11"></contains>
+	<contains xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#" rdf:resource="info:fedora/uuid:child12"></contains>
+	<originalDeposit xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#" rdf:resource="info:fedora/uuid:record1"></originalDeposit>
+	<owner xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#" rdf:resource="info:fedora/uuid:owner"></owner>
+	<slug xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#">folder_1</slug>
+	<hasModel xmlns="info:fedora/fedora-system:def/model#" rdf:resource="info:fedora/cdr-model:Collection"></hasModel>
+	<hasModel xmlns="info:fedora/fedora-system:def/model#" rdf:resource="info:fedora/cdr-model:Container"></hasModel>
+	<hasModel xmlns="info:fedora/fedora-system:def/model#" rdf:resource="info:fedora/cdr-model:PreservedObject"></hasModel>
+</rdf:Description>
+
+</rdf:RDF>

--- a/persistence/src/test/resources/fedora/containerRELSEXT2.xml
+++ b/persistence/src/test/resources/fedora/containerRELSEXT2.xml
@@ -1,0 +1,20 @@
+
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+
+<rdf:Description rdf:about="info:fedora/uuid:container2">
+	<allowIndexing xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#">yes</allowIndexing>
+	<contains xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#" rdf:resource="info:fedora/uuid:child21"></contains>
+	<contains xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#" rdf:resource="info:fedora/uuid:child22"></contains>
+	<contains xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#" rdf:resource="info:fedora/uuid:child23"></contains>
+	<contains xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#" rdf:resource="info:fedora/uuid:child24"></contains>
+	<contains xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#" rdf:resource="info:fedora/uuid:child25"></contains>
+	<contains xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#" rdf:resource="info:fedora/uuid:child26"></contains>
+	<contains xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#" rdf:resource="info:fedora/uuid:child27"></contains>
+	<originalDeposit xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#" rdf:resource="info:fedora/uuid:record1"></originalDeposit>
+	<owner xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#" rdf:resource="info:fedora/uuid:owner"></owner>
+	<slug xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#">folder_1</slug>
+	<hasModel xmlns="info:fedora/fedora-system:def/model#" rdf:resource="info:fedora/cdr-model:Container"></hasModel>
+	<hasModel xmlns="info:fedora/fedora-system:def/model#" rdf:resource="info:fedora/cdr-model:PreservedObject"></hasModel>
+</rdf:Description>
+
+</rdf:RDF>

--- a/persistence/src/test/resources/fedora/containerRELSEXT3.xml
+++ b/persistence/src/test/resources/fedora/containerRELSEXT3.xml
@@ -1,0 +1,15 @@
+
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+
+<rdf:Description rdf:about="info:fedora/uuid:container3">
+	<allowIndexing xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#">yes</allowIndexing>
+	<contains xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#" rdf:resource="info:fedora/uuid:child31"></contains>
+	<contains xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#" rdf:resource="info:fedora/uuid:child32"></contains>
+	<originalDeposit xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#" rdf:resource="info:fedora/uuid:record1"></originalDeposit>
+	<owner xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#" rdf:resource="info:fedora/uuid:owner"></owner>
+	<slug xmlns="http://cdr.unc.edu/definitions/1.0/base-model.xml#">folder_3</slug>
+	<hasModel xmlns="info:fedora/fedora-system:def/model#" rdf:resource="info:fedora/cdr-model:Container"></hasModel>
+	<hasModel xmlns="info:fedora/fedora-system:def/model#" rdf:resource="info:fedora/cdr-model:PreservedObject"></hasModel>
+</rdf:Description>
+
+</rdf:RDF>

--- a/persistence/src/test/resources/fedora/mdContents1.xml
+++ b/persistence/src/test/resources/fedora/mdContents1.xml
@@ -1,0 +1,17 @@
+<m:structMap xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:m="http://www.loc.gov/METS/">
+	<m:div TYPE="Container">
+		<m:div ID="uuid:child1" ORDER="1"></m:div>
+		<m:div ID="uuid:child2" ORDER="2"></m:div>
+		<m:div ID="uuid:child3" ORDER="3"></m:div>
+		<m:div ID="uuid:child4" ORDER="4"></m:div>
+		<m:div ID="uuid:child5" ORDER="5"></m:div>
+		<m:div ID="uuid:child6" ORDER="6"></m:div>
+		<m:div ID="uuid:child7" ORDER="7"></m:div>
+		<m:div ID="uuid:child8" ORDER="8"></m:div>
+		<m:div ID="uuid:child9" ORDER="9"></m:div>
+		<m:div ID="uuid:child10" ORDER="10"></m:div>
+		<m:div ID="uuid:child11" ORDER="11"></m:div>
+		<m:div ID="uuid:child12" ORDER="12"></m:div>
+	</m:div>
+</m:structMap>

--- a/persistence/src/test/resources/service-context.xml
+++ b/persistence/src/test/resources/service-context.xml
@@ -28,9 +28,17 @@
 	<bean id="managementClient" class="org.mockito.Mockito" factory-method="mock">
 		<constructor-arg index="0" value="edu.unc.lib.dl.fedora.ManagementClient"/>
 	</bean>
+	
+	<bean id="forwardedManagementClient" class="org.mockito.Mockito" factory-method="mock">
+		<constructor-arg index="0" value="edu.unc.lib.dl.fedora.ManagementClient"/>
+	</bean>
 
 	<bean id="accessClient" class="org.mockito.Mockito" factory-method="mock">
 		<constructor-arg value="edu.unc.lib.dl.fedora.AccessClient"/>
+	</bean>
+	
+	<bean id="accessControlService" class="org.mockito.Mockito" factory-method="mock">
+		<constructor-arg value="edu.unc.lib.dl.fedora.FedoraAccessControlService"/>
 	</bean>
 
 	<bean id="jmsTemplate" factory-method="mock" class="org.mockito.Mockito">
@@ -44,7 +52,9 @@
 
 	<bean id="digitalObjectManager" class="edu.unc.lib.dl.services.DigitalObjectManagerImpl">
 		<property name="managementClient" ref="managementClient"/>
+		<property name="forwardedManagementClient" ref="forwardedManagementClient"/>
 		<property name="accessClient" ref="accessClient"/>
+		<property name="aclService" ref="accessControlService"/>
 		<property name="operationsMessageSender" ref="operationsMessageSender"/>
 		<property name="tripleStoreQueryService" ref="tripleStoreQueryService"/>
 		<property name="schematronValidator" ref="schematronValidator"/>

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/processing/MoveRollbackJob.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/processing/MoveRollbackJob.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.cdr.services.processing;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.ingest.IngestException;
+import edu.unc.lib.dl.services.DigitalObjectManager;
+import edu.unc.lib.dl.util.ContentModelHelper;
+import edu.unc.lib.dl.util.TripleStoreQueryService;
+
+/**
+ * Task which seeks out any previously failed move operations and attempts to roll them back
+ *
+ * @author bbpennel
+ * @date Feb 12, 2015
+ */
+public class MoveRollbackJob {
+
+	private static final Logger log = LoggerFactory.getLogger(MoveRollbackJob.class);
+
+	@Autowired
+	private TripleStoreQueryService queryService;
+	@Autowired
+	private DigitalObjectManager objectManager;
+
+	private final String REMOVE_CHILD_QUERY = "select $parent $child from <%1$s> where $parent <%2$s> $child;";
+
+	/**
+	 * Seeks out containers with leftover removed children placeholders and attempts to roll back move operations
+	 */
+	public void rollbackAllFailed() {
+
+		Map<PID, List<PID>> removedMap = getRemovedMap();
+		if (removedMap.size() == 0) {
+			log.info("No failed move operations were found");
+		}
+		log.info("Attempting to rollback move operations from {} sources", removedMap.size());
+
+		for (Entry<PID, List<PID>> removedEntry : removedMap.entrySet()) {
+			try {
+				objectManager.rollbackMove(removedEntry.getKey(), removedEntry.getValue());
+			} catch (IngestException e) {
+				log.error("Failed to rollback previous move operation from {}", removedEntry.getKey(), e);
+			}
+		}
+
+	}
+
+	private Map<PID, List<PID>> getRemovedMap() {
+		String query = String.format(
+				REMOVE_CHILD_QUERY,
+				queryService.getResourceIndexModelUri(),
+				ContentModelHelper.Relationship.removedChild.toString());
+
+		Map<PID, List<PID>> parentToRemoved = new HashMap<>();
+		List<List<String>> response = queryService.queryResourceIndex(query);
+
+		if (!response.isEmpty()) {
+			for (List<String> values : response) {
+				PID parent = new PID(values.get(0));
+				PID child = new PID(values.get(1));
+
+				List<PID> removed = parentToRemoved.get(parent);
+				if (removed == null) {
+					removed = new ArrayList<>();
+					parentToRemoved.put(parent, removed);
+				}
+				removed.add(child);
+			}
+		}
+		return parentToRemoved;
+	}
+
+}

--- a/services/src/main/webapp/WEB-INF/service-context.xml
+++ b/services/src/main/webapp/WEB-INF/service-context.xml
@@ -324,6 +324,13 @@
 		<property name="targetMethod" value="cleanupFinishedMessages" />
 	</bean>
 	
+	<bean id="rollbackMoveJob" class="edu.unc.lib.dl.cdr.services.processing.MoveRollbackJob"></bean>
+	
+	<bean id="rollbackMoveJobDetail" class="org.springframework.scheduling.quartz.MethodInvokingJobDetailFactoryBean">
+		<property name="targetObject" ref="rollbackMoveJob" />
+		<property name="targetMethod" value="rollbackAllFailed" />
+	</bean>
+	
 	<bean id="embargoCronTrigger" class="org.springframework.scheduling.quartz.CronTriggerBean">
 		<property name="jobDetail" ref="embargoJobDetail" />
 		<property name="cronExpression" value="${scheduled.embargoUpdate.cron}" />
@@ -344,6 +351,12 @@
 		<property name="cronExpression" value="${scheduled.cleanupFinishedEnhancements.cron}" />
 	</bean>
 	
+	<bean id="moveRollbackTrigger" class="org.springframework.scheduling.quartz.SimpleTriggerBean">
+		<property name="jobDetail" ref="rollbackMoveJobDetail" />
+		<property name="repeatCount" value="0"/>
+		<property name="repeatInterval" value="1"/>
+	</bean>
+	
 	<bean class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
 		<property name="triggers">
 			<list>
@@ -351,6 +364,7 @@
 				<ref bean="catchUpActivateCronTrigger" />
 				<ref bean="catchUpDeactivateCronTrigger" />
 				<ref bean="cleanupFinishedEnhancementsCronTrigger" />
+				<ref bean="moveRollbackTrigger" />
 			</list>
 		</property>
 		<property name="autoStartup">

--- a/services/src/main/webapp/WEB-INF/sword-servlet.xml
+++ b/services/src/main/webapp/WEB-INF/sword-servlet.xml
@@ -66,6 +66,7 @@
 		<property name="forwardedManagementClient" ref="forwardedManagementClient"/>
 		<property name="accessClient" ref="accessClient"/>
 		<property name="operationsMessageSender" ref="operationsMessageSender"/>
+		<property name="aclService" ref="accessControlService"/>
 		<property name="tripleStoreQueryService" ref="tripleStoreQueryService"/>
 		<property name="schematronValidator" ref="schematronValidator"/>
 		<property name="available" value="true"/>

--- a/services/src/main/webapp/WEB-INF/sword-servlet.xml
+++ b/services/src/main/webapp/WEB-INF/sword-servlet.xml
@@ -62,7 +62,8 @@
 	</bean>
 	
 	<bean id="digitalObjectManager" class="edu.unc.lib.dl.services.DigitalObjectManagerImpl">
-		<property name="managementClient" ref="forwardedManagementClient"/>
+		<property name="managementClient" ref="managementClient"/>
+		<property name="forwardedManagementClient" ref="forwardedManagementClient"/>
 		<property name="accessClient" ref="accessClient"/>
 		<property name="operationsMessageSender" ref="operationsMessageSender"/>
 		<property name="tripleStoreQueryService" ref="tripleStoreQueryService"/>


### PR DESCRIPTION
Refactored the move operation to happen as three RELS-EXT datastream updates instead of addRelationship/removeRelationship per item.  Implemented an automatic rollback mechanism that will attempt to undo the move, either immediately or after a server restart