### PR TITLE
Fixed bug which caused aggregate objects to be labeled as isPart:true…

### DIFF
--- a/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetPathFilter.java
+++ b/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetPathFilter.java
@@ -141,7 +141,7 @@ public class SetPathFilter extends AbstractIndexDocumentFilter {
 		idb.setAncestorIds(ancestorIds.toString());
 
 		// If this item is in an aggregate object then it should rollup as part of its parent
-		if (firstAggregate != null) {
+		if (firstAggregate != null && !firstAggregate.pid.equals(idb.getPid())) {
 			idb.setRollup(firstAggregate.pid.getPid());
 			idb.setIsPart(Boolean.TRUE);
 			log.debug("From query, parent is in an aggregate: " + idb.getRollup());
@@ -233,7 +233,7 @@ public class SetPathFilter extends AbstractIndexDocumentFilter {
 		}
 		idb.setAncestorIds(ancestorIds.toString());
 
-		// If the parent has a rollup other than its own id, that means its nested inside an aggregate, so it inherits
+		// If the parent has a rollup other than its own id, that means it is nested inside an aggregate, so it inherits
 		if (!parentDIP.getPid().getPid().equals(parentDIP.getDocument().getRollup())) {
 			if (parentDIP.getDocument().getRollup() == null) {
 				idb.setRollup(idb.getId());

--- a/solr-search/src/main/java/edu/unc/lib/dl/search/solr/model/IndexDocumentBean.java
+++ b/solr-search/src/main/java/edu/unc/lib/dl/search/solr/model/IndexDocumentBean.java
@@ -35,7 +35,7 @@ public class IndexDocumentBean {
 
 	protected List<String> scope;
 	protected String rollup;
-	protected Boolean isPart = Boolean.FALSE;
+	protected Boolean isPart;
 	protected Long _version_;
 
 	protected List<String> datastream;


### PR DESCRIPTION
… when updating by query.  Fixed bug which would override isPart to false if it was not specified, such as during SolrUpdateEnhancement updates