### PR TITLE
Introduce resubmitting ingests

### DIFF
--- a/access/src/main/external/static/css/admin/admin_forms.css
+++ b/access/src/main/external/static/css/admin/admin_forms.css
@@ -78,6 +78,10 @@
 	text-align: left;
 }
 
+.edit_form .error_message {
+	text-align: left;
+}
+
 .edit_form p {
 	padding-top: 7px;
 	text-align: left;

--- a/access/src/main/external/static/css/cdr_admin.css
+++ b/access/src/main/external/static/css/cdr_admin.css
@@ -3411,6 +3411,10 @@ h1 {
 	text-align: left;
 }
 
+.edit_form .error_message {
+	text-align: left;
+}
+
 .edit_form p {
 	padding-top: 7px;
 	text-align: left;

--- a/access/src/main/external/static/js/admin/src/ResubmitPackageForm.js
+++ b/access/src/main/external/static/js/admin/src/ResubmitPackageForm.js
@@ -1,0 +1,48 @@
+/**
+ * Implements functionality and UI for the Resubmit Package form
+ */
+define('ResubmitPackageForm', [ 'jquery', 'jquery-ui', 'underscore', 'RemoteStateChangeMonitor', 'tpl!../templates/admin/resubmitPackageForm', 
+		'ModalLoadingOverlay', 'ConfirmationDialog', 'AbstractFileUploadForm'], 
+		function($, ui, _, RemoteStateChangeMonitor, resubmitPackageTemplate, ModalLoadingOverlay, ConfirmationDialog, AbstractFileUploadForm) {
+	
+	var defaultOptions = {
+			title : 'Resubmit Ingest Package',
+			createFormTemplate : resubmitPackageTemplate
+	};
+	
+	function ResubmitPackageForm(options) {
+		this.options = $.extend({}, AbstractFileUploadForm.prototype.getDefaultOptions(), defaultOptions, options);
+	};
+	
+	ResubmitPackageForm.prototype.constructor = ResubmitPackageForm;
+	ResubmitPackageForm.prototype = Object.create( AbstractFileUploadForm.prototype );
+	
+	// Validate the form and retrieve any errors
+	ResubmitPackageForm.prototype.validationErrors = function() {
+		var errors = [];
+		var packageFile = $("input[type='file']", this.$form).val();
+		if (!packageFile) {
+			errors.push("You must select an ingest package file to resubmit.");
+		}
+		return errors;
+	};
+	
+	ResubmitPackageForm.prototype.getSuccessMessage = function(data) {
+		return "The ingest package " + this.ingestFile.name + " has been successfully resubmitted. You will receive an email when it completes.";
+	};
+	
+	ResubmitPackageForm.prototype.getErrorMessage = function(data) {
+		if (data && data.error && !this.closed) {
+			this.setError(data.error);
+		}
+		return "Failed to resubmit ingest package " + this.ingestFile.name + ".";
+	};
+	
+	ResubmitPackageForm.prototype.setError = function(message) {
+		$(".errors", this.$form).show();
+		$(".error_message", this.$form).html(message);
+		this.dialog.dialog("option", "position", "center");
+	};
+	
+	return ResubmitPackageForm;
+});

--- a/access/src/main/external/static/js/admin/src/statusMonitor/DepositMonitor.js
+++ b/access/src/main/external/static/js/admin/src/statusMonitor/DepositMonitor.js
@@ -1,5 +1,5 @@
-define('DepositMonitor', [ 'jquery', 'jquery-ui', 'underscore', 'AbstractStatusMonitor', 'tpl!../templates/admin/statusMonitor/depositMonitorJob', 'tpl!../templates/admin/statusMonitor/depositMonitorJobDetails'],
-		function($, ui, _, AbstractStatusMonitor, depositMonitorJobTemplate, depositMonitorDetailsTemplate) {
+define('DepositMonitor', [ 'jquery', 'jquery-ui', 'underscore', 'AbstractStatusMonitor', 'tpl!../templates/admin/statusMonitor/depositMonitorJob', 'tpl!../templates/admin/statusMonitor/depositMonitorJobDetails', 'ResubmitPackageForm'],
+		function($, ui, _, AbstractStatusMonitor, depositMonitorJobTemplate, depositMonitorDetailsTemplate, ResubmitPackageForm) {
 			
 	var defaultOptions = {
 		name : "deposit",
@@ -41,6 +41,17 @@ define('DepositMonitor', [ 'jquery', 'jquery-ui', 'underscore', 'AbstractStatusM
 			$.post($this.attr("href"), function(){
 				
 			});
+			return false;
+		});
+		
+		var resubmitPackageForm = new ResubmitPackageForm({
+			alertHandler : this.options.alertHandler
+		});
+		
+		$(this.element).on("click", ".resubmit_action", function() {
+			var $this = $(this);
+			// FIXME: prepending "uuid:" is a hack??
+			resubmitPackageForm.open("uuid:" + $this.data("uuid"));
 			return false;
 		});
 	};

--- a/access/src/main/external/static/js/admin/src/statusMonitor/StatusMonitorManager.js
+++ b/access/src/main/external/static/js/admin/src/statusMonitor/StatusMonitorManager.js
@@ -2,6 +2,9 @@ define('StatusMonitorManager', [ 'jquery', 'jquery-ui', 'underscore', 'DepositMo
 		function($, ui, _, DepositMonitor, IndexingMonitor, EnhancementMonitor) {
 			
 	function StatusMonitorManager(element, options) {
+		this.$alertHandler = $("<div id='alertHandler'></div>");
+		this.$alertHandler.alertHandler().appendTo(document.body).hide();
+		
 		this.element = element;
 		this.options = options;
 		this.tabList = $("<ul/>").attr("id", "status_monitor_tabs").appendTo(this.element);
@@ -35,7 +38,7 @@ define('StatusMonitorManager', [ 'jquery', 'jquery-ui', 'underscore', 'DepositMo
 	};
 	
 	StatusMonitorManager.prototype.addMonitors = function() {
-		this.addMonitor(new DepositMonitor(this.options));
+		this.addMonitor(new DepositMonitor($.extend({}, { alertHandler: this.$alertHandler }, this.options)));
 		this.addMonitor(new IndexingMonitor());
 		this.addMonitor(new EnhancementMonitor());
 	};

--- a/access/src/main/external/static/js/admin/statusMonitor.js
+++ b/access/src/main/external/static/js/admin/statusMonitor.js
@@ -15,6 +15,8 @@ require.config({
 		'IndexingMonitor' : 'cdr-admin',
 		'EnhancementMonitor' : 'cdr-admin',
 		'URLUtilities' : 'cdr-admin',
+		
+		"editable" : "admin/lib/jqueryui-editable.min",
 		'moment' : 'cdr-admin'
 	},
 	shim: {

--- a/access/src/main/external/static/templates/admin/resubmitPackageForm.html
+++ b/access/src/main/external/static/templates/admin/resubmitPackageForm.html
@@ -1,0 +1,17 @@
+<iframe id="upload_file_frame" name="upload_file_frame" height="0" width="0" style="display: none;"></iframe>
+<form id="resubmit_package_form" method="post" action="ingest/<%= pid %>/resubmit" enctype="multipart/form-data" target="upload_file_frame" class="edit_form">
+	<h3>Package</h3>
+	<div class="form_field">
+		<label>Package</label>
+		<input type="file" id="resubmit_package_file" name="file"/>
+		<div class="file_info">&nbsp;</div>
+	</div>
+	<div class="update_field">
+		<input type="submit" id="resubmit_package_button" class="update_button" value="Resubmit" />
+	</div>
+	<div class="errors">
+		<h3>Errors</h3>
+		<div class="error_message">
+		</div>
+	</div>
+</form>

--- a/access/src/main/external/static/templates/admin/statusMonitor/depositMonitorJobDetails.html
+++ b/access/src/main/external/static/templates/admin/statusMonitor/depositMonitorJobDetails.html
@@ -2,6 +2,10 @@
 	<h3>Details for ingest</h3> (<span class="<%= data.state.toLowerCase() %>"><%= data.state %></span>, refreshed <%= moment().format('h:mm:ssa') %>)
 
 	<% if (isAdmin || data.depositorName == username) { %>
+	<% if (data.state == "failed") { %>
+		<p><a href="#" class="resubmit_action" data-uuid="<%= data.uuid %>">Resubmit</a></p>
+	<% } %>
+  
 	<% if (data.state == "failed" || data.state == "paused") { %>
 		<p><a href="/services/api/edit/deposit/<%= data.uuid %>?action=resume" class="monitor_action">Resume</a></p>
 	<% } %>

--- a/access/src/main/external/static/templates/admin/statusMonitor/depositMonitorJobDetails.html
+++ b/access/src/main/external/static/templates/admin/statusMonitor/depositMonitorJobDetails.html
@@ -2,11 +2,8 @@
 	<h3>Details for ingest</h3> (<span class="<%= data.state.toLowerCase() %>"><%= data.state %></span>, refreshed <%= moment().format('h:mm:ssa') %>)
 
 	<% if (isAdmin || data.depositorName == username) { %>
-	<% if (data.state == "failed") { %>
-		<p><a href="#" class="resubmit_action" data-uuid="<%= data.uuid %>">Resubmit</a></p>
-	<% } %>
-  
 	<% if (data.state == "failed" || data.state == "paused") { %>
+		<p><a href="#" class="resubmit_action" data-uuid="<%= data.uuid %>">Resubmit</a></p>
 		<p><a href="/services/api/edit/deposit/<%= data.uuid %>?action=resume" class="monitor_action">Resume</a></p>
 	<% } %>
 	

--- a/admin/src/main/java/edu/unc/lib/dl/admin/controller/ResubmitIngestController.java
+++ b/admin/src/main/java/edu/unc/lib/dl/admin/controller/ResubmitIngestController.java
@@ -73,14 +73,14 @@ public class ResubmitIngestController {
 		}
 		
 		
-		// Check that the deposit is in the failed state
+		// Check that the deposit is in the failed or paused state
 		
 		String state = status.get(DepositField.state.name());
 		
-		if (state == null || !state.equals(DepositState.failed.name())) {
+		if (state == null || !(state.equals(DepositState.failed.name()) || state.equals(DepositState.paused.name()))) {
 			response.setStatus(400);
-			result.put("error", "The deposit isn't in the failed state.");
-			log.error("Tried to resubmit deposit {} but it isn't in the failed state", depositPid);
+			result.put("error", "The deposit must be paused or failed.");
+			log.error("Tried to resubmit deposit {} but it isn't in the failed or paused state", depositPid);
 			return result;
 		}
 		

--- a/admin/src/main/java/edu/unc/lib/dl/admin/controller/ResubmitIngestController.java
+++ b/admin/src/main/java/edu/unc/lib/dl/admin/controller/ResubmitIngestController.java
@@ -1,0 +1,176 @@
+package edu.unc.lib.dl.admin.controller;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.HashMap;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.multipart.MultipartFile;
+
+import edu.unc.lib.dl.acl.util.AccessGroupConstants;
+import edu.unc.lib.dl.acl.util.AccessGroupSet;
+import edu.unc.lib.dl.acl.util.GroupsThreadStore;
+import edu.unc.lib.dl.util.RedisWorkerConstants.DepositField;
+import edu.unc.lib.dl.util.RedisWorkerConstants.DepositAction;
+import edu.unc.lib.dl.util.RedisWorkerConstants.DepositState;
+import edu.unc.lib.dl.util.MetsHeaderScanner;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.util.DepositConstants;
+import edu.unc.lib.dl.util.DepositStatusFactory;
+
+@Controller
+public class ResubmitIngestController {
+	
+	private static final Logger log = LoggerFactory.getLogger(ResubmitIngestController.class);
+	
+	@Autowired
+	private DepositStatusFactory depositStatusFactory;
+	
+	@Autowired
+	private File depositsDirectory;
+	
+	@RequestMapping(value = "ingest/{pid}/resubmit", method = RequestMethod.POST)
+	public @ResponseBody
+	Map<String, ? extends Object> handleResubmit(@PathVariable("pid") String pid, @RequestParam("file") MultipartFile uploadedFile, HttpServletRequest request, HttpServletResponse response) {
+		
+		Map<String, Object> result = new HashMap<String, Object>();
+		PID depositPid = new PID(pid);
+		
+		
+		// Try to retrieve the deposit status
+		
+		Map<String, String> status = depositStatusFactory.get(depositPid.getUUID());
+		
+		if (status == null || status.isEmpty()) {
+			response.setStatus(400);
+			result.put("error", "Couldn't find the deposit.");
+			return result;
+		}
+		
+		
+		// Check that the current user is either an admin or was the depositor
+		
+		AccessGroupSet groups = GroupsThreadStore.getGroups();
+		String depositorName = status.get(DepositField.depositorName.name());
+		
+		if (!(groups.contains(AccessGroupConstants.ADMIN_GROUP) || depositorName.equals(GroupsThreadStore.getUsername()))) {
+			response.setStatus(401);
+			return result;
+		}
+		
+		
+		// Check that the deposit is in the failed state
+		
+		String state = status.get(DepositField.state.name());
+		
+		if (state == null || !state.equals(DepositState.failed.name())) {
+			response.setStatus(400);
+			result.put("error", "The deposit isn't in the failed state.");
+			return result;
+		}
+		
+		
+		// Create the resubmit deposit directory
+		
+		String resubmitDirName;
+		
+		try {
+			resubmitDirName = createResubmitDirectory();
+		} catch (IOException e) {
+			response.setStatus(500);
+			result.put("error", "Couldn't save the resubmitted ingest package.");
+			return result;
+		}
+		
+		File resubmitDir = new File(depositsDirectory, resubmitDirName);
+		File resubmitDataDir = new File(resubmitDir, DepositConstants.DATA_DIR);
+		
+		
+		// Transfer the uploaded file to the resubmit data directory
+		
+		File resubmitPackageFile = new File(resubmitDataDir, uploadedFile.getOriginalFilename());
+		
+		try {
+			uploadedFile.transferTo(resubmitPackageFile);
+		} catch (IOException e) {
+			response.setStatus(500);
+			result.put("error", "Couldn't save the resubmitted ingest package.");
+			return result;
+		}
+		
+		
+		// Scan the ingest file
+		
+		MetsHeaderScanner scanner = new MetsHeaderScanner();
+		
+		try {
+			scanner.scan(resubmitPackageFile, uploadedFile.getOriginalFilename());
+		} catch (Exception e) {
+			response.setStatus(500);
+			result.put("error", "Couldn't scan the resubmitted ingest package.");
+			return result;
+		}
+		
+		
+		// Check that the ingest file has the same deposit pid as the deposit status
+		
+		PID depositPackageId = scanner.getObjID();
+		
+		if (depositPackageId == null) {
+			response.setStatus(400);
+			result.put("error", "The resubmitted ingest package doesn't have an ID.");
+			return result;
+		}
+		
+		if (!depositPackageId.equals(depositPid)) {
+			response.setStatus(400);
+			result.put("error", "The resubmitted ingest package doesn't match the deposit.");
+			return result;
+		}
+		
+		
+		// Set new deposit status
+		
+		depositStatusFactory.set(depositPid.getUUID(), DepositField.resubmitDirName, resubmitDirName);
+		depositStatusFactory.set(depositPid.getUUID(), DepositField.resubmitFileName, resubmitPackageFile.getName());
+		depositStatusFactory.set(depositPid.getUUID(), DepositField.actionRequest, DepositAction.resubmit.name());
+		
+		// Return result indicating that we've submitted the file for resubmission
+		
+		response.setStatus(202);
+		result.put("pid", pid);
+
+		return result;
+		
+	}
+	
+	/**
+	 * Create a resubmit directory inside the deposits directory, containing a data directory.
+	 *
+	 * @return the name of the resubmit directory (relative to the deposits directory)
+	 */
+	private String createResubmitDirectory() throws IOException {
+		File resubmitDir = File.createTempFile(DepositConstants.RESUBMIT_DIR_PREFIX, "", depositsDirectory);
+		resubmitDir.delete();
+		resubmitDir.mkdir();
+		
+		File dataDir = new File(resubmitDir, DepositConstants.DATA_DIR);
+		dataDir.mkdir();
+		
+		return resubmitDir.getName();
+	}
+	
+}

--- a/admin/src/main/java/edu/unc/lib/dl/admin/controller/ResubmitIngestController.java
+++ b/admin/src/main/java/edu/unc/lib/dl/admin/controller/ResubmitIngestController.java
@@ -57,6 +57,7 @@ public class ResubmitIngestController {
 		if (status == null || status.isEmpty()) {
 			response.setStatus(400);
 			result.put("error", "Couldn't find the deposit.");
+			log.error("Tried to resubmit deposit PID {} but couldn't find it", depositPid);
 			return result;
 		}
 		
@@ -79,6 +80,7 @@ public class ResubmitIngestController {
 		if (state == null || !state.equals(DepositState.failed.name())) {
 			response.setStatus(400);
 			result.put("error", "The deposit isn't in the failed state.");
+			log.error("Tried to resubmit deposit {} but it isn't in the failed state", depositPid);
 			return result;
 		}
 		
@@ -92,6 +94,7 @@ public class ResubmitIngestController {
 		} catch (IOException e) {
 			response.setStatus(500);
 			result.put("error", "Couldn't save the resubmitted ingest package.");
+			log.error("Couldn't create a resubmit directory for deposit PID " + depositPid, e);
 			return result;
 		}
 		
@@ -108,6 +111,7 @@ public class ResubmitIngestController {
 		} catch (IOException e) {
 			response.setStatus(500);
 			result.put("error", "Couldn't save the resubmitted ingest package.");
+			log.error("Couldn't transfer the resubmitted ingest package for deposit PID " + depositPid, e);
 			return result;
 		}
 		
@@ -121,6 +125,7 @@ public class ResubmitIngestController {
 		} catch (Exception e) {
 			response.setStatus(500);
 			result.put("error", "Couldn't scan the resubmitted ingest package.");
+			log.error("Error scanning the resubmitted ingest package for deposit PID " + depositPid, e);
 			return result;
 		}
 		
@@ -132,12 +137,14 @@ public class ResubmitIngestController {
 		if (depositPackageId == null) {
 			response.setStatus(400);
 			result.put("error", "The resubmitted ingest package doesn't have an ID.");
+			log.error("The resubmitted ingest package for deposit PID {} doesn't have an ID", depositPid);
 			return result;
 		}
 		
 		if (!depositPackageId.equals(depositPid)) {
 			response.setStatus(400);
 			result.put("error", "The resubmitted ingest package doesn't match the deposit.");
+			log.error("The resubmitted ingest package doesn't match the deposit. The deposit has PID {} but the package has ID {}.", depositPid, depositPackageId);
 			return result;
 		}
 		

--- a/deposit/src/main/java/edu/unc/lib/deposit/PrepareResubmitJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/PrepareResubmitJob.java
@@ -1,0 +1,53 @@
+package edu.unc.lib.deposit;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import edu.unc.lib.deposit.work.AbstractDepositJob;
+import edu.unc.lib.dl.util.RedisWorkerConstants.DepositField;
+import edu.unc.lib.dl.util.DepositConstants;
+import edu.unc.lib.dl.util.DepositStatusFactory;
+import edu.unc.lib.dl.util.PremisEventLogger.Type;
+import edu.unc.lib.dl.util.RedisWorkerConstants.DepositField;
+
+public class PrepareResubmitJob extends AbstractDepositJob {
+	
+	private static final Logger LOG = LoggerFactory.getLogger(CleanupDepositJob.class);
+
+	public PrepareResubmitJob() {
+	}
+
+	public PrepareResubmitJob(String uuid, String depositUUID) {
+		super(uuid, depositUUID);
+	}
+	
+	@Override
+	public void runJob() {
+		
+		String uuid = getDepositUUID();
+		Map<String, String> status = getDepositStatus();
+		
+		File resubmitDir = new File(getDepositsDirectory(), status.get(DepositField.resubmitDirName.name()));
+		File backupDir = new File(resubmitDir, DepositConstants.RESUBMIT_BACKUP_DIR);
+		File depositDirectory = getDepositDirectory();
+		
+		// Swap directories: existing deposit directory becomes backup directory inside resubmit directory,
+		// resubmit directory becomes former deposit directory.
+		depositDirectory.renameTo(backupDir);
+		resubmitDir.renameTo(depositDirectory);
+		
+		// Set isResubmit flag, update the fileName, and remove resubmit fields.
+		DepositStatusFactory depositStatusFactory = getDepositStatusFactory();
+		depositStatusFactory.set(uuid, DepositField.isResubmit, "true");
+		depositStatusFactory.set(uuid, DepositField.fileName, status.get(DepositField.resubmitFileName.name()));
+		depositStatusFactory.deleteField(uuid, DepositField.resubmitDirName);
+		depositStatusFactory.deleteField(uuid, DepositField.resubmitFileName);
+		
+	}
+	
+}

--- a/deposit/src/main/java/edu/unc/lib/deposit/work/AbstractDepositJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/work/AbstractDepositJob.java
@@ -165,6 +165,10 @@ public abstract class AbstractDepositJob implements Runnable {
 		return new File(getDepositDirectory(), DESCRIPTION_DIR);
 	}
 
+	public File getDepositsDirectory() {
+		return depositsDirectory;
+	}
+
 	public File getDepositDirectory() {
 		return depositDirectory;
 	}

--- a/deposit/src/main/resources/service-context.xml
+++ b/deposit/src/main/resources/service-context.xml
@@ -222,6 +222,10 @@
 		<constructor-arg index="0" type="java.lang.Class" value="edu.unc.lib.deposit.clean.MailNotifier"/> 
 		<constructor-arg index="1" value=""/> </bean> </property> </bean> -->
 
+	<bean id="PrepareResubmitJob" class="edu.unc.lib.deposit.PrepareResubmitJob"
+		scope="prototype">
+	</bean>
+
 	<bean id="PackageIntegrityCheckJob" class="edu.unc.lib.deposit.validate.PackageIntegrityCheckJob"
 		scope="prototype">
 	</bean>

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/FedoraFaultMessageResolver.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/FedoraFaultMessageResolver.java
@@ -30,7 +30,7 @@ public class FedoraFaultMessageResolver {
 					|| r.contains("DatastreamNotFoundException") || r.contains("no path in db registry")
 					|| r.contains("No datastream could be returned")) {
 				throw new NotFoundException(e);
-			} else if (r.contains("ObjectExistsException")) {
+			} else if (r.contains("ObjectExistsException") || r.contains("already exists in the registry; the object can't be re-created")) {
 				throw new ObjectExistsException(e);
 			} else if (r.contains("LowlevelStorageException")) {
 				throw new FileSystemException(e);

--- a/metadata/src/main/java/edu/unc/lib/dl/util/DepositConstants.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/util/DepositConstants.java
@@ -10,6 +10,8 @@ public class DepositConstants {
 	public static final String DUBLINCORE_DIR = "dc";
 	public static final String FOXML_DIR = "foxml";
 	public static final String DATA_DIR = "data";
+	public static final String RESUBMIT_DIR_PREFIX = "resubmit-";
+	public static final String RESUBMIT_BACKUP_DIR = "resubmit-backup";
 	public static final String FILE_LOCATOR_URI = "http://cdr.lib.unc.edu/schema/bag#locator";
 
 	/**

--- a/metadata/src/main/java/edu/unc/lib/dl/util/RedisWorkerConstants.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/util/RedisWorkerConstants.java
@@ -10,10 +10,10 @@ public class RedisWorkerConstants {
 
 	public static enum DepositField {
 		uuid, state, actionRequest, contactName, depositorName, intSenderIdentifier, intSenderDescription,
-		fileName, depositMethod, containerId, payLoadOctets, createTime, startTime,
-		endTime, ingestedOctets, ingestedObjects, directory, lock, submitTime, depositorEmail, 
-		packagingType, metsProfile, metsType, permissionGroups, depositMd5, depositSlug, errorMessage, 
-		stackTrace, excludeDepositRecord, stagingFolderURI, publishObjects, manifestURI;
+		fileName, resubmitDirName, resubmitFileName, isResubmit, depositMethod, containerId, payLoadOctets,
+		createTime, startTime, endTime, ingestedOctets, ingestedObjects, directory, lock, submitTime,
+		depositorEmail, packagingType, metsProfile, metsType, permissionGroups, depositMd5, depositSlug,
+		errorMessage, stackTrace, excludeDepositRecord, stagingFolderURI, publishObjects, manifestURI;
 	}
 
 	public static enum JobField {
@@ -34,6 +34,6 @@ public class RedisWorkerConstants {
 	 *
 	 */
 	public static enum DepositAction {
-		register, pause, resume, cancel, destroy;
+		register, pause, resume, cancel, destroy, resubmit;
 	}
 }


### PR DESCRIPTION
- Add ResubmitIngestController which checks resubmitted packages and saves them to the batch ingest directory
- Add PrepareResubmitJob which backs up the previous ingest, arranges the resubmitted ingest package for processing by the rest of the pipeline, and marks the deposit as a resubmission
- Modify IngestDeposit to consider "object exists" exceptions confirmation that the object has already been ingested when the deposit is marked as a resubmission
- Add ReingestPackageForm and "Reingest" link to details pane in status monitor