### PR TITLE
Ensure that we are actually asking for optimistic locking for moves

### DIFF
--- a/persistence/src/main/java/edu/unc/lib/dl/services/DigitalObjectManagerImpl.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/services/DigitalObjectManagerImpl.java
@@ -638,7 +638,7 @@ public class DigitalObjectManagerImpl implements DigitalObjectManager {
 					return null;
 				}
 				
-				log.debug("Got datastream, attempting to get dissemination version with create date " + managementClient.getDatastream(pid, datastreamName).getCreateDate());
+				log.debug("Got datastream, attempting to get dissemination version with create date " + datastream.getCreateDate());
 			
 				try {
 			


### PR DESCRIPTION
- Make sure the lastModifiedDate parameter is actually added when attempting to modify a datastream
- Retrieve a datastream's metadata before retrieving its content so that we have its last modified date to millisecond resolution, rather than second resolution as available from the Last-Modified header
- Clean up debug logging in move methods (removeChildren, addChildren, cleanupRemovedChildren)