### PR TITLE
Destroy deposit model in PrepareResubmitJob

### DIFF
--- a/deposit/src/main/java/edu/unc/lib/deposit/PrepareResubmitJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/PrepareResubmitJob.java
@@ -48,6 +48,9 @@ public class PrepareResubmitJob extends AbstractDepositJob {
 		depositStatusFactory.deleteField(uuid, DepositField.resubmitDirName);
 		depositStatusFactory.deleteField(uuid, DepositField.resubmitFileName);
 		
+		// Destroy our model, since we'll recreate it in later steps
+		this.destroyModel();
+		
 	}
 	
 }


### PR DESCRIPTION
- This fixes that resubmitted ingests would cause incorrect counts to appear in the status monitor and IngestDeposit to attempt to ingest the same object more than once