### PR TITLE
Prevent duplicate deposit jobs from enqueuing when resuming

### DIFF
--- a/deposit/src/main/resources/service-context.xml
+++ b/deposit/src/main/resources/service-context.xml
@@ -67,6 +67,11 @@
 		<constructor-arg ref="jedisPool" />
 	</bean>
 	
+	<bean id="queueDAO" class="net.greghaines.jesque.meta.dao.impl.QueueInfoDAORedisImpl">
+		<constructor-arg ref="jesqueConfig" />
+		<constructor-arg ref="jedisPool" />
+	</bean>
+	
 	<bean id="dataSet" class="com.hp.hpl.jena.tdb.TDBFactory" factory-method="createDataset" destroy-method="close">
 		<constructor-arg value="${deposits.dir}/jena-tdb-dataset"/>
 	</bean>

--- a/deposit/src/test/resources/service-context.xml
+++ b/deposit/src/test/resources/service-context.xml
@@ -73,6 +73,11 @@
 		<constructor-arg ref="jedisPool" />
 	</bean>
 	
+	<bean id="queueDAO" class="net.greghaines.jesque.meta.dao.impl.QueueInfoDAORedisImpl">
+		<constructor-arg ref="jesqueConfig" />
+		<constructor-arg ref="jedisPool" />
+	</bean>
+	
 	<bean id="dataSet" class="com.hp.hpl.jena.tdb.TDBFactory" factory-method="createDataset" destroy-method="close">
 		<constructor-arg value="#{depositsDirectory+'/jena-tdb-dataset'}"/>
 	</bean>

--- a/metadata/src/main/java/edu/unc/lib/dl/util/RedisWorkerConstants.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/util/RedisWorkerConstants.java
@@ -9,6 +9,11 @@ public class RedisWorkerConstants {
 	public static final String DEPOSIT_TO_JOBS_PREFIX = "deposit-to-jobs:";
 	public static final String JOB_STATUS_PREFIX = "job-status:";
 
+	public static final String DEPOSIT_PREPARE_QUEUE = "PREPARE";
+	public static final String DEPOSIT_DELAYED_QUEUE = "DELAYED_PREPARE";
+	public static final String DEPOSIT_CDRMETS_QUEUE = "CDRMETSCONVERT";
+	public static final String RESQUE_QUEUE_PREFIX = "resque:queue:";
+
 	public static enum DepositField {
 		uuid, state, actionRequest, contactName, depositorName, intSenderIdentifier, intSenderDescription,
 		fileName, resubmitDirName, resubmitFileName, isResubmit, depositMethod, containerId, payLoadOctets,


### PR DESCRIPTION
Verifying that jobs are not already queued for a deposit before resuming or re-enqueuing during service startup to prevent duplicate jobs being created