### PR TITLE
Wildcard searching

### DIFF
--- a/access-common/src/test/resources/search.properties
+++ b/access-common/src/test/resources/search.properties
@@ -1,4 +1,3 @@
-search.solr.reservedCharacters=+-!(){}[]^"~*?:\\
 search.query.maxLength=256
 search.query.defaultOperator=AND
 search.query.operators=AND,OR

--- a/access/src/test/resources/search.properties
+++ b/access/src/test/resources/search.properties
@@ -1,4 +1,3 @@
-search.solr.reservedCharacters=+-!(){}[]^"~*?:\\
 search.query.maxLength=256
 search.query.defaultOperator=AND
 search.query.operators=AND,OR

--- a/solr-search/src/main/java/edu/unc/lib/dl/search/solr/util/SolrSettings.java
+++ b/solr-search/src/main/java/edu/unc/lib/dl/search/solr/util/SolrSettings.java
@@ -24,7 +24,6 @@ import java.util.regex.Pattern;
 
 import org.apache.solr.client.solrj.SolrServer;
 import org.apache.solr.client.solrj.impl.HttpSolrServer;
-import org.apache.solr.client.solrj.util.ClientUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -109,7 +108,22 @@ public class SolrSettings extends AbstractSettings {
 	public static String sanitize(String value) {
 		if (value == null)
 			return value;
-		return escapeReservedWords.matcher(ClientUtils.escapeQueryChars(value)).replaceAll("'$1'");
+		return escapeReservedWords.matcher(escapeQueryChars(value)).replaceAll("'$1'");
+	}
+
+	public static String escapeQueryChars(String s) {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < s.length(); i++) {
+			char c = s.charAt(i);
+			// These characters are part of the query syntax and must be escaped
+			if (c == '\\' || c == '+' || c == '-' || c == '!' || c == '(' || c == ')' || c == ':' || c == '^' || c == '['
+					|| c == ']' || c == '\"' || c == '{' || c == '}' || c == '~' || c == '?' || c == '|'
+					|| c == '&' || c == ';' || c == '/' || Character.isWhitespace(c)) {
+				sb.append('\\');
+			}
+			sb.append(c);
+		}
+		return sb.toString();
 	}
 
 	private static Pattern splitTermFragmentsRegex = Pattern.compile("(\"(([^\"]|\\\")*)\"|([^\" ,]+))");

--- a/solr-search/src/main/java/edu/unc/lib/dl/search/solr/util/SolrSettings.java
+++ b/solr-search/src/main/java/edu/unc/lib/dl/search/solr/util/SolrSettings.java
@@ -103,12 +103,13 @@ public class SolrSettings extends AbstractSettings {
 		return server;
 	}
 
-	private static Pattern escapeReservedWords = Pattern.compile("\\b(AND|OR|NOT)\\b");
+	private static Pattern escapeReservedWords
+		= Pattern.compile("(\\s|[\\\\+\\-!():\\^\\[\\]\"{}~?|&;/])(AND|OR|NOT)(\\s|[\\\\+\\-!():\\^\\[\\]\"{}~?|&;/])");
 
 	public static String sanitize(String value) {
 		if (value == null)
 			return value;
-		return escapeReservedWords.matcher(escapeQueryChars(value)).replaceAll("'$1'");
+		return escapeReservedWords.matcher(escapeQueryChars(value)).replaceAll("$1'$2'$3");
 	}
 
 	public static String escapeQueryChars(String s) {

--- a/solr-search/src/main/java/edu/unc/lib/dl/search/solr/util/SolrSettings.java
+++ b/solr-search/src/main/java/edu/unc/lib/dl/search/solr/util/SolrSettings.java
@@ -104,12 +104,12 @@ public class SolrSettings extends AbstractSettings {
 	}
 
 	private static Pattern escapeReservedWords
-		= Pattern.compile("(\\s|[\\\\+\\-!():\\^\\[\\]\"{}~?|&;/])(AND|OR|NOT)(\\s|[\\\\+\\-!():\\^\\[\\]\"{}~?|&;/])");
+		= Pattern.compile("\\b(?<!\\*)(AND|OR|NOT)\\b(?!\\*)");
 
 	public static String sanitize(String value) {
 		if (value == null)
 			return value;
-		return escapeReservedWords.matcher(escapeQueryChars(value)).replaceAll("$1'$2'$3");
+		return escapeReservedWords.matcher(escapeQueryChars(value)).replaceAll("'$1'");
 	}
 
 	public static String escapeQueryChars(String s) {

--- a/solr-search/src/test/java/edu/unc/lib/dl/search/solr/util/SolrSettingsTest.java
+++ b/solr-search/src/test/java/edu/unc/lib/dl/search/solr/util/SolrSettingsTest.java
@@ -27,6 +27,16 @@ public class SolrSettingsTest extends Assert {
 		String pid = SolrSettings.sanitize("uuid:2dbf9ab9-0c47-42c7-8e7c-5092febf3415");
 		assertEquals("uuid\\:2dbf9ab9\\-0c47\\-42c7\\-8e7c\\-5092febf3415", pid);
 		
+		assertEquals("*.txt", SolrSettings.sanitize("*.txt"));
+		assertEquals("\\/regex\\/*.txt", SolrSettings.sanitize("/regex/*.txt"));
+		
+		assertEquals("AND*", SolrSettings.sanitize("AND*"));
+		assertEquals("hello\\ 'OR'\\ world", SolrSettings.sanitize("hello OR world"));
+	}
+	
+	@Test
+	public void sanitizeWildCardTest() {
+		
 	}
 	
 	@Test
@@ -47,6 +57,11 @@ public class SolrSettingsTest extends Assert {
 		tokens = SolrSettings.getSearchTermFragments("\"hello world\" welcome");
 		assertEquals("\"hello\\ world\"", tokens.get(0));
 		assertEquals("welcome", tokens.get(1));
+		assertEquals(2, tokens.size());
+		
+		tokens = SolrSettings.getSearchTermFragments("\"hello world\" wel*");
+		assertEquals("\"hello\\ world\"", tokens.get(0));
+		assertEquals("wel*", tokens.get(1));
 		assertEquals(2, tokens.size());
 	}
 	

--- a/solr-search/src/test/java/edu/unc/lib/dl/search/solr/util/SolrSettingsTest.java
+++ b/solr-search/src/test/java/edu/unc/lib/dl/search/solr/util/SolrSettingsTest.java
@@ -32,6 +32,7 @@ public class SolrSettingsTest extends Assert {
 		
 		assertEquals("AND*", SolrSettings.sanitize("AND*"));
 		assertEquals("hello\\ 'OR'\\ world", SolrSettings.sanitize("hello OR world"));
+		assertEquals("hello\\ *AND*\\ world", SolrSettings.sanitize("hello *AND* world"));
 	}
 	
 	@Test

--- a/solr-search/src/test/resources/search.properties
+++ b/solr-search/src/test/resources/search.properties
@@ -1,4 +1,3 @@
-#search.solr.reservedCharacters=+-!(){}[]^"~*?:\\
 search.query.maxLength=256
 search.query.defaultOperator=AND
 search.query.operators=AND,OR


### PR DESCRIPTION
Not particularly elegant, but it seemed better to duplicate the solr parameter cleaning method minus the * character versus unescaping the character.