### PR TITLE
Using jodatime utilities to handle UTC parsing, fixed bug which caused r...

### DIFF
--- a/metadata/pom.xml
+++ b/metadata/pom.xml
@@ -74,7 +74,7 @@
 		<dependency>
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>
-			<version>1.6.2</version>
+			<version>2.7</version>
 		</dependency>
 		<dependency>
 			<groupId>xerces</groupId>

--- a/metadata/src/main/java/edu/unc/lib/dl/util/DateTimeUtil.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/util/DateTimeUtil.java
@@ -33,76 +33,22 @@ import org.joda.time.format.ISODateTimeFormat;
  */
 public class DateTimeUtil {
 
-	/**
-	 * Parse a date in any ISO 8601 format. Default TZ is based on Locale.
-	 *
-	 * @param isoDate
-	 *           ISO8601 date/time string with or without TZ offset
-	 * @return a Joda DateTime object in UTC (call toString() to print)
-	 */
-	public static DateTime parseISO8601toUTC(String isoDate) {
-		DateTime result = null;
-		DateTimeFormatter fmt = ISODateTimeFormat.dateTimeParser().withOffsetParsed();
-		// TODO what about preserving the precision of the original?
-		DateTime isoDT = fmt.parseDateTime(isoDate);
-		if (isoDT.year().get() > 9999) {
-			// you parsed my month as part of the year!
-			try {
-				fmt = DateTimeFormat.forPattern("yyyyMMdd");
-				fmt = fmt.withZone(DateTimeZone.forID("America/New_York"));
-				isoDT = fmt.parseDateTime(isoDate);
-			} catch (IllegalArgumentException e) {
-				try {
-					fmt = DateTimeFormat.forPattern("yyyyMM");
-					fmt = fmt.withZone(DateTimeZone.forID("America/New_York"));
-					isoDT = fmt.parseDateTime(isoDate);
-				} catch (IllegalArgumentException e1) {
-					try {
-						fmt = DateTimeFormat.forPattern("yyyy");
-						fmt = fmt.withZone(DateTimeZone.forID("America/New_York"));
-						isoDT = fmt.parseDateTime(isoDate);
-					} catch (IllegalArgumentException ignored) {
-						// I guess we go with first parse?
-					}
-				}
-			}
-		}
-		result = isoDT.withZoneRetainFields(DateTimeZone.forID("Etc/UTC"));
-		return result;
-	}
-
 	public final static DateTimeFormatter utcFormatter = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
 			.withZone(DateTimeZone.UTC);
-	public final static DateTimeFormatter utcYFormatter = DateTimeFormat.forPattern("yyyy").withZone(DateTimeZone.UTC);
 	public final static DateTimeFormatter utcYMDFormatter = DateTimeFormat.forPattern("yyyy-MM-dd").withZone(
 			DateTimeZone.UTC);
-	public final static DateTimeFormatter utcYMDHMSFormatter = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss")
-			.withZone(DateTimeZone.UTC);
+
+	public static Date parseUTCDateToDate(String utcDate) throws ParseException {
+		return ISODateTimeFormat.dateParser().parseDateTime(utcDate).toDate();
+	}
 
 	public static Date parseUTCToDate(String utcDate) throws ParseException {
-		DateTime dateTime = utcFormatter.parseDateTime(utcDate);
-		return dateTime.toDate();
+		return parseUTCToDateTime(utcDate).toDate();
 	}
 
-	public static Date parsePartialUTCToDate(String utcDate) throws ParseException {
-		return parsePartialUTCToDateTime(utcDate).toDate();
-	}
-
-	public static DateTime parsePartialUTCToDateTime(String utcDate) throws ParseException {
-		if (utcDate.length() == 4) {
-			DateTime dateTime = utcYFormatter.parseDateTime(utcDate);
-			return dateTime;
-		}
-		if (utcDate.length() == 10) {
-			DateTime dateTime = utcYMDFormatter.parseDateTime(utcDate);
-			return dateTime;
-		}
-		if (utcDate.length() == 19) {
-			DateTime dateTime = utcYMDHMSFormatter.parseDateTime(utcDate);
-			return dateTime;
-		}
-		DateTime dateTime = utcFormatter.parseDateTime(utcDate);
-		return dateTime;
+	public static DateTime parseUTCToDateTime(String utcDate) throws IllegalArgumentException {
+		DateTime isoDT = ISODateTimeFormat.dateTimeParser().withOffsetParsed().parseDateTime(utcDate);
+		return isoDT.withZone(DateTimeZone.forID("UTC"));
 	}
 
 	public static String formatDateToUTC(Date date) throws ParseException {

--- a/metadata/src/main/java/edu/unc/lib/dl/xml/JDOMQueryUtil.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/xml/JDOMQueryUtil.java
@@ -61,7 +61,7 @@ public class JDOMQueryUtil {
 		String dateString = parent.getChildText(childName, namespace);
 		if (dateString != null) {
 			try {
-				return DateTimeUtil.parsePartialUTCToDate(dateString);
+				return DateTimeUtil.parseUTCToDate(dateString);
 			} catch (ParseException e) {
 				// Wasn't a valid date, ignore it.
 			} catch (IllegalArgumentException e) {

--- a/metadata/src/test/java/edu/unc/lib/dl/util/DateTimeUtilTest.java
+++ b/metadata/src/test/java/edu/unc/lib/dl/util/DateTimeUtilTest.java
@@ -18,12 +18,13 @@
  */
 package edu.unc.lib.dl.util;
 
+import java.util.Date;
+
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -32,50 +33,103 @@ import org.junit.Test;
  */
 public class DateTimeUtilTest extends Assert {
 
-    /**
-     * @throws java.lang.Exception
-     */
-    @BeforeClass
-    public static void setUpBeforeClass() throws Exception {
-    }
+	private final DateTimeZone defaultTimeZone = DateTimeZone.getDefault();
 
-    /**
-     * @throws java.lang.Exception
-     */
-    @AfterClass
-    public static void tearDownAfterClass() throws Exception {
-    }
+	@Before
+	public void init() {
+		DateTimeZone.setDefault(DateTimeZone.forID("EST"));
+	}
 
-    /**
-     * @throws java.lang.Exception
-     */
-    @Before
-    public void setUp() throws Exception {
-    }
+	@After
+	public void after() {
+		DateTimeZone.setDefault(defaultTimeZone);
+	}
 
-    /**
-     * @throws java.lang.Exception
-     */
-    @After
-    public void tearDown() throws Exception {
-    }
+	@Test
+	public void utcToDateTest() throws Exception {
+		Date plainDate = DateTimeUtil.parseUTCDateToDate("2001");
+		DateTime date = new DateTime(plainDate.getTime());
+		assertEquals(2001, date.getYear());
 
-    /**
-     * Test method for {@link edu.unc.lib.dl.util.DateTimeUtil#parseISO8601(java.lang.String)}.
-     */
-    @Test
-    public void testParseISO8601() {
-	String test = "2008-05-04T14:24:18-05:00";
-	DateTime dt = DateTimeUtil.parseISO8601toUTC(test);
-	System.err.println("Is this UTC for "+test+"? "+dt);
+		plainDate = DateTimeUtil.parseUTCDateToDate("2001-05-08");
+		date = new DateTime(plainDate.getTime());
+		assertEquals(2001, date.getYear());
+		assertEquals(5, date.getMonthOfYear());
+		assertEquals(8, date.getDayOfMonth());
 
-	test = "200805";
-	dt = DateTimeUtil.parseISO8601toUTC(test);
-	System.err.println("Is this UTC for "+test+"? "+dt);
+		try {
+			plainDate = DateTimeUtil.parseUTCDateToDate("2002-02-01T12:13:14");
+			fail();
+		} catch (IllegalArgumentException e) {
+		}
+	}
 
-	test = "2008-05";
-	dt = DateTimeUtil.parseISO8601toUTC(test);
-	System.err.println("Is this UTC for "+test+"? "+dt);
-    }
+	@Test
+	public void utcToDateTimeTest() throws Exception {
+		DateTime date = DateTimeUtil.parseUTCToDateTime("2001");
+		assertEquals(2001, date.getYear());
+
+		date = DateTimeUtil.parseUTCToDateTime("2001-05-08");
+		assertEquals(2001, date.getYear());
+		assertEquals(5, date.getMonthOfYear());
+		assertEquals(8, date.getDayOfMonth());
+
+		date = DateTimeUtil.parseUTCToDateTime("2002-02-01T12:13:14");
+		assertEquals(2002, date.getYear());
+		assertEquals(2, date.getMonthOfYear());
+		assertEquals(1, date.getDayOfMonth());
+		assertEquals(17, date.getHourOfDay());
+		assertEquals(13, date.getMinuteOfHour());
+		assertEquals(14, date.getSecondOfMinute());
+
+		date = DateTimeUtil.parseUTCToDateTime("2004-02-04T12:13:14.005");
+		assertEquals(2004, date.getYear());
+		assertEquals(2, date.getMonthOfYear());
+		assertEquals(4, date.getDayOfMonth());
+		assertEquals(17, date.getHourOfDay());
+		assertEquals(13, date.getMinuteOfHour());
+		assertEquals(14, date.getSecondOfMinute());
+		assertEquals(5, date.getMillisOfSecond());
+
+		date = DateTimeUtil.parseUTCToDateTime("2004-02-04T12:13:14+04:00");
+		date = date.withZone(DateTimeZone.forID("UTC"));
+		assertEquals(2004, date.getYear());
+		assertEquals(2, date.getMonthOfYear());
+		assertEquals(4, date.getDayOfMonth());
+		assertEquals(8, date.getHourOfDay());
+		assertEquals(13, date.getMinuteOfHour());
+		assertEquals(14, date.getSecondOfMinute());
+		assertEquals(0, date.getMillisOfSecond());
+
+		date = DateTimeUtil.parseUTCToDateTime("2004-02-04T12:13:14.005Z");
+		assertEquals(2004, date.getYear());
+		assertEquals(2, date.getMonthOfYear());
+		assertEquals(4, date.getDayOfMonth());
+		assertEquals(12, date.getHourOfDay());
+		assertEquals(13, date.getMinuteOfHour());
+		assertEquals(14, date.getSecondOfMinute());
+		assertEquals(5, date.getMillisOfSecond());
+
+		date = DateTimeUtil.parseUTCToDateTime("2004-02-04T12:13Z");
+		assertEquals(2004, date.getYear());
+		assertEquals(2, date.getMonthOfYear());
+		assertEquals(4, date.getDayOfMonth());
+		assertEquals(12, date.getHourOfDay());
+		assertEquals(13, date.getMinuteOfHour());
+		assertEquals(0, date.getSecondOfMinute());
+		assertEquals(0, date.getMillisOfSecond());
+
+		try {
+			date = DateTimeUtil.parseUTCToDateTime("not even close");
+			fail();
+		} catch (IllegalArgumentException e) {
+		}
+	}
+
+	@Test
+	public void formatDateToUTCTest() throws Exception {
+		Date date = new Date(1407470400000L);
+		assertEquals("2014-08-08T04:00:00.000Z", DateTimeUtil.formatDateToUTC(date));
+	}
 
 }

--- a/security/src/main/java/edu/unc/lib/dl/acl/util/ObjectAccessControlsBean.java
+++ b/security/src/main/java/edu/unc/lib/dl/acl/util/ObjectAccessControlsBean.java
@@ -212,7 +212,7 @@ public class ObjectAccessControlsBean {
 			this.activeEmbargoes = new ArrayList<Date>(embargoes.size());
 			for (String embargo : embargoes) {
 				try {
-					this.activeEmbargoes.add(DateTimeUtil.parsePartialUTCToDate(embargo));
+					this.activeEmbargoes.add(DateTimeUtil.parseUTCToDate(embargo));
 				} catch (ParseException e) {
 					LOG.warn("Failed to parse embargo " + embargo, e);
 				} catch (IllegalArgumentException e) {

--- a/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetAccessControlFilter.java
+++ b/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetAccessControlFilter.java
@@ -108,7 +108,7 @@ public class SetAccessControlFilter extends AbstractIndexDocumentFilter {
 		String embargo = getFirstTripleValue(triples, ContentModelHelper.CDRProperty.embargoUntil.toString());
 		if (embargo != null) {
 			try {
-				Date embargoDate = DateTimeUtil.parsePartialUTCToDate(embargo);
+				Date embargoDate = DateTimeUtil.parseUTCToDate(embargo);
 				Date currentDate = new Date();
 				if (currentDate.before(embargoDate))
 					status.add("Embargoed");

--- a/solr-ingest/src/test/java/edu/unc/lib/dl/data/ingest/solr/filter/SetDescriptiveMetadataFilterTest.java
+++ b/solr-ingest/src/test/java/edu/unc/lib/dl/data/ingest/solr/filter/SetDescriptiveMetadataFilterTest.java
@@ -90,7 +90,7 @@ public class SetDescriptiveMetadataFilterTest {
 		assertEquals("BMC Bioinformatics. 2008 May 19;9(1):241", idb.getCitation());
 
 		assertEquals("English", idb.getLanguage().get(0));
-		assertEquals(DateTimeUtil.parseUTCToDate("2008-05-19T00:00:00.000Z"), idb.getDateCreated());
+		assertEquals(DateTimeUtil.parseUTCToDate("2008-05-19T00:00:00.000"), idb.getDateCreated());
 		assertTrue(idb.getIdentifier().contains("pmpid|18489778"));
 		assertTrue(idb.getIdentifier().contains("doi|10.1186/1471-2105-9-241"));
 

--- a/solr-search/src/main/java/edu/unc/lib/dl/search/solr/model/BriefObjectMetadataBean.java
+++ b/solr-search/src/main/java/edu/unc/lib/dl/search/solr/model/BriefObjectMetadataBean.java
@@ -307,7 +307,7 @@ public class BriefObjectMetadataBean extends IndexDocumentBean implements BriefO
 			for (String embargo : embargoUntil) {
 				Date embargoDate;
 				try {
-					embargoDate = DateTimeUtil.parsePartialUTCToDate(embargo);
+					embargoDate = DateTimeUtil.parseUTCToDate(embargo);
 					if (embargoDate.after(dateNow)) {
 						if (result == null || embargoDate.after(result)) {
 							result = embargoDate;


### PR DESCRIPTION
...esults pages not to load when embargoes unexpectedly had Z's on them.  Updated jodatime to 2.7