### PR TITLE
Xml export

### DIFF
--- a/access/src/main/external/static/css/admin/admin_forms.css
+++ b/access/src/main/external/static/css/admin/admin_forms.css
@@ -31,6 +31,11 @@
 	margin-right: 20px;
 }
 
+.edit_form label.form_inline {
+	text-align: left;
+	width: 100%;
+}
+
 .edit_form input, .edit_form textarea, .edit_form select {
 	background-color: #FFFFFF;
 	border: 1px solid #C8D8E0;

--- a/access/src/main/external/static/css/cdr_admin.css
+++ b/access/src/main/external/static/css/cdr_admin.css
@@ -3407,6 +3407,11 @@ h1 {
 	margin-right: 20px;
 }
 
+.edit_form label.form_inline {
+	text-align: left;
+	width: 100%;
+}
+
 .edit_form input, .edit_form textarea, .edit_form select {
 	background-color: #FFFFFF;
 	border: 1px solid #C8D8E0;

--- a/access/src/main/external/static/js/admin/src/ResultObjectActionMenu.js
+++ b/access/src/main/external/static/js/admin/src/ResultObjectActionMenu.js
@@ -41,6 +41,7 @@ define('ResultObjectActionMenu', [ 'jquery', 'jquery-ui', 'StringUtilities',  'E
 						var def = {
 							label : actionDefinition.label,
 							actionClass : actionClass,
+							joiner : actionDefinition.joiner,
 							action : new actionClass({ target : self.options.resultList }),
 							group : group.groupName? group.groupName : index
 						};
@@ -282,6 +283,7 @@ define('ResultObjectActionMenu', [ 'jquery', 'jquery-ui', 'StringUtilities',  'E
 			var validCount = definition.action.countTargets();
 			items[actionName] = {
 				name : definition.label + (validCount? ' ' + validCount : '') 
+					+ (definition.joiner? definition.joiner : "")
 					+ " object" + (validCount == 1? '' : 's'),
 				disabled : validCount == 0
 			};

--- a/access/src/main/external/static/js/admin/src/ResultObjectActionMenu.js
+++ b/access/src/main/external/static/js/admin/src/ResultObjectActionMenu.js
@@ -147,6 +147,11 @@ define('ResultObjectActionMenu', [ 'jquery', 'jquery-ui', 'StringUtilities',  'E
 		if ($.inArray('info:fedora/cdr-model:Container', metadata.model) != -1) {
 			items["exportCSV"] = {name : 'Export as CSV'};
 		}
+		if ($.inArray('editDescription', metadata.permissions) != -1) {
+			if ($.inArray('info:fedora/cdr-model:Container', metadata.model) != -1) {
+				items["exportContainerXML"] = {name : 'Export folder as XML'};
+			}
+		}
 		items["copyid"] = {name : 'Copy PID to Clipboard'};
 		
 		// Admin actions
@@ -241,8 +246,12 @@ define('ResultObjectActionMenu', [ 'jquery', 'jquery-ui', 'StringUtilities',  'E
 						document.location.href = baseUrl + "export/" + metadata.id;
 						break;
 					
-					case "exportXML" :
-						document.location.href = baseUrl + "exportxml/" + metadata.id;
+					case "exportContainerXML" :
+						self.actionHandler.addEvent({
+							action : 'ExportMetadataXMLBatch',
+							targets : [resultObject],
+							exportContainerMode : true
+						});
 						break;
 					
 					case "copyid" :

--- a/access/src/main/external/static/js/admin/src/ResultObjectActionMenu.js
+++ b/access/src/main/external/static/js/admin/src/ResultObjectActionMenu.js
@@ -137,9 +137,6 @@ define('ResultObjectActionMenu', [ 'jquery', 'jquery-ui', 'StringUtilities',  'E
 		
 		if ($.inArray('editDescription', metadata.permissions) != -1) {
 			items["editDescription"] = {name : 'Edit Description'};
-			if ($.inArray('info:fedora/cdr-model:Container', metadata.model) != -1) {
-				items["exportXML"] = {name : 'Export as XML'};
-			}
 		}
 		
 		// Export actions
@@ -148,9 +145,7 @@ define('ResultObjectActionMenu', [ 'jquery', 'jquery-ui', 'StringUtilities',  'E
 			items["exportCSV"] = {name : 'Export as CSV'};
 		}
 		if ($.inArray('editDescription', metadata.permissions) != -1) {
-			if ($.inArray('info:fedora/cdr-model:Container', metadata.model) != -1) {
-				items["exportContainerXML"] = {name : 'Export folder as XML'};
-			}
+			items["exportXML"] = {name : 'Export MODS'};
 		}
 		items["copyid"] = {name : 'Copy PID to Clipboard'};
 		
@@ -246,11 +241,10 @@ define('ResultObjectActionMenu', [ 'jquery', 'jquery-ui', 'StringUtilities',  'E
 						document.location.href = baseUrl + "export/" + metadata.id;
 						break;
 					
-					case "exportContainerXML" :
+					case "exportXML" :
 						self.actionHandler.addEvent({
 							action : 'ExportMetadataXMLBatch',
-							targets : [resultObject],
-							exportContainerMode : true
+							targets : [resultObject]
 						});
 						break;
 					

--- a/access/src/main/external/static/js/admin/src/ResultObjectActionMenu.js
+++ b/access/src/main/external/static/js/admin/src/ResultObjectActionMenu.js
@@ -137,11 +137,9 @@ define('ResultObjectActionMenu', [ 'jquery', 'jquery-ui', 'StringUtilities',  'E
 		
 		if ($.inArray('editDescription', metadata.permissions) != -1) {
 			items["editDescription"] = {name : 'Edit Description'};
-		}
-		
-		if ($.inArray('editResourceType', metadata.permissions) != -1
-				&& $.inArray('info:fedora/cdr-model:Container', metadata.model) != -1) {
-			items["editType"] = {name : 'Edit Type'};
+			if ($.inArray('info:fedora/cdr-model:Container', metadata.model) != -1) {
+				items["exportXML"] = {name : 'Export as XML'};
+			}
 		}
 		
 		// Export actions
@@ -242,6 +240,11 @@ define('ResultObjectActionMenu', [ 'jquery', 'jquery-ui', 'StringUtilities',  'E
 					case "exportCSV" :
 						document.location.href = baseUrl + "export/" + metadata.id;
 						break;
+					
+					case "exportXML" :
+						document.location.href = baseUrl + "exportxml/" + metadata.id;
+						break;
+					
 					case "copyid" :
 						window.prompt("Copy PID to clipboard", metadata.id);
 						break;

--- a/access/src/main/external/static/js/admin/src/ResultView.js
+++ b/access/src/main/external/static/js/admin/src/ResultView.js
@@ -21,9 +21,9 @@ define('ResultView', [ 'jquery', 'jquery-ui', 'ResultObjectList', 'URLUtilities'
 			resultActions : [
 						{
 							actions : [
-								{action : 'EditTypeBatch', label : 'Edit Type', joiner : ' for '},
+								{action : 'EditTypeBatch', label : 'Edit Type', joiner : ' for'},
 								{action : 'SetAsDefaultWebObjectBatch', label : 'Set as Primary'}
-								{action : 'ExportMetadataXMLBatch', label : 'Export MODS', joiner : ' for '}
+								{action : 'ExportMetadataXMLBatch', label : 'Export MODS', joiner : ' for'}
 							]
 						},
 						{

--- a/access/src/main/external/static/js/admin/src/ResultView.js
+++ b/access/src/main/external/static/js/admin/src/ResultView.js
@@ -21,9 +21,13 @@ define('ResultView', [ 'jquery', 'jquery-ui', 'ResultObjectList', 'URLUtilities'
 			resultActions : [
 						{
 							actions : [
+								{action : 'ExportMetadataXMLBatch', label : 'Export MODS', joiner : ' for'}
+							]
+						},
+						{
+							actions : [
 								{action : 'EditTypeBatch', label : 'Edit Type', joiner : ' for'},
 								{action : 'SetAsDefaultWebObjectBatch', label : 'Set as Primary'}
-								{action : 'ExportMetadataXMLBatch', label : 'Export MODS', joiner : ' for'}
 							]
 						},
 						{

--- a/access/src/main/external/static/js/admin/src/ResultView.js
+++ b/access/src/main/external/static/js/admin/src/ResultView.js
@@ -21,9 +21,9 @@ define('ResultView', [ 'jquery', 'jquery-ui', 'ResultObjectList', 'URLUtilities'
 			resultActions : [
 						{
 							actions : [
-								{action : 'EditTypeBatch', label : 'Edit Type'},
+								{action : 'EditTypeBatch', label : 'Edit Type', joiner : ' for '},
 								{action : 'SetAsDefaultWebObjectBatch', label : 'Set as Primary'}
-								{action : 'ExportMetadataXMLBatch', label : 'Export MODS'}
+								{action : 'ExportMetadataXMLBatch', label : 'Export MODS', joiner : ' for '}
 							]
 						},
 						{

--- a/access/src/main/external/static/js/admin/src/ResultView.js
+++ b/access/src/main/external/static/js/admin/src/ResultView.js
@@ -23,6 +23,7 @@ define('ResultView', [ 'jquery', 'jquery-ui', 'ResultObjectList', 'URLUtilities'
 							actions : [
 								{action : 'EditTypeBatch', label : 'Edit Type'},
 								{action : 'SetAsDefaultWebObjectBatch', label : 'Set as Primary'}
+								{action : 'ExportMetadataXMLBatch', label : 'Export XML'}
 							]
 						},
 						{

--- a/access/src/main/external/static/js/admin/src/ResultView.js
+++ b/access/src/main/external/static/js/admin/src/ResultView.js
@@ -23,7 +23,7 @@ define('ResultView', [ 'jquery', 'jquery-ui', 'ResultObjectList', 'URLUtilities'
 							actions : [
 								{action : 'EditTypeBatch', label : 'Edit Type'},
 								{action : 'SetAsDefaultWebObjectBatch', label : 'Set as Primary'}
-								{action : 'ExportMetadataXMLBatch', label : 'Export XML'}
+								{action : 'ExportMetadataXMLBatch', label : 'Export MODS'}
 							]
 						},
 						{

--- a/access/src/main/external/static/js/admin/src/action/ExportMetadataXMLBatchAction.js
+++ b/access/src/main/external/static/js/admin/src/action/ExportMetadataXMLBatchAction.js
@@ -1,0 +1,99 @@
+define('ExportMetadataXMLBatchAction', [ 'jquery', 'AbstractBatchAction', "tpl!../templates/admin/exportMetadataForm"], function($, AbstractBatchAction, exportMetadataTemplate) {
+
+	function ExportMetadataXMLBatchAction(context) {
+		this._create(context);
+	};
+	
+	ExportMetadataXMLBatchAction.prototype.constructor = ExportMetadataXMLBatchAction;
+	ExportMetadataXMLBatchAction.prototype = Object.create( AbstractBatchAction.prototype );
+	
+	ExportMetadataXMLBatchAction.prototype.isValidTarget = function(target) {
+		return target.isSelected() && target.isEnabled() && $.inArray("editDescription", target.metadata.permissions) != -1;
+	};
+	
+	ExportMetadataXMLBatchAction.prototype.getTargets = function(targets) {
+		if (this.context.targets) {
+			return this.context.targets;
+		} 
+		return AbstractBatchAction.prototype.getTargets.call(this);
+	};
+	
+	ExportMetadataXMLBatchAction.prototype.execute = function() {
+		var self = this;
+		
+		var exportContainerMode = this.context.exportContainerMode;
+		
+		this.targets = this.getTargets();
+		var title;
+		var defaultType;
+		if (this.targets.length == 1) {
+			title = "Export XML metadata for " + this.targets[0].metadata.title.substring(0, 30);
+			if (exportContainerMode) {
+				title += " and all objects contained in it."
+			}
+		} else {
+			title = "Export XML metadata for " + this.targets.length + " objects";
+			if (exportContainerMode) {
+				title += " and all objects contained within them."
+			}
+		}
+		
+		// Retrieve the last email address used by this user
+		var onyen = this.context.view.resultData.onyen;
+		
+		var emailAddress = localStorage.getItem("send_to_address_" + onyen);
+		if (!emailAddress) {
+			emailAddress = this.context.view.resultData.email;
+			if (!emailAddress && onyen) {
+				// No email, so generate one
+				emailAddress = onyen + "@email.unc.edu";
+			}
+		}
+		
+		var exportMetadataForm = exportMetadataTemplate({email : emailAddress});
+		this.dialog = $("<div class='containingDialog'>" + exportMetadataForm + "</div>");
+		this.dialog.dialog({
+			autoOpen: true,
+			width: 'auto',
+			minWidth: '500',
+			height: 'auto',
+			modal: true,
+			title: title
+		});
+		this.$form = this.dialog.first();
+		
+		this.$form.submit(function(e){
+			var email = $("#xml_recipient_email", self.$form).val();
+			
+			if (!email || !$.trim(email)) {
+				return false;
+			}
+			localStorage.setItem("send_to_address_" + onyen, email);
+
+			var pids = [];
+			for (var index in self.targets) {
+				pids.push(self.targets[index].getPid());
+			}
+			
+			$.ajax({
+				url : exportContainerMode? "exportContainerXML" : "exportXML",
+				type : "POST",
+				contentType: "application/json; charset=utf-8",
+				dataType: "json",
+				data : JSON.stringify({
+					email : email,
+					pids : pids
+				})
+			}).done(function(response) {
+				self.context.view.$alertHandler.alertHandler("message", response.message);
+				self.dialog.remove();
+			}).fail(function() {
+				self.context.view.$alertHandler.alertHandler("error", "Failed to export " + self.targets.length + " objects");
+			});
+			
+			e.preventDefault();
+		});
+	}
+	
+	return ExportMetadataXMLBatchAction;
+});

--- a/access/src/main/external/static/js/admin/src/action/ExportMetadataXMLBatchAction.js
+++ b/access/src/main/external/static/js/admin/src/action/ExportMetadataXMLBatchAction.js
@@ -28,14 +28,8 @@ define('ExportMetadataXMLBatchAction', [ 'jquery', 'AbstractBatchAction', "tpl!.
 		var defaultType;
 		if (this.targets.length == 1) {
 			title = "Export XML metadata for " + this.targets[0].metadata.title.substring(0, 30);
-			if (exportContainerMode) {
-				title += " and all objects contained in it."
-			}
 		} else {
 			title = "Export XML metadata for " + this.targets.length + " objects";
-			if (exportContainerMode) {
-				title += " and all objects contained within them."
-			}
 		}
 		
 		// Retrieve the last email address used by this user
@@ -64,6 +58,7 @@ define('ExportMetadataXMLBatchAction', [ 'jquery', 'AbstractBatchAction', "tpl!.
 		
 		this.$form.submit(function(e){
 			var email = $("#xml_recipient_email", self.$form).val();
+			var includeChildren = $("#export_xml_include_children", self.$form).prop("checked");
 			
 			if (!email || !$.trim(email)) {
 				return false;
@@ -76,7 +71,7 @@ define('ExportMetadataXMLBatchAction', [ 'jquery', 'AbstractBatchAction', "tpl!.
 			}
 			
 			$.ajax({
-				url : exportContainerMode? "exportContainerXML" : "exportXML",
+				url : includeChildren? "exportContainerXML" : "exportXML",
 				type : "POST",
 				contentType: "application/json; charset=utf-8",
 				dataType: "json",

--- a/access/src/main/external/static/js/cdr-admin.js
+++ b/access/src/main/external/static/js/cdr-admin.js
@@ -3828,9 +3828,13 @@ define('ResubmitPackageForm', [ 'jquery', 'jquery-ui', 'underscore', 'RemoteStat
 			resultActions : [
 						{
 							actions : [
+								{action : 'ExportMetadataXMLBatch', label : 'Export MODS', joiner : ' for'}
+							]
+						},
+						{
+							actions : [
 								{action : 'EditTypeBatch', label : 'Edit Type', joiner : ' for'},
 								{action : 'SetAsDefaultWebObjectBatch', label : 'Set as Primary'}
-								{action : 'ExportMetadataXMLBatch', label : 'Export MODS', joiner : ' for'}
 							]
 						},
 						{

--- a/access/src/main/external/static/js/cdr-admin.js
+++ b/access/src/main/external/static/js/cdr-admin.js
@@ -2885,6 +2885,11 @@ define('ResubmitPackageForm', [ 'jquery', 'jquery-ui', 'underscore', 'RemoteStat
 		if ($.inArray('info:fedora/cdr-model:Container', metadata.model) != -1) {
 			items["exportCSV"] = {name : 'Export as CSV'};
 		}
+		if ($.inArray('editDescription', metadata.permissions) != -1) {
+			if ($.inArray('info:fedora/cdr-model:Container', metadata.model) != -1) {
+				items["exportContainerXML"] = {name : 'Export folder as XML'};
+			}
+		}
 		items["copyid"] = {name : 'Copy PID to Clipboard'};
 		
 		// Admin actions
@@ -2979,8 +2984,12 @@ define('ResubmitPackageForm', [ 'jquery', 'jquery-ui', 'underscore', 'RemoteStat
 						document.location.href = baseUrl + "export/" + metadata.id;
 						break;
 					
-					case "exportXML" :
-						document.location.href = baseUrl + "exportxml/" + metadata.id;
+					case "exportContainerXML" :
+						self.actionHandler.addEvent({
+							action : 'ExportMetadataXMLBatch',
+							targets : [resultObject],
+							exportContainerMode : true
+						});
 						break;
 					
 					case "copyid" :
@@ -3825,6 +3834,7 @@ define('ResubmitPackageForm', [ 'jquery', 'jquery-ui', 'underscore', 'RemoteStat
 							actions : [
 								{action : 'EditTypeBatch', label : 'Edit Type'},
 								{action : 'SetAsDefaultWebObjectBatch', label : 'Set as Primary'}
+								{action : 'ExportMetadataXMLBatch', label : 'Export XML'}
 							]
 						},
 						{
@@ -4882,6 +4892,104 @@ define('ResubmitPackageForm', [ 'jquery', 'jquery-ui', 'underscore', 'RemoteStat
 	}
 	
 	return EditTypeBatchAction;
+});define('ExportMetadataXMLBatchAction', [ 'jquery', 'AbstractBatchAction', "tpl!../templates/admin/exportMetadataForm"], function($, AbstractBatchAction, exportMetadataTemplate) {
+
+	function ExportMetadataXMLBatchAction(context) {
+		this._create(context);
+	};
+	
+	ExportMetadataXMLBatchAction.prototype.constructor = ExportMetadataXMLBatchAction;
+	ExportMetadataXMLBatchAction.prototype = Object.create( AbstractBatchAction.prototype );
+	
+	ExportMetadataXMLBatchAction.prototype.isValidTarget = function(target) {
+		return target.isSelected() && target.isEnabled() && $.inArray("editDescription", target.metadata.permissions) != -1;
+	};
+	
+	ExportMetadataXMLBatchAction.prototype.getTargets = function(targets) {
+		if (this.context.targets) {
+			return this.context.targets;
+		} 
+		return AbstractBatchAction.prototype.getTargets.call(this);
+	};
+	
+	ExportMetadataXMLBatchAction.prototype.execute = function() {
+		var self = this;
+		
+		var exportContainerMode = this.context.exportContainerMode;
+		
+		this.targets = this.getTargets();
+		var title;
+		var defaultType;
+		if (this.targets.length == 1) {
+			title = "Export XML metadata for " + this.targets[0].metadata.title.substring(0, 30);
+			if (exportContainerMode) {
+				title += " and all objects contained in it."
+			}
+		} else {
+			title = "Export XML metadata for " + this.targets.length + " objects";
+			if (exportContainerMode) {
+				title += " and all objects contained within them."
+			}
+		}
+		
+		// Retrieve the last email address used by this user
+		var onyen = this.context.view.resultData.onyen;
+		
+		var emailAddress = localStorage.getItem("send_to_address_" + onyen);
+		if (!emailAddress) {
+			emailAddress = this.context.view.resultData.email;
+			if (!emailAddress && onyen) {
+				// No email, so generate one
+				emailAddress = onyen + "@email.unc.edu";
+			}
+		}
+		
+		var exportMetadataForm = exportMetadataTemplate({email : emailAddress});
+		this.dialog = $("<div class='containingDialog'>" + exportMetadataForm + "</div>");
+		this.dialog.dialog({
+			autoOpen: true,
+			width: 'auto',
+			minWidth: '500',
+			height: 'auto',
+			modal: true,
+			title: title
+		});
+		this.$form = this.dialog.first();
+		
+		this.$form.submit(function(e){
+			var email = $("#xml_recipient_email", self.$form).val();
+			
+			if (!email || !$.trim(email)) {
+				return false;
+			}
+			localStorage.setItem("send_to_address_" + onyen, email);
+
+			var pids = [];
+			for (var index in self.targets) {
+				pids.push(self.targets[index].getPid());
+			}
+			
+			$.ajax({
+				url : exportContainerMode? "exportContainerXML" : "exportXML",
+				type : "POST",
+				contentType: "application/json; charset=utf-8",
+				dataType: "json",
+				data : JSON.stringify({
+					email : email,
+					pids : pids
+				})
+			}).done(function(response) {
+				self.context.view.$alertHandler.alertHandler("message", response.message);
+				self.dialog.remove();
+			}).fail(function() {
+				self.context.view.$alertHandler.alertHandler("error", "Failed to export " + self.targets.length + " objects");
+			});
+			
+			e.preventDefault();
+		});
+	}
+	
+	return ExportMetadataXMLBatchAction;
 });define('MoveObjectsAction', ['jquery'], function($) {
 	
 	// Context parameters:

--- a/access/src/main/external/static/js/cdr-admin.js
+++ b/access/src/main/external/static/js/cdr-admin.js
@@ -2779,6 +2779,7 @@ define('ResubmitPackageForm', [ 'jquery', 'jquery-ui', 'underscore', 'RemoteStat
 						var def = {
 							label : actionDefinition.label,
 							actionClass : actionClass,
+							joiner : actionDefinition.joiner,
 							action : new actionClass({ target : self.options.resultList }),
 							group : group.groupName? group.groupName : index
 						};
@@ -3020,6 +3021,7 @@ define('ResubmitPackageForm', [ 'jquery', 'jquery-ui', 'underscore', 'RemoteStat
 			var validCount = definition.action.countTargets();
 			items[actionName] = {
 				name : definition.label + (validCount? ' ' + validCount : '') 
+					+ (definition.joiner? definition.joiner : "")
 					+ " object" + (validCount == 1? '' : 's'),
 				disabled : validCount == 0
 			};
@@ -3826,9 +3828,9 @@ define('ResubmitPackageForm', [ 'jquery', 'jquery-ui', 'underscore', 'RemoteStat
 			resultActions : [
 						{
 							actions : [
-								{action : 'EditTypeBatch', label : 'Edit Type'},
+								{action : 'EditTypeBatch', label : 'Edit Type', joiner : ' for '},
 								{action : 'SetAsDefaultWebObjectBatch', label : 'Set as Primary'}
-								{action : 'ExportMetadataXMLBatch', label : 'Export MODS'}
+								{action : 'ExportMetadataXMLBatch', label : 'Export MODS', joiner : ' for '}
 							]
 						},
 						{

--- a/access/src/main/external/static/js/cdr-admin.js
+++ b/access/src/main/external/static/js/cdr-admin.js
@@ -2875,9 +2875,6 @@ define('ResubmitPackageForm', [ 'jquery', 'jquery-ui', 'underscore', 'RemoteStat
 		
 		if ($.inArray('editDescription', metadata.permissions) != -1) {
 			items["editDescription"] = {name : 'Edit Description'};
-			if ($.inArray('info:fedora/cdr-model:Container', metadata.model) != -1) {
-				items["exportXML"] = {name : 'Export as XML'};
-			}
 		}
 		
 		// Export actions
@@ -2886,9 +2883,7 @@ define('ResubmitPackageForm', [ 'jquery', 'jquery-ui', 'underscore', 'RemoteStat
 			items["exportCSV"] = {name : 'Export as CSV'};
 		}
 		if ($.inArray('editDescription', metadata.permissions) != -1) {
-			if ($.inArray('info:fedora/cdr-model:Container', metadata.model) != -1) {
-				items["exportContainerXML"] = {name : 'Export folder as XML'};
-			}
+			items["exportXML"] = {name : 'Export MODS'};
 		}
 		items["copyid"] = {name : 'Copy PID to Clipboard'};
 		
@@ -2984,11 +2979,10 @@ define('ResubmitPackageForm', [ 'jquery', 'jquery-ui', 'underscore', 'RemoteStat
 						document.location.href = baseUrl + "export/" + metadata.id;
 						break;
 					
-					case "exportContainerXML" :
+					case "exportXML" :
 						self.actionHandler.addEvent({
 							action : 'ExportMetadataXMLBatch',
-							targets : [resultObject],
-							exportContainerMode : true
+							targets : [resultObject]
 						});
 						break;
 					
@@ -3834,7 +3828,7 @@ define('ResubmitPackageForm', [ 'jquery', 'jquery-ui', 'underscore', 'RemoteStat
 							actions : [
 								{action : 'EditTypeBatch', label : 'Edit Type'},
 								{action : 'SetAsDefaultWebObjectBatch', label : 'Set as Primary'}
-								{action : 'ExportMetadataXMLBatch', label : 'Export XML'}
+								{action : 'ExportMetadataXMLBatch', label : 'Export MODS'}
 							]
 						},
 						{
@@ -4922,14 +4916,8 @@ define('ResubmitPackageForm', [ 'jquery', 'jquery-ui', 'underscore', 'RemoteStat
 		var defaultType;
 		if (this.targets.length == 1) {
 			title = "Export XML metadata for " + this.targets[0].metadata.title.substring(0, 30);
-			if (exportContainerMode) {
-				title += " and all objects contained in it."
-			}
 		} else {
 			title = "Export XML metadata for " + this.targets.length + " objects";
-			if (exportContainerMode) {
-				title += " and all objects contained within them."
-			}
 		}
 		
 		// Retrieve the last email address used by this user
@@ -4958,6 +4946,7 @@ define('ResubmitPackageForm', [ 'jquery', 'jquery-ui', 'underscore', 'RemoteStat
 		
 		this.$form.submit(function(e){
 			var email = $("#xml_recipient_email", self.$form).val();
+			var includeChildren = $("#export_xml_include_children", self.$form).prop("checked");
 			
 			if (!email || !$.trim(email)) {
 				return false;
@@ -4970,7 +4959,7 @@ define('ResubmitPackageForm', [ 'jquery', 'jquery-ui', 'underscore', 'RemoteStat
 			}
 			
 			$.ajax({
-				url : exportContainerMode? "exportContainerXML" : "exportXML",
+				url : includeChildren? "exportContainerXML" : "exportXML",
 				type : "POST",
 				contentType: "application/json; charset=utf-8",
 				dataType: "json",

--- a/access/src/main/external/static/js/cdr-admin.js
+++ b/access/src/main/external/static/js/cdr-admin.js
@@ -3828,9 +3828,9 @@ define('ResubmitPackageForm', [ 'jquery', 'jquery-ui', 'underscore', 'RemoteStat
 			resultActions : [
 						{
 							actions : [
-								{action : 'EditTypeBatch', label : 'Edit Type', joiner : ' for '},
+								{action : 'EditTypeBatch', label : 'Edit Type', joiner : ' for'},
 								{action : 'SetAsDefaultWebObjectBatch', label : 'Set as Primary'}
-								{action : 'ExportMetadataXMLBatch', label : 'Export MODS', joiner : ' for '}
+								{action : 'ExportMetadataXMLBatch', label : 'Export MODS', joiner : ' for'}
 							]
 						},
 						{

--- a/access/src/main/external/static/js/cdr-admin.js
+++ b/access/src/main/external/static/js/cdr-admin.js
@@ -2875,11 +2875,9 @@ define('ResubmitPackageForm', [ 'jquery', 'jquery-ui', 'underscore', 'RemoteStat
 		
 		if ($.inArray('editDescription', metadata.permissions) != -1) {
 			items["editDescription"] = {name : 'Edit Description'};
-		}
-		
-		if ($.inArray('editResourceType', metadata.permissions) != -1
-				&& $.inArray('info:fedora/cdr-model:Container', metadata.model) != -1) {
-			items["editType"] = {name : 'Edit Type'};
+			if ($.inArray('info:fedora/cdr-model:Container', metadata.model) != -1) {
+				items["exportXML"] = {name : 'Export as XML'};
+			}
 		}
 		
 		// Export actions
@@ -2980,6 +2978,11 @@ define('ResubmitPackageForm', [ 'jquery', 'jquery-ui', 'underscore', 'RemoteStat
 					case "exportCSV" :
 						document.location.href = baseUrl + "export/" + metadata.id;
 						break;
+					
+					case "exportXML" :
+						document.location.href = baseUrl + "exportxml/" + metadata.id;
+						break;
+					
 					case "copyid" :
 						window.prompt("Copy PID to clipboard", metadata.id);
 						break;

--- a/access/src/main/external/static/templates/admin/exportMetadataForm.html
+++ b/access/src/main/external/static/templates/admin/exportMetadataForm.html
@@ -1,0 +1,21 @@
+<form id="export_xml_form" method="post" class="edit_form export_xml_form">
+	<p>
+		Exported metadata will be emailed to the provided email address when it is ready.
+	</p>
+	<p>
+		<div class="form_field">
+			<label>Email Address</label>
+			<input id="xml_recipient_email" type="text" size="40" value="<%= email %>" />
+		</div>
+	
+		<div class="update_field">
+			<input type="submit" id="export_xml_submit_button" class="update_button" value="Export" />
+		</div>
+	</p>
+	
+	<div class="errors">
+		<h3>Errors</h3>
+		<div class="error_stack">
+		</div>
+	</div>
+</form>

--- a/access/src/main/external/static/templates/admin/exportMetadataForm.html
+++ b/access/src/main/external/static/templates/admin/exportMetadataForm.html
@@ -2,16 +2,16 @@
 	<p>
 		Exported metadata will be emailed to the provided email address when it is ready.
 	</p>
-	<p>
-		<div class="form_field">
-			<label>Email Address</label>
-			<input id="xml_recipient_email" type="text" size="40" value="<%= email %>" />
-		</div>
+	<div class="form_field">
+		<label>Email Address</label>
+		<input id="xml_recipient_email" type="text" size="40" value="<%= email %>" />
+	</div>
 	
-		<div class="update_field">
-			<input type="submit" id="export_xml_submit_button" class="update_button" value="Export" />
-		</div>
-	</p>
+	<label class="form_inline"><input type="checkbox" id="export_xml_include_children" checked="checked"> Include metadata for all items contained within the selected object(s).</label>
+
+	<div class="update_field">
+		<input type="submit" id="export_xml_submit_button" class="update_button" value="Export" />
+	</div>
 	
 	<div class="errors">
 		<h3>Errors</h3>

--- a/admin/src/main/java/edu/unc/lib/dl/admin/controller/ExportXMLController.java
+++ b/admin/src/main/java/edu/unc/lib/dl/admin/controller/ExportXMLController.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.admin.controller;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Resource;
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.solr.client.solrj.beans.Field;
+import org.jdom2.Document;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.jdom2.output.XMLOutputter;
+
+import edu.unc.lib.dl.acl.util.GroupsThreadStore;
+import edu.unc.lib.dl.fedora.AccessClient;
+import edu.unc.lib.dl.fedora.FedoraDataService;
+import edu.unc.lib.dl.fedora.FedoraException;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.fedora.types.MIMETypedStream;
+import edu.unc.lib.dl.search.solr.model.BriefObjectMetadata;
+import edu.unc.lib.dl.search.solr.model.SearchRequest;
+import edu.unc.lib.dl.search.solr.model.SearchResultResponse;
+import edu.unc.lib.dl.search.solr.model.SearchState;
+import edu.unc.lib.dl.search.solr.util.SearchFieldKeys;
+import edu.unc.lib.dl.ui.controller.AbstractSolrSearchController;
+import edu.unc.lib.dl.util.RedisWorkerConstants.DepositField;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+
+
+@Controller
+@RequestMapping("exportxml")
+public class ExportXMLController extends AbstractSolrSearchController {
+	private static final Logger LOG = LoggerFactory.getLogger(ExportXMLController.class);
+	
+	@Autowired
+	private JavaMailSender mailSender;
+	@Resource
+	@Qualifier("forwardedAccessClient")
+	private AccessClient client;
+	
+	
+	@RequestMapping(value = "{pid}", method = RequestMethod.GET)
+	public @ResponseBody 
+	Object export(@PathVariable("pid") final String pid, final HttpServletRequest request) throws IOException, FedoraException {
+		
+		Runnable xmlGenerationRunnable = new Runnable() {
+			@Override
+			public void run() {
+				try {
+					SearchRequest searchRequest = generateSearchRequest(request, searchStateFactory.createSearchState());
+					
+					SearchState searchState = searchRequest.getSearchState();
+					searchState.setResultFields(Arrays.asList(SearchFieldKeys.ID.name(), SearchFieldKeys.TITLE.name(),
+							SearchFieldKeys.RESOURCE_TYPE.name(), SearchFieldKeys.ANCESTOR_IDS.name(),
+							SearchFieldKeys.STATUS.name(), SearchFieldKeys.DATASTREAM.name(),
+							SearchFieldKeys.ANCESTOR_PATH.name(), SearchFieldKeys.CONTENT_MODEL.name(),
+							SearchFieldKeys.DATE_ADDED.name(), SearchFieldKeys.DATE_UPDATED.name(),
+							SearchFieldKeys.LABEL.name()));
+					searchState.setSortType("export");
+					searchState.setRowsPerPage(searchSettings.maxPerPage);
+					
+					BriefObjectMetadata container = queryLayer.addSelectedContainer(pid, searchState, false);
+					SearchResultResponse resultResponse = queryLayer.getSearchResults(searchRequest);
+					
+					List<BriefObjectMetadata> objects = resultResponse.getResultList();
+					objects.add(0, container);
+					queryLayer.getChildrenCounts(objects, searchRequest);
+					
+					String xmlString = "<?xml version=\"1.0\" encoding=\"utf-8\"?><bulkMetadata xmlns:mods=\"http://www.loc.gov/mods/v3\" xmlns:acl=\"http://cdr.unc.edu/definitions/acl\">";
+					 			
+					for (BriefObjectMetadata object : objects) {
+						try{
+							byte[] modsBytes = client.getDatastreamDissemination(object.getPid(), "MD_DESCRIPTIVE", null).getStream();
+							Document mods = edu.unc.lib.dl.fedora.ClientUtils.parseXML(modsBytes);
+							xmlString += "<object pid=\""+ object.getPid().getPid() +"\"><update type=\"MODS\">" + new XMLOutputter().outputString(mods).split(">", 2)[1] + "</update></object>";
+							
+						} catch(Exception e) {
+							LOG.error("Failed to generate XMl in thread for ", pid, e);
+						}
+					}
+					xmlString += "</bulkMetadata>";
+					sendEmail(xmlString, "sreenu@live.unc.edu");
+				} catch(Exception e) {
+					LOG.error("Failed to generate XMl in thread for ", pid, e);
+				}
+			}
+		};
+
+		Thread thread = new Thread(xmlGenerationRunnable);
+		thread.start();
+		
+		Map <String, String> response = new HashMap<>();
+		response.put("message", "You will receive an email with XML Data shortly");
+		return response;
+	}
+	
+	public void sendEmail(String xmlString, String toEmail) {
+		MimeMessage mimeMessage = mailSender.createMimeMessage();
+		try {
+			MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, MimeMessageHelper.MULTIPART_MODE_MIXED);
+			
+			helper.setSubject("XML File creation complete");
+			helper.setFrom("no-reply@example.com");
+			helper.setText("Attached the XML");
+			helper.setTo(toEmail);
+			helper.addAttachment("cdr.xml",
+			        new ByteArrayResource(xmlString.getBytes(Charset.forName("UTF-8"))));
+			this.mailSender.send(mimeMessage);
+			LOG.debug("sending email");
+		} catch (MessagingException e) {
+			LOG.error("Cannot send notification email", e);
+		}
+	}
+}

--- a/admin/src/main/java/edu/unc/lib/dl/admin/controller/ExportXMLController.java
+++ b/admin/src/main/java/edu/unc/lib/dl/admin/controller/ExportXMLController.java
@@ -234,9 +234,7 @@ public class ExportXMLController {
 				try (FileOutputStream xfop = new FileOutputStream(mdExportFile)) {
 					xfop.write(exportHeaderBytes);
 
-					Format format = Format.getPrettyFormat();
-					format.setLineSeparator(separator);
-					XMLOutputter xmlOutput = new XMLOutputter(Format.getPrettyFormat());
+					XMLOutputter xmlOutput = new XMLOutputter(Format.getRawFormat());
 					for (String pidString : request.getPids()) {
 						PID pid = new PID(pidString);
 

--- a/admin/src/main/java/edu/unc/lib/dl/admin/controller/ExportXMLController.java
+++ b/admin/src/main/java/edu/unc/lib/dl/admin/controller/ExportXMLController.java
@@ -253,11 +253,16 @@ public class ExportXMLController {
 									.getXMLDatastreamIfExists(pid, Datastream.MD_DESCRIPTIVE.getName());
 
 							if (modsDS != null) {
+								objectEl.addContent(separator);
+								
 								Element modsUpdateEl = new Element("update");
 								modsUpdateEl.setAttribute("type", "MODS");
 								modsUpdateEl.setAttribute("lastModified", modsDS.getLastModified());
+								modsUpdateEl.addContent(separator);
 								modsUpdateEl.addContent(modsDS.getDocument().detachRootElement());
+								modsUpdateEl.addContent(separator);
 								objectEl.addContent(modsUpdateEl);
+								objectEl.addContent(separator);
 							}
 
 							xmlOutput.output(objectEl, xfop);

--- a/admin/src/main/java/edu/unc/lib/dl/admin/controller/SearchController.java
+++ b/admin/src/main/java/edu/unc/lib/dl/admin/controller/SearchController.java
@@ -130,14 +130,14 @@ public class SearchController extends AbstractSearchController {
 	Map<String, Object> searchJSON(@PathVariable("pid") String pid, HttpServletRequest request,
 			HttpServletResponse response) {
 		SearchResultResponse resultResponse = getSearchResults(getSearchRequest(pid, request));
-		return getResults(resultResponse, "search");
+		return getResults(resultResponse, "search", request);
 	}
 
 	@RequestMapping(value = "search", method = RequestMethod.GET, produces = "application/json")
 	public @ResponseBody
 	Map<String, Object> searchJSON(HttpServletRequest request, HttpServletResponse response) {
 		SearchResultResponse resultResponse = getSearchResults(getSearchRequest(null, request));
-		return getResults(resultResponse, "search");
+		return getResults(resultResponse, "search", request);
 	}
 
 	@RequestMapping(value = "search", method = RequestMethod.GET)
@@ -170,14 +170,14 @@ public class SearchController extends AbstractSearchController {
 	Map<String, Object> listJSON(@PathVariable("pid") String pid, HttpServletRequest request,
 			HttpServletResponse response) {
 		SearchResultResponse resultResponse = getSearchResults(getListRequest(pid, request));
-		return getResults(resultResponse, "list");
+		return getResults(resultResponse, "list", request);
 	}
 
 	@RequestMapping(value = "list", method = RequestMethod.GET, produces = "application/json")
 	public @ResponseBody
 	Map<String, Object> listJSON(HttpServletRequest request, HttpServletResponse response) {
 		SearchResultResponse resultResponse = getSearchResults(getListRequest(collectionsPid.getPid(), request));
-		return getResults(resultResponse, "list");
+		return getResults(resultResponse, "list", request);
 	}
 
 	@RequestMapping(value = "list", method = RequestMethod.GET, produces = "text/html")
@@ -196,7 +196,8 @@ public class SearchController extends AbstractSearchController {
 		return searchRequest;
 	}
 
-	private Map<String, Object> getResults(SearchResultResponse resp, String queryMethod) {
+	private Map<String, Object> getResults(SearchResultResponse resp, String queryMethod,
+			HttpServletRequest request) {
 		AccessGroupSet groups = GroupsThreadStore.getGroups();
 		List<Map<String, Object>> resultList = SerializationUtil.resultsToList(resp, groups);
 		Map<String, Object> results = new HashMap<>();
@@ -209,6 +210,15 @@ public class SearchController extends AbstractSearchController {
 		results.put("searchStateUrl", SearchStateUtil.generateStateParameterString(state));
 		results.put("searchQueryUrl", SearchStateUtil.generateSearchParameterString(state));
 		results.put("queryMethod", queryMethod);
+		results.put("onyen", GroupsThreadStore.getUsername());
+
+		String email = request.getHeader("mail");
+		if (email != null) {
+			if (email.endsWith("_UNC")) {
+				email = email.substring(0, email.length() - 4);
+			}
+			results.put("email", email);
+		}
 
 		if (resp.getSelectedContainer() != null) {
 			results.put("container", SerializationUtil.metadataToMap(resp.getSelectedContainer(), groups));

--- a/admin/src/main/webapp/WEB-INF/uiapp-servlet.xml
+++ b/admin/src/main/webapp/WEB-INF/uiapp-servlet.xml
@@ -134,4 +134,10 @@
 		<property name="helperClasses" ref="vocabHelperClassMap" />
 		<property name="collectionsPID" ref="collectionsPid" />
 	</bean>
+	
+	<bean id="mailSender" class="org.springframework.mail.javamail.JavaMailSenderImpl">
+		<property name="host" value="${smtp.host:localhost}" />
+		<property name="port" value="${smtp.port:25}" />
+		<property name="defaultEncoding" value="UTF-8" />
+	</bean>
 </beans>

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/DatastreamDocument.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/DatastreamDocument.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.fedora;
+
+import org.jdom2.Document;
+
+/**
+ * @author bbpennel
+ * @date Jul 2, 2015
+ */
+public class DatastreamDocument {
+	private final Document document;
+	private final String lastModified;
+
+	public DatastreamDocument(Document document, String lastModified) {
+		super();
+		this.document = document;
+		this.lastModified = lastModified;
+	}
+
+	public Document getDocument() {
+		return document;
+	}
+
+	public String getLastModified() {
+		return lastModified;
+	}
+}

--- a/persistence/src/main/java/edu/unc/lib/dl/services/DigitalObjectManager.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/services/DigitalObjectManager.java
@@ -191,5 +191,4 @@ public interface DigitalObjectManager {
 	 */
 	void editDefaultWebObject(List<PID> dwo, boolean clear, String user) throws UpdateException;
 
-
 }

--- a/persistence/src/main/java/edu/unc/lib/dl/services/DigitalObjectManagerImpl.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/services/DigitalObjectManagerImpl.java
@@ -294,7 +294,7 @@ public class DigitalObjectManagerImpl implements DigitalObjectManager {
 			do {
 				try {
 					log.debug("Assigning {} as the DWO for {}", dwo, aggregate);
-					DatastreamDocument relsExtResp = getXMLDatastreamIfExists(aggregate, RELS_EXT.getName());
+					DatastreamDocument relsExtResp = managementClient.getXMLDatastreamIfExists(aggregate, RELS_EXT.getName());
 	
 					if (relsExtResp == null) {
 						throw new UpdateException("Unable to retrieve RELS-EXT for " + aggregate

--- a/persistence/src/test/java/edu/unc/lib/dl/services/DigitalObjectManagerImplTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/services/DigitalObjectManagerImplTest.java
@@ -59,12 +59,13 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import edu.unc.lib.dl.acl.util.AccessGroupSet;
 import edu.unc.lib.dl.acl.util.Permission;
 import edu.unc.lib.dl.fedora.AccessClient;
+import edu.unc.lib.dl.fedora.ClientUtils;
+import edu.unc.lib.dl.fedora.DatastreamDocument;
 import edu.unc.lib.dl.fedora.FedoraAccessControlService;
 import edu.unc.lib.dl.fedora.FedoraException;
 import edu.unc.lib.dl.fedora.ManagementClient;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.fedora.ServiceException;
-import edu.unc.lib.dl.fedora.types.Datastream;
 import edu.unc.lib.dl.fedora.types.MIMETypedStream;
 import edu.unc.lib.dl.ingest.IngestException;
 import edu.unc.lib.dl.update.UpdateException;
@@ -409,15 +410,13 @@ public class DigitalObjectManagerImplTest {
 	public void testChangeResourceType() throws Exception {
 		String relsName = ContentModelHelper.Datastream.RELS_EXT.toString();
 		
-		Datastream relsDS = mock(Datastream.class);
-		when(relsDS.getCreateDate()).thenReturn("2015-06-03");
-		when(managementClient.getDatastream(any(PID.class), eq(relsName))).thenReturn(relsDS);
+		DatastreamDocument dsDoc = mock(DatastreamDocument.class);
+		when(dsDoc.getLastModified()).thenReturn("2015-06-03");
+		when(managementClient.getXMLDatastreamIfExists(any(PID.class), eq(relsName)))
+			.thenReturn(dsDoc);
 		
-		MIMETypedStream datastream = mock(MIMETypedStream.class);
-		byte[] stream = IOUtils.toByteArray(getClass().getResourceAsStream("/datastream/collectionRels.xml"));
-		when(datastream.getStream()).thenReturn(stream);
-		
-		when(accessClient.getDatastreamDissemination(any(PID.class), eq(relsName), anyString())).thenReturn(datastream);
+		when(dsDoc.getDocument()).thenReturn(ClientUtils.parseXML(
+				IOUtils.toByteArray(getClass().getResourceAsStream("/datastream/collectionRels.xml"))));
 		
 		when(aclService.hasAccess(any(PID.class), any(AccessGroupSet.class), eq(Permission.editResourceType)))
 		.thenReturn(true);


### PR DESCRIPTION
Exports an XML document containing the MODS for a set of selected objects.  The set can either be specified as a tree starting from a selected folder or by selecting a set of specific objects via the admin interface.  The exported XML document is sent to the provided email address (or the user's default email address).

Moved getXMLDatastreamIfExists from DigitalObjectManager to ManagementClient so that it can be more broadly used, and because it's a more fitting home