### PR TITLE
Embargo clearing

### DIFF
--- a/services/src/main/resources/edu/unc/lib/dl/cdr/services/solr/embargo-update-candidates.sparql
+++ b/services/src/main/resources/edu/unc/lib/dl/cdr/services/solr/embargo-update-candidates.sparql
@@ -2,5 +2,5 @@ SELECT ?pid
 FROM <%1$s>
 WHERE {
 	?pid <http://cdr.unc.edu/definitions/acl#embargo-until> ?embargoUntil
-	FILTER (?embargoUntil > "%2$s"^^xsd:dateTime && ?embargoUntil <= "%3$s"^^xsd:dateTime)
+	FILTER (?embargoUntil <= "%2$s"^^xsd:dateTime)
 }

--- a/services/src/main/resources/scheduled-events.properties
+++ b/services/src/main/resources/scheduled-events.properties
@@ -1,13 +1,2 @@
 #Cron schedule format
-scheduled.embargoUpdate.cron=0 0 0 * * ?
-scheduled.embargoUpdate.windowHours=24
-scheduled.acCacheReset.cron=0 0 * * * ?
-scheduled.catchUpActivate.cron=0 0 1 * * ?
-scheduled.catchUpDeactivate.cron=0 0 5 * * ?
-scheduled.backupFailedPids.cron=0 0 0/2 * * ?
-scheduled.cleanupFinishedEnhancements.cron=0 0 0 * * ?
-scheduled.cleanupFinishedEnhancements.windowMilli=86400000
-scheduled.cleanupFinishedIndexing.cron=0 0 0/4 * * ?
-scheduled.cleanupFinishedIndexing.windowMilli=11400000
-#Time between event firings
-#scheduled.thisIsAnExample.timer=3600
+scheduled.embargoUpdate.cron=0 0 1 * * ?

--- a/services/src/main/webapp/WEB-INF/service-context.xml
+++ b/services/src/main/webapp/WEB-INF/service-context.xml
@@ -340,10 +340,9 @@
 	</bean>
 	
 	<bean id="embargoUpdateService" class="edu.unc.lib.dl.cdr.services.solr.EmbargoUpdateService">
-		<property name="solrSearchService" ref="queryLayer" />
+		<property name="managementClient" ref="managementClient" />
 		<property name="tripleStoreQueryService" ref="tripleStoreQueryService"/>
-		<property name="active" value="true"/>
-		<property name="windowSizeHours" value="${scheduled.embargoUpdate.windowHours}" />
+		<property name="messageSender" ref="operationsMessageSender"/>
 	</bean>
 	
 	<bean id="solrJMXService" class="edu.unc.lib.dl.cdr.services.jmx.SolrJMXService">
@@ -390,7 +389,7 @@
 		</property>
 		<property name="autoStartup">
 			<value>true</value>
-        </property>
+		</property>
 		<property name="configLocation" value="classpath:quartz.properties"/>
 	</bean>
 	


### PR DESCRIPTION
Refactored embargo service to remove embargo relations when the embargo expires, and record the expired embargo in premis.  Processes all expired embargoes instead of those within a window to avoid the risk of embargoes never lifting