### PR TITLE
Record deposit metrics.

### DIFF
--- a/deposit/src/main/java/edu/unc/lib/deposit/work/DepositSupervisor.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/work/DepositSupervisor.java
@@ -390,9 +390,11 @@ public class DepositSupervisor implements WorkerListener {
 				if (t instanceof JobFailedException) {
 					jobStatusFactory.failed(jobUUID, t.getLocalizedMessage());
 					depositStatusFactory.fail(depositUUID, t.getLocalizedMessage());
+					depositStatusFactory.incrFailedJob(job.getClassName());
 				} else {
 					jobStatusFactory.failed(jobUUID);
 					depositStatusFactory.fail(depositUUID);
+					depositStatusFactory.incrFailed();
 				}
 				
 				depositEmailHandler.sendDepositResults(depositUUID);
@@ -566,6 +568,7 @@ public class DepositSupervisor implements WorkerListener {
 			c.end();
 		} else {
 			depositStatusFactory.setState(depositUUID, DepositState.finished);
+			depositStatusFactory.incrFinished();
 			
 			depositEmailHandler.sendDepositResults(depositUUID);
 			depositMessageHandler.sendDepositMessage(depositUUID);

--- a/metadata/src/main/java/edu/unc/lib/dl/util/RedisWorkerConstants.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/util/RedisWorkerConstants.java
@@ -3,6 +3,7 @@ package edu.unc.lib.dl.util;
 public class RedisWorkerConstants {
 	public static final String DEPOSIT_SET = "deposits";
 	public static final String DEPOSIT_STATUS_PREFIX = "deposit-status:";
+	public static final String DEPOSIT_METRICS_PREFIX = "deposit-metrics:";
 	public static final String INGESTS_CONFIRMED_PREFIX = "ingests-confirmed:";
 	public static final String INGESTS_UPLOADED_PREFIX = "ingests-uploaded:";
 	public static final String DEPOSIT_TO_JOBS_PREFIX = "deposit-to-jobs:";


### PR DESCRIPTION
Whenever a deposit fails or finishes, a field in a hash with a key of today's date is incremented. The number of finished and failed deposits is recorded, along with counts per job class name.

To get metrics for a particular day:

  > HGETALL deposit-metrics:2015-08-07
  1) "finished"
  2) "1"
  3) "failed"
  4) "2"
  5) "failed-job:edu.unc.lib.deposit.normalize.CDRMETS2N3BagJob"
  6) "1"
  7) "failed-job:edu.unc.lib.deposit.validate.VirusScanJob"
  8) "1"