### PR TITLE
Trigger the inline viewer only when the thumbnail at the top of a full record page is clicked

### DIFF
--- a/access/src/main/external/static/js/public/fullRecord.js
+++ b/access/src/main/external/static/js/public/fullRecord.js
@@ -69,8 +69,8 @@ define('fullRecord', ['module', 'jquery', 'JP2Viewer', 'StructureView', 'VideoPl
 	if ($audioPlayer.length > 0)
 		toggleViewer($audioPlayer, 'audioPlayer', $(".audio_player_link"), 'showAudio', 'Listen');
 	
-	if ($(".inline_viewer_link").length > 0){
-		$(".thumbnail").bind("click", function() {
+	if ($(".inline_viewer_link").length > 0) {
+		$(".full_record_top .thumbnail").bind("click", function() {
 			$(".inline_viewer_link").trigger("click");
 			return false;
 		});


### PR DESCRIPTION
Otherwise, we end up triggering the inline viewer when related items are clicked.