### PR TITLE
Fixes for deposit emails related to vocab enforcement failures

### DIFF
--- a/deposit/src/main/java/edu/unc/lib/deposit/work/DepositSupervisor.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/work/DepositSupervisor.java
@@ -36,9 +36,9 @@ import edu.unc.lib.deposit.normalize.Simple2N3BagJob;
 import edu.unc.lib.deposit.normalize.UnpackDepositJob;
 import edu.unc.lib.deposit.normalize.VocabularyEnforcementJob;
 import edu.unc.lib.deposit.validate.PackageIntegrityCheckJob;
+import edu.unc.lib.deposit.validate.ValidateFileAvailabilityJob;
 import edu.unc.lib.deposit.validate.ValidateMODS;
 import edu.unc.lib.deposit.validate.VirusScanJob;
-import edu.unc.lib.deposit.validate.ValidateFileAvailabilityJob;
 import edu.unc.lib.dl.fedora.FedoraTimeoutException;
 import edu.unc.lib.dl.util.DepositConstants;
 import edu.unc.lib.dl.util.DepositStatusFactory;
@@ -390,12 +390,12 @@ public class DepositSupervisor implements WorkerListener {
 				if (t instanceof JobFailedException) {
 					jobStatusFactory.failed(jobUUID, t.getLocalizedMessage());
 					depositStatusFactory.fail(depositUUID, t.getLocalizedMessage());
-					depositStatusFactory.incrFailedJob(job.getClassName());
 				} else {
 					jobStatusFactory.failed(jobUUID);
-					depositStatusFactory.fail(depositUUID);
-					depositStatusFactory.incrFailed();
+					String serviceName = job.getClassName().substring(job.getClassName().lastIndexOf('.') + 1);
+					depositStatusFactory.fail(depositUUID, "Failed while performing service " + serviceName);
 				}
+				depositStatusFactory.incrFailedJob(job.getClassName());
 				
 				depositEmailHandler.sendDepositResults(depositUUID);
 				

--- a/deposit/src/main/resources/email_html.txt
+++ b/deposit/src/main/resources/email_html.txt
@@ -26,7 +26,7 @@
   <img style="float: right;" alt="UNC Libraries logo" src="{{baseUrl}}/static/images/email_logo.png"/>
   {{^error}}
   <h3>CDR deposit complete: {{fileName}}</h3>
-  <p>{{ingestedObjects}} item(s) successfully deposited.</p>
+  {{#ingestedObjects}}<p>{{ingestedObjects}} item(s) successfully deposited.</p>{{/ingestedObjects}}
   {{/error}}
   {{#error}}
   <h3>CDR deposit error: {{fileName}}</h3>

--- a/deposit/src/main/resources/email_html.txt
+++ b/deposit/src/main/resources/email_html.txt
@@ -18,21 +18,23 @@
 <html>
 <head>
   <title>
-    {{^error}}CDR deposit complete: {{fileName}}{{/error}}
-    {{#error}}CDR deposit error: {{fileName}}{{/error}}
+    {{^failed}}CDR deposit complete: {{fileName}}{{/failed}}
+    {{#failed}}CDR deposit failed: {{fileName}}{{/failed}}
   </title>
 </head>
 <body>
   <img style="float: right;" alt="UNC Libraries logo" src="{{baseUrl}}/static/images/email_logo.png"/>
-  {{^error}}
+  {{^failed}}
   <h3>CDR deposit complete: {{fileName}}</h3>
   {{#ingestedObjects}}<p>{{ingestedObjects}} item(s) successfully deposited.</p>{{/ingestedObjects}}
-  {{/error}}
-  {{#error}}
-  <h3>CDR deposit error: {{fileName}}</h3>
-  <p>There was an error processing your deposit.</p> 
-  <div style="background: yellow">{{errorMessage}}</div>
-  {{/error}}
+  {{/failed}}
+  {{#failed}}
+  <h3>CDR deposit failed: {{fileName}}</h3>
+  <p>There was an error processing your deposit.</p>
+  {{#errorMessage}}
+    <div style="background: yellow">{{errorMessage}}</div>
+  {{/errorMessage}}
+  {{/failed}}
   <p>For details, see the <a href="{{baseUrl}}/admin/statusMonitor">status monitor</a>.</p>
   <p>Thank you for contributing to the <a href="{{baseUrl}}">Carolina Digital Repository</a>, a service of the <a href="http://www.lib.unc.edu/">University of North Carolina at Chapel Hill Libraries</a>.</p>
 </body>

--- a/deposit/src/main/resources/email_text.txt
+++ b/deposit/src/main/resources/email_text.txt
@@ -18,7 +18,7 @@
 {{^error}}CDR deposit complete: {{fileName}}{{/error}}
 {{#error}}CDR deposit error: {{fileName}}{{/error}}
 
-{{^error}}{{ingestedObjects}} item(s) successfully deposited.{{/error}}
+{{^error}}{{#ingestedObjects}}{{ingestedObjects}} item(s) successfully deposited.{{/ingestedObjects}}{{/error}}
 {{#error}}
 There was an error processing your deposit:
 

--- a/deposit/src/main/resources/email_text.txt
+++ b/deposit/src/main/resources/email_text.txt
@@ -15,15 +15,16 @@
     limitations under the License.
 
 }}
-{{^error}}CDR deposit complete: {{fileName}}{{/error}}
-{{#error}}CDR deposit error: {{fileName}}{{/error}}
+{{^failed}}CDR deposit complete: {{fileName}}{{/failed}}
+{{#failed}}CDR deposit failed: {{fileName}}{{/failed}}
 
-{{^error}}{{#ingestedObjects}}{{ingestedObjects}} item(s) successfully deposited.{{/ingestedObjects}}{{/error}}
-{{#error}}
-There was an error processing your deposit:
-
+{{^failed}}{{#ingestedObjects}}{{ingestedObjects}} item(s) successfully deposited.{{/ingestedObjects}}{{/failed}}
+{{#failed}}
+There was an error processing your deposit.
+{{#errorMessage}}
   {{errorMessage}}
-{{/error}}
+{{/errorMessage}}
+{{/failed}}
 
 For details, see the status monitor:
 

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/ManagementClient.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/ManagementClient.java
@@ -931,6 +931,20 @@ public class ManagementClient extends WebServiceTemplate {
 		return false;
 	}
 
+	/**
+	 * Blocks until the repository is accessible or the process is interrupted
+	 */
+	public void waitForRepositoryAvailable() {
+		while (!isRepositoryAvailable()) {
+			try {
+				log.info("Waiting for the repository to become available");
+				Thread.sleep(10000L);
+			} catch (InterruptedException e) {
+				return;
+			}
+		}
+	}
+
 	public String writePremisEventsToFedoraObject(PremisEventLogger eventLogger, PID pid) throws FedoraException {
 		Document dom = null;
 		boolean newDatastream = false;

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/util/VocabularyHelperManager.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/util/VocabularyHelperManager.java
@@ -86,6 +86,9 @@ public class VocabularyHelperManager {
 	private Boolean initialized = false;
 
 	public synchronized void init() {
+		// Wait for the repository to be up before loading vocabularies
+		managementClient.waitForRepositoryAvailable();
+		
 		log.debug("Initializing vocabulary helpers");
 		initialized = true;
 


### PR DESCRIPTION
* Wait for the repository to become available before initializing the departments vocabulary to prevent VocabularyEnforcementJob from failing due to an NPE
* Store a failure message for non-JobFailureExceptions so that the mail sender will realize the job failed
* Check that the ingested count variable is set in deposit email template so that it won't throw an exception when the deposit fails before the ingest job