### PR TITLE
Relationship updating cleanup

### DIFF
--- a/deposit/src/main/java/edu/unc/lib/deposit/fcrepo3/IngestDeposit.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/fcrepo3/IngestDeposit.java
@@ -316,7 +316,8 @@ public class IngestDeposit extends AbstractDepositJob implements ListenerJob {
 
 		while (true) {
 			try {
-				client.addObjectRelationship(destinationPID, Relationship.contains.getURI().toString(), new PID(pid));
+				client.addObjectRelationship(destinationPID, Relationship.contains.name(),
+						Relationship.contains.getNamespace(), new PID(pid));
 				return;
 			} catch (FedoraTimeoutException e) {
 				throw e;

--- a/deposit/src/test/java/edu/unc/lib/deposit/fcrepo3/IngestDepositTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/fcrepo3/IngestDepositTest.java
@@ -239,7 +239,7 @@ public class IngestDepositTest {
 		verify(jobStatusFactory, times(job.getIngestObjectCount() + 1)).incrCompletion(eq(job.getJobUUID()), eq(1));
 
 		verify(client, times(job.getTopLevelPids().size()))
-				.addObjectRelationship(any(PID.class), anyString(), any(PID.class));
+				.addObjectRelationship(any(PID.class), anyString(), any(Namespace.class), any(PID.class));
 
 		verify(client, times(job.getIngestObjectCount() + 1))
 				.ingestRaw(any(byte[].class), any(Format.class), anyString());
@@ -275,7 +275,7 @@ public class IngestDepositTest {
 		jobThread.join();
 
 		// Only the one successful top level pid added because of ordering
-		verify(client).addObjectRelationship(any(PID.class), anyString(), any(PID.class));
+		verify(client).addObjectRelationship(any(PID.class), anyString(), any(Namespace.class), any(PID.class));
 
 		// Failing on third ingestRaw
 		verify(client, times(3)).ingestRaw(any(byte[].class), any(Format.class), anyString());
@@ -358,7 +358,7 @@ public class IngestDepositTest {
 		verify(jobStatusFactory, times(job.getIngestObjectCount())).incrCompletion(eq(job.getJobUUID()), eq(1));
 
 		verify(client, times(job.getTopLevelPids().size())).addObjectRelationship(any(PID.class), anyString(),
-				any(PID.class));
+				any(Namespace.class), any(PID.class));
 
 		verify(client, times(job.getIngestObjectCount())).ingestRaw(any(byte[].class), any(Format.class), anyString());
 
@@ -399,7 +399,7 @@ public class IngestDepositTest {
 		verify(jobStatusFactory, times(job.getIngestObjectCount() + 1)).incrCompletion(eq(job.getJobUUID()), eq(1));
 
 		verify(client, times(job.getTopLevelPids().size())).addObjectRelationship(any(PID.class), anyString(),
-				any(PID.class));
+				any(Namespace.class), any(PID.class));
 
 		verify(client, times(job.getIngestObjectCount() + 1))
 				.ingestRaw(any(byte[].class), any(Format.class), anyString());
@@ -439,7 +439,7 @@ public class IngestDepositTest {
 		verify(jobStatusFactory, times(job.getIngestObjectCount() + 2)).incrCompletion(eq(job.getJobUUID()), eq(1));
 
 		verify(client, times(job.getTopLevelPids().size())).addObjectRelationship(any(PID.class), anyString(),
-				any(PID.class));
+				any(Namespace.class), any(PID.class));
 
 	}
 

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/ManagementClient.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/ManagementClient.java
@@ -266,9 +266,9 @@ public class ManagementClient extends WebServiceTemplate {
 	public void addTriple(PID pid, String pred, Namespace ns, boolean isLiteral, String value, String datatype)
 			throws FedoraException {
 		
-		DatastreamDocument dsDoc = getRELSEXTWithRetries(pid);
-		
 		do {
+			DatastreamDocument dsDoc = getRELSEXTWithRetries(pid);
+			
 			try {
 				Document doc = dsDoc.getDocument();
 				RDFXMLUtil.addTriple(doc.getRootElement(), pred, ns, isLiteral, value, datatype);
@@ -683,9 +683,9 @@ public class ManagementClient extends WebServiceTemplate {
 	public boolean purgeTriple(PID pid, String predicate, Namespace ns, boolean isLiteral, String value,
 			String datatype) throws FedoraException {
 		
-		DatastreamDocument dsDoc = getRELSEXTWithRetries(pid);
-		
 		do {
+			DatastreamDocument dsDoc = getRELSEXTWithRetries(pid);
+			
 			try {
 				Document doc = dsDoc.getDocument();
 				boolean removed = RDFXMLUtil.removeTriple(doc.getRootElement(), predicate, ns, isLiteral, value, datatype);
@@ -1065,9 +1065,9 @@ public class ManagementClient extends WebServiceTemplate {
 			boolean isLiteral, String datatype)
 			throws FedoraException {
 		
-		DatastreamDocument dsDoc = getRELSEXTWithRetries(pid);
-		
 		do {
+			DatastreamDocument dsDoc = getRELSEXTWithRetries(pid);
+			
 			try {
 				Document doc = dsDoc.getDocument();
 				RDFXMLUtil.setExclusiveTriple(doc.getRootElement(), predicate, namespace, isLiteral, value, datatype);

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/ManagementClient.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/ManagementClient.java
@@ -271,7 +271,7 @@ public class ManagementClient extends WebServiceTemplate {
 		do {
 			try {
 				Document doc = dsDoc.getDocument();
-				RDFXMLUtil.addTriple(doc.getRootElement(), pid, pred, ns, isLiteral, value, datatype);
+				RDFXMLUtil.addTriple(doc.getRootElement(), pred, ns, isLiteral, value, datatype);
 				
 				modifyDatastream(pid, RELS_EXT.getName(),
 						"Setting exclusive relation", dsDoc.getLastModified(), dsDoc.getDocument());
@@ -1070,7 +1070,7 @@ public class ManagementClient extends WebServiceTemplate {
 		do {
 			try {
 				Document doc = dsDoc.getDocument();
-				RDFXMLUtil.setExclusiveTriple(doc.getRootElement(), pid, predicate, namespace, isLiteral, value, datatype);
+				RDFXMLUtil.setExclusiveTriple(doc.getRootElement(), predicate, namespace, isLiteral, value, datatype);
 				
 				modifyDatastream(pid, RELS_EXT.getName(),
 						"Setting exclusive relation", dsDoc.getLastModified(), dsDoc.getDocument());

--- a/metadata/src/main/java/edu/unc/lib/dl/xml/RDFXMLUtil.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/xml/RDFXMLUtil.java
@@ -69,25 +69,25 @@ public class RDFXMLUtil {
 		return removed;
 	}
 	
-	public static void setExclusiveRelation(Element root, PID subject, String predicate, Namespace ns, PID object) {
-		setExclusiveTriple(root, subject, predicate, ns, false, object.getURI(), null);
+	public static void setExclusiveRelation(Element root, String predicate, Namespace ns, PID object) {
+		setExclusiveTriple(root, predicate, ns, false, object.getURI(), null);
 	}
 	
-	public static void setExclusiveLiteral(Element root, PID subject, String predicate, Namespace ns,
+	public static void setExclusiveLiteral(Element root, String predicate, Namespace ns,
 			String value, String datatype) {
-		setExclusiveTriple(root, subject, predicate, ns, true, value, datatype);
+		setExclusiveTriple(root, predicate, ns, true, value, datatype);
 	}
 
-	public static void setExclusiveTriple(Element root, PID pid, String predicate, Namespace ns, boolean isLiteral,
+	public static void setExclusiveTriple(Element root, String predicate, Namespace ns, boolean isLiteral,
 			String value, String datatype) {
 		Element descEl = root.getChild("Description", JDOMNamespaceUtil.RDF_NS);
 		
 		descEl.removeChildren(predicate, ns);
 		
-		addTriple(root, pid, predicate, ns, isLiteral, value, datatype);
+		addTriple(root, predicate, ns, isLiteral, value, datatype);
 	}
 	
-	public static void addTriple(Element root, PID pid, String predicate, Namespace ns, boolean isLiteral,
+	public static void addTriple(Element root, String predicate, Namespace ns, boolean isLiteral,
 			String value, String datatype) {
 		Element descEl = root.getChild("Description", JDOMNamespaceUtil.RDF_NS);
 		

--- a/metadata/src/main/java/edu/unc/lib/dl/xml/RDFXMLUtil.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/xml/RDFXMLUtil.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.xml;
+
+import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.RDF_NS;
+
+import java.util.Iterator;
+
+import org.jdom2.Element;
+import org.jdom2.Namespace;
+
+import edu.unc.lib.dl.fedora.PID;
+
+/**
+ * @author bbpennel
+ * @date Aug 24, 2015
+ */
+public class RDFXMLUtil {
+	
+	public static boolean removeRelationship(Element root, String predicate, Namespace ns, PID object) {
+		return removeTriple(root, predicate, ns, false, object.getURI(), null);
+	}
+	
+	public static boolean removeLiteral(Element root, String predicate, Namespace ns, String value, String datatype) {
+		return removeTriple(root, predicate, ns, true, value, datatype);
+	}
+	
+	public static boolean removeTriple(Element root, String predicate, Namespace ns, boolean isLiteral,
+			String value, String datatype) {
+		Element descEl = root.getChild("Description", RDF_NS);
+		if (value == null) {
+			// Specific value not specified, remove all by predicate
+			return descEl.removeChildren(predicate, ns);
+		}
+		
+		boolean removed = false;
+		Iterator<Element> elIt = descEl.getChildren(predicate, ns).iterator();
+		while (elIt.hasNext()) {
+			Element el = elIt.next();
+			if (isLiteral) {
+				if (datatype != null && !datatype.equals(el.getAttributeValue("resource", RDF_NS))) {
+					continue;
+				}
+				if (value.equals(el.getText())) {
+					elIt.remove();
+					removed = true;
+				}
+			} else {
+				String atVal = el.getAttributeValue("resource", RDF_NS);
+				if (value.equals(atVal)) {
+					elIt.remove();
+					removed = true;
+				}
+			}
+		}
+		return removed;
+	}
+	
+	public static void setExclusiveRelation(Element root, PID subject, String predicate, Namespace ns, PID object) {
+		setExclusiveTriple(root, subject, predicate, ns, false, object.getURI(), null);
+	}
+	
+	public static void setExclusiveLiteral(Element root, PID subject, String predicate, Namespace ns,
+			String value, String datatype) {
+		setExclusiveTriple(root, subject, predicate, ns, true, value, datatype);
+	}
+
+	public static void setExclusiveTriple(Element root, PID pid, String predicate, Namespace ns, boolean isLiteral,
+			String value, String datatype) {
+		Element descEl = root.getChild("Description", JDOMNamespaceUtil.RDF_NS);
+		
+		descEl.removeChildren(predicate, ns);
+		
+		addTriple(root, pid, predicate, ns, isLiteral, value, datatype);
+	}
+	
+	public static void addTriple(Element root, PID pid, String predicate, Namespace ns, boolean isLiteral,
+			String value, String datatype) {
+		Element descEl = root.getChild("Description", JDOMNamespaceUtil.RDF_NS);
+		
+		Element relEl = new Element(predicate, ns);
+		if (isLiteral) {
+			if (datatype != null) {
+				relEl.setAttribute("datatype", datatype, JDOMNamespaceUtil.RDF_NS);
+			}
+			relEl.setText(value);
+		} else {
+			relEl.setAttribute("resource", value, JDOMNamespaceUtil.RDF_NS);
+		}
+		
+		descEl.addContent(relEl);
+	}
+}

--- a/persistence/src/main/java/edu/unc/lib/dl/services/DigitalObjectManager.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/services/DigitalObjectManager.java
@@ -22,28 +22,11 @@ import edu.unc.lib.dl.fedora.NotFoundException;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.ingest.IngestException;
 import edu.unc.lib.dl.update.UpdateException;
-import edu.unc.lib.dl.util.ContentModelHelper;
 import edu.unc.lib.dl.util.ContentModelHelper.Datastream;
 import edu.unc.lib.dl.util.ContentModelHelper.Model;
 import edu.unc.lib.dl.util.ResourceType;
 
 public interface DigitalObjectManager {
-
-	/**
-	 * Adds a relationship between two repository objects.
-	 *
-	 * @param subject
-	 *           the subject PID
-	 * @param rel
-	 *           the relationship (enum)
-	 * @param object
-	 *           the object PID
-	 * @throws NotFoundException
-	 *            if either object is not found
-	 * @throws IngestException
-	 */
-	public void addRelationship(PID subject, ContentModelHelper.Relationship rel, PID object) throws NotFoundException,
-			IngestException;
 	
 	/**
 	 * Changes the content models of the subject to the content models necessary to change to the new resource type
@@ -73,22 +56,6 @@ public interface DigitalObjectManager {
 	 *           the PIDs of the objects to inactive
 	 */
 	// public abstract void inactivate(PID id, Agent user, String message) throws IngestException;
-
-	/**
-	 * Removes a relationship between two repository objects
-	 *
-	 * @param subject
-	 *           the subject PID
-	 * @param rel
-	 *           the relationship enum
-	 * @param object
-	 *           the object PID
-	 * @throws NotFoundException
-	 *            if either objects or their relationship are not found
-	 * @throws IngestException
-	 */
-	public void purgeRelationship(PID subject, ContentModelHelper.Relationship rel, PID object)
-			throws NotFoundException, IngestException;
 
 	/**
 	 * Updates the specified source datastream on an object with appropriate additions to preservation logs. Note that

--- a/persistence/src/test/java/edu/unc/lib/dl/services/DigitalObjectManagerImplTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/services/DigitalObjectManagerImplTest.java
@@ -41,6 +41,7 @@ import javax.annotation.Resource;
 import org.apache.commons.io.IOUtils;
 import org.jdom2.Attribute;
 import org.jdom2.Document;
+import org.jdom2.Namespace;
 import org.jdom2.filter.Filters;
 import org.jdom2.xpath.XPathExpression;
 import org.jdom2.xpath.XPathFactory;
@@ -175,26 +176,6 @@ public class DigitalObjectManagerImplTest {
 
 	/**
 	 * Test method for
-	 * {@link edu.unc.lib.dl.services.DigitalObjectManagerImpl#addRelationship(edu.unc.lib.dl.fedora.PID, edu.unc.lib.dl.util.ContentModelHelper.Relationship, edu.unc.lib.dl.fedora.PID)}
-	 * .
-	 */
-	@Test
-	public void testAddRelationship() {
-		try {
-			when(forwardedManagementClient.addObjectRelationship(any(PID.class), any(String.class), any(PID.class)))
-					.thenReturn(
-					Boolean.TRUE);
-			this.getDigitalObjectManagerImpl().addRelationship(new PID("cdr:test1"),
-					ContentModelHelper.Relationship.contains, new PID("cdr:test2"));
-			verify(forwardedManagementClient, times(1)).addObjectRelationship(any(PID.class),
-					eq(ContentModelHelper.Relationship.contains.getURI().toString()), any(PID.class));
-		} catch (Exception e) {
-			fail("Got unexpected exception: " + e.getMessage());
-		}
-	}
-
-	/**
-	 * Test method for
 	 * {@link edu.unc.lib.dl.services.DigitalObjectManagerImpl#delete(edu.unc.lib.dl.fedora.PID, edu.unc.lib.dl.agents.Agent, java.lang.String)}
 	 * .
 	 */
@@ -211,8 +192,8 @@ public class DigitalObjectManagerImplTest {
 		when(tripleStoreQueryService.fetchObjectReferences(any(PID.class))).thenReturn(refs);
 		when(tripleStoreQueryService.fetchContainer(any(PID.class))).thenReturn(container, container, container);
 
-		when(forwardedManagementClient.purgeObjectRelationship(any(PID.class), any(String.class), any(PID.class)))
-				.thenReturn(true);
+		when(forwardedManagementClient.purgeObjectRelationship(any(PID.class), any(String.class),
+				any(Namespace.class), any(PID.class))).thenReturn(true);
 
 		ArrayList<URI> cms = new ArrayList<URI>();
 		cms.add(ContentModelHelper.Model.CONTAINER.getURI());
@@ -269,8 +250,8 @@ public class DigitalObjectManagerImplTest {
 		when(tripleStoreQueryService.fetchObjectReferences(any(PID.class))).thenReturn(refs);
 		when(tripleStoreQueryService.fetchContainer(any(PID.class))).thenReturn(container, container, container);
 
-		when(forwardedManagementClient.purgeObjectRelationship(any(PID.class), any(String.class), any(PID.class)))
-				.thenReturn(true);
+		when(forwardedManagementClient.purgeObjectRelationship(any(PID.class), any(String.class),
+				any(Namespace.class), any(PID.class))).thenReturn(true);
 
 		ArrayList<URI> cms = new ArrayList<URI>();
 		cms.add(ContentModelHelper.Model.CONTAINER.getURI());
@@ -322,8 +303,8 @@ public class DigitalObjectManagerImplTest {
 		when(tripleStoreQueryService.fetchObjectReferences(any(PID.class))).thenReturn(refs);
 		when(tripleStoreQueryService.fetchContainer(any(PID.class))).thenReturn(container, container, container);
 
-		when(forwardedManagementClient.purgeObjectRelationship(any(PID.class), any(String.class), any(PID.class)))
-				.thenReturn(true);
+		when(forwardedManagementClient.purgeObjectRelationship(any(PID.class), any(String.class),
+				any(Namespace.class), any(PID.class))).thenReturn(true);
 
 		ArrayList<URI> cms = new ArrayList<URI>();
 		cms.add(ContentModelHelper.Model.CONTAINER.getURI());
@@ -368,20 +349,6 @@ public class DigitalObjectManagerImplTest {
 
 	/**
 	 * Test method for
-	 * {@link edu.unc.lib.dl.services.DigitalObjectManagerImpl#purgeRelationship(edu.unc.lib.dl.fedora.PID, edu.unc.lib.dl.util.ContentModelHelper.Relationship, edu.unc.lib.dl.fedora.PID)}
-	 * .
-	 */
-	@Test
-	public void testPurgeRelationship() throws Exception {
-		PID test = new PID("test:object");
-		PID test2 = new PID("test:object2");
-		this.getDigitalObjectManagerImpl().purgeRelationship(test, ContentModelHelper.Relationship.member, test2);
-		verify(forwardedManagementClient, times(1)).purgeObjectRelationship(eq(test),
-				eq(ContentModelHelper.Relationship.member.getURI().toString()), eq(test2));
-	}
-
-	/**
-	 * Test method for
 	 * {@link edu.unc.lib.dl.services.DigitalObjectManagerImpl#updateSourceData(edu.unc.lib.dl.fedora.PID, java.lang.String, java.io.File, java.lang.String, java.lang.String, java.lang.String, edu.unc.lib.dl.agents.Agent, java.lang.String)}
 	 * .
 	 */
@@ -397,8 +364,7 @@ public class DigitalObjectManagerImplTest {
 	public void testAvailabilityException() throws Exception {
 		this.getDigitalObjectManagerImpl().setAvailable(false,
 				"The repository manager is unavailable for a test of the availability check.");
-		this.getDigitalObjectManagerImpl().addRelationship(new PID("foo"), ContentModelHelper.Relationship.member,
-				new PID("bar"));
+		this.getDigitalObjectManagerImpl().delete(new PID("foo"), "Delete", "user");
 	}
 	
 	@Test(expected = UpdateException.class)

--- a/persistence/src/test/java/edu/unc/lib/dl/services/DigitalObjectManagerMoveTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/services/DigitalObjectManagerMoveTest.java
@@ -177,7 +177,7 @@ public class DigitalObjectManagerMoveTest {
 		PairedAnswer sourceRelsExtAnswer = new PairedAnswer(doc, sourceRelsExtMatcher);
 		when(dsDoc.getDocument()).thenAnswer(sourceRelsExtAnswer);
 		
-		when(managementClient.getXMLDatastreamIfExists(eq(targetPID), eq(RELS_EXT.getName())))
+		when(managementClient.getRELSEXTWithRetries(eq(targetPID)))
 			.thenReturn(dsDoc);
 
 		doNothing().when(managementClient)
@@ -199,7 +199,7 @@ public class DigitalObjectManagerMoveTest {
 
 		digitalMan.move(moving, destPID, "user", "");
 
-		verify(managementClient, times(2)).getXMLDatastreamIfExists(eq(source1PID), eq(RELS_EXT.getName()));
+		verify(managementClient, times(2)).getRELSEXTWithRetries(eq(source1PID));
 		
 		verifySourceMoved(source1PID, moving, 10);
 		verifyDestinationMoved(moving, 9);
@@ -255,7 +255,7 @@ public class DigitalObjectManagerMoveTest {
 
 		DatastreamDocument dsDoc = mock(DatastreamDocument.class);
 		when(dsDoc.getDocument()).thenAnswer(sourceRelsExtAnswer);
-		when(managementClient.getXMLDatastreamIfExists(eq(source1PID), eq(RELS_EXT.getName())))
+		when(managementClient.getRELSEXTWithRetries(eq(source1PID)))
 				.thenReturn(dsDoc);
 
 		Datastream ds = mock(Datastream.class);
@@ -269,7 +269,7 @@ public class DigitalObjectManagerMoveTest {
 
 		digitalMan.move(moving, destPID, "user", "");
 
-		verify(managementClient, times(3)).getXMLDatastreamIfExists(eq(source1PID), eq(RELS_EXT.getName()));
+		verify(managementClient, times(3)).getRELSEXTWithRetries(eq(source1PID));
 
 		ArgumentCaptor<Document> sourceRelsExtUpdateCaptor = ArgumentCaptor.forClass(Document.class);
 
@@ -321,8 +321,8 @@ public class DigitalObjectManagerMoveTest {
 
 		digitalMan.move(moving, destPID, "user", "");
 
-		verify(managementClient, times(2)).getXMLDatastreamIfExists(eq(source1PID), eq(RELS_EXT.getName()));
-		verify(managementClient, times(2)).getXMLDatastreamIfExists(eq(source2PID), eq(RELS_EXT.getName()));
+		verify(managementClient, times(2)).getRELSEXTWithRetries(eq(source1PID));
+		verify(managementClient, times(2)).getRELSEXTWithRetries(eq(source2PID));
 		
 		verifySourceMoved(source1PID, Arrays.asList(new PID("uuid:child1")), 11);
 		verifySourceMoved(source2PID, Arrays.asList(new PID("uuid:child32")), 1);
@@ -338,7 +338,7 @@ public class DigitalObjectManagerMoveTest {
 		when(doc.getRootElement()).thenReturn(
 				new Element("RDF", JDOMNamespaceUtil.RDF_NS)
 				.addContent(new Element("Description", JDOMNamespaceUtil.RDF_NS)));
-		when(managementClient.getXMLDatastreamIfExists(any(PID.class), anyString()))
+		when(managementClient.getRELSEXTWithRetries(any(PID.class)))
 				.thenReturn(dsDoc);
 		
 		List<PID> moving = Arrays.asList(new PID("uuid:child1"), new PID("uuid:child5"));
@@ -363,7 +363,7 @@ public class DigitalObjectManagerMoveTest {
 				.thenReturn(Arrays.asList(Arrays.asList(source1PID.getPid())))
 				.thenReturn(null).thenReturn(null);
 		
-		when(managementClient.getXMLDatastreamIfExists(eq(destPID), eq(RELS_EXT.getName()))).thenReturn(null);
+		when(managementClient.getRELSEXTWithRetries(eq(destPID))).thenReturn(null);
 
 		try {
 			digitalMan.move(moving, destPID, "user", "");
@@ -418,7 +418,7 @@ public class DigitalObjectManagerMoveTest {
 				.thenReturn(Arrays.asList(Arrays.asList(destPID.getPid())));
 		
 		// Second attempt to get the source RELS-EXT will return null to trigger rollback
-		when (managementClient.getXMLDatastreamIfExists(eq(source1PID), eq(RELS_EXT.getName())))
+		when (managementClient.getRELSEXTWithRetries(eq(source1PID)))
 			.thenReturn(dsDoc).thenThrow(new FedoraException("")).thenReturn(dsDoc);
 
 		try {
@@ -516,7 +516,7 @@ public class DigitalObjectManagerMoveTest {
 	private void verifyDestinationMoved(List<PID> moving, int destinationCount)
 			throws Exception {
 		// Verify that the destination had the moved children added to it
-		verify(managementClient).getXMLDatastreamIfExists(eq(destPID), eq(RELS_EXT.getName()));
+		verify(managementClient).getRELSEXTWithRetries(eq(destPID));
 		ArgumentCaptor<Document> destRelsExtUpdateCaptor = ArgumentCaptor.forClass(Document.class);
 		verify(managementClient).modifyDatastream(eq(destPID), eq(RELS_EXT.getName()), anyString(),
 				anyString(), destRelsExtUpdateCaptor.capture());

--- a/services-worker/src/main/java/edu/unc/lib/dl/cdr/services/AbstractFedoraEnhancement.java
+++ b/services-worker/src/main/java/edu/unc/lib/dl/cdr/services/AbstractFedoraEnhancement.java
@@ -19,72 +19,33 @@ import java.util.List;
 
 import org.jdom2.Document;
 import org.jdom2.Element;
-import org.jdom2.Namespace;
 
 import edu.unc.lib.dl.cdr.services.model.EnhancementMessage;
 import edu.unc.lib.dl.fedora.FedoraException;
+import edu.unc.lib.dl.fedora.ManagementClient;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.util.ContentModelHelper;
 import edu.unc.lib.dl.xml.FOXMLJDOMUtil;
 import edu.unc.lib.dl.xml.JDOMNamespaceUtil;
 
 public abstract class AbstractFedoraEnhancement extends Enhancement<Element> {
+	
 	protected AbstractFedoraEnhancementService service;
 	protected EnhancementMessage message;
+	protected ManagementClient client;
 	
 	protected AbstractFedoraEnhancement(AbstractFedoraEnhancementService service, PID pid) {
 		super(pid);
 		this.service = service;
 		this.message = null;
+		this.client = service.getManagementClient();
 	}
 	
 	protected AbstractFedoraEnhancement(AbstractFedoraEnhancementService service, EnhancementMessage message) {
 		super(message.getPid());
 		this.message = message;
 		this.service = service;
-	}
-	
-	protected void setExclusiveTripleRelation(PID pid, String predicate, Namespace namespace, PID exclusivePID, Document foxml)
-			throws FedoraException {
-		List<String> rel = FOXMLJDOMUtil.getRelationValues(predicate, namespace, FOXMLJDOMUtil.getRelsExt(foxml));
-		String predicateUri = namespace.getURI() + predicate;
-		if (rel != null) {
-			String valueString = exclusivePID.toString();
-			if (rel.contains(valueString)) {
-				rel.remove(valueString);
-			} else {
-				// add missing rel
-				service.getManagementClient().addObjectRelationship(pid, predicateUri, exclusivePID);
-			}
-			// remove any other same predicate triples
-			for (String oldValue : rel) {
-				service.getManagementClient().purgeObjectRelationship(pid, predicateUri, new PID(oldValue));
-			}
-		} else {
-			// add missing rel
-			service.getManagementClient().addObjectRelationship(pid, predicateUri, exclusivePID);
-		}
-	}
-	
-	protected void setExclusiveTripleValue(PID pid, String predicate, Namespace namespace, String newExclusiveValue, String datatype, Document foxml)
-			throws FedoraException {
-		List<String> rel = FOXMLJDOMUtil.getRelationValues(predicate, namespace, FOXMLJDOMUtil.getRelsExt(foxml));
-		String predicateUri = namespace.getURI() + predicate;
-		if (rel != null) {
-			if (rel.contains(newExclusiveValue)) {
-				rel.remove(newExclusiveValue);
-			} else {
-				// add missing rel
-				service.getManagementClient().addLiteralStatement(pid, predicateUri, newExclusiveValue, datatype);
-			}
-			// remove any other same predicate triples
-			for (String oldValue : rel) {
-				service.getManagementClient().purgeLiteralStatement(pid, predicateUri, oldValue, datatype);
-			}
-		} else {
-			// add missing rel
-			service.getManagementClient().addLiteralStatement(pid, predicateUri, newExclusiveValue, datatype);
-		}
+		this.client = service.getManagementClient();
 	}
 	
 	protected Document retrieveFoxml() throws FedoraException {

--- a/services-worker/src/main/java/edu/unc/lib/dl/cdr/services/imaging/ImageEnhancement.java
+++ b/services-worker/src/main/java/edu/unc/lib/dl/cdr/services/imaging/ImageEnhancement.java
@@ -37,7 +37,10 @@ import edu.unc.lib.dl.fedora.FileSystemException;
 import edu.unc.lib.dl.fedora.NotFoundException;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.util.ContentModelHelper;
+import edu.unc.lib.dl.util.ContentModelHelper.CDRProperty;
 import edu.unc.lib.dl.util.ContentModelHelper.Datastream;
+import edu.unc.lib.dl.util.ContentModelHelper.FedoraProperty;
+import edu.unc.lib.dl.util.ContentModelHelper.Model;
 import edu.unc.lib.dl.xml.FOXMLJDOMUtil;
 import edu.unc.lib.dl.xml.JDOMNamespaceUtil;
 
@@ -80,7 +83,7 @@ public class ImageEnhancement extends AbstractFedoraEnhancement {
 
 				LOG.debug("Image DS location: {}", dsLocation);
 				if (dsLocation != null) {
-					dsIrodsPath = service.getManagementClient().getIrodsPath(dsLocation);
+					dsIrodsPath = client.getIrodsPath(dsLocation);
 					// Ask irods to make the jp2 object
 					LOG.debug("Convert to JP2");
 					String convertResultPath = runConvertJP2(dsIrodsPath);
@@ -94,13 +97,13 @@ public class ImageEnhancement extends AbstractFedoraEnhancement {
 					if (exists) {
 						LOG.debug("Replacing managed datastream for JP2");
 						String message = "Replacing derived JP2000 image datastream.";
-						service.getManagementClient().modifyDatastreamByReference(pid,
+						client.modifyDatastreamByReference(pid,
 								Datastream.IMAGE_JP2000.getName(), false, message,
 								new ArrayList<String>(), "Derived JP2000 image", "image/jp2", null, null, convertResultURI);
 					} else {
 						LOG.debug("Adding managed datastream for JP2");
 						String message = "Adding derived JP2000 image datastream.";
-						service.getManagementClient().addManagedDatastream(pid,
+						client.addManagedDatastream(pid,
 								Datastream.IMAGE_JP2000.getName(), false, message,
 								new ArrayList<String>(), "Derived JP2000 image", false, "image/jp2", convertResultURI);
 					}
@@ -112,8 +115,8 @@ public class ImageEnhancement extends AbstractFedoraEnhancement {
 
 					List<String> jp2rel = rels.get(ContentModelHelper.CDRProperty.derivedJP2.toString());
 					if (jp2rel == null || !jp2rel.contains(newDSPID.getURI())) {
-						service.getManagementClient().addObjectRelationship(pid,
-								ContentModelHelper.CDRProperty.derivedJP2.toString(), newDSPID);
+						client.setExclusiveTripleRelation(pid, CDRProperty.derivedJP2.getPredicate(),
+								CDRProperty.derivedJP2.getNamespace(), newDSPID);
 					}
 
 					// add object model
@@ -121,9 +124,8 @@ public class ImageEnhancement extends AbstractFedoraEnhancement {
 					if (models == null
 							|| !models.contains(ContentModelHelper.Model.JP2DERIVEDIMAGE.getPID().getURI().toString())) {
 						LOG.debug("Adding JP2DerivedImage content model relationship");
-						service.getManagementClient().addObjectRelationship(pid,
-								ContentModelHelper.FedoraProperty.hasModel.toString(),
-								ContentModelHelper.Model.JP2DERIVEDIMAGE.getPID());
+						client.setExclusiveTripleRelation(pid, FedoraProperty.hasModel.getFragment(),
+								FedoraProperty.hasModel.getNamespace(), Model.JP2DERIVEDIMAGE.getPID());
 					}
 
 					// Clean up the temporary irods file

--- a/services-worker/src/main/java/edu/unc/lib/dl/cdr/services/techmd/TechnicalMetadataEnhancement.java
+++ b/services-worker/src/main/java/edu/unc/lib/dl/cdr/services/techmd/TechnicalMetadataEnhancement.java
@@ -47,6 +47,7 @@ import edu.unc.lib.dl.fedora.FileSystemException;
 import edu.unc.lib.dl.fedora.NotFoundException;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.util.ContentModelHelper;
+import edu.unc.lib.dl.util.ContentModelHelper.CDRProperty;
 import edu.unc.lib.dl.xml.FOXMLJDOMUtil;
 import edu.unc.lib.dl.xml.JDOMNamespaceUtil;
 
@@ -187,19 +188,17 @@ public class TechnicalMetadataEnhancement extends AbstractFedoraEnhancement {
 							fitsMimetype = fitsMimetype.substring(0, index);
 						}
 						
-						setExclusiveTripleValue(pid, ContentModelHelper.CDRProperty.hasSourceMimeType.getPredicate(),
-								ContentModelHelper.CDRProperty.hasSourceMimeType.getNamespace(), fitsMimetype, null, foxml);
+						client.setExclusiveLiteral(pid, CDRProperty.hasSourceMimeType.getPredicate(),
+								CDRProperty.hasSourceMimeType.getNamespace(), fitsMimetype, null);
 					} else { // application/octet-stream
-						setExclusiveTripleValue(pid, ContentModelHelper.CDRProperty.hasSourceMimeType.getPredicate(),
-								ContentModelHelper.CDRProperty.hasSourceMimeType.getNamespace(), "application/octet-stream",
-								null, foxml);
+						client.setExclusiveLiteral(pid, CDRProperty.hasSourceMimeType.getPredicate(),
+								CDRProperty.hasSourceMimeType.getNamespace(), "application/octet-stream", null);
 					}
 
 					try {
 						Long.parseLong(size);
-						setExclusiveTripleValue(pid, ContentModelHelper.CDRProperty.hasSourceFileSize.getPredicate(),
-								ContentModelHelper.CDRProperty.hasSourceFileSize.getNamespace(), size,
-								"http://www.w3.org/2001/XMLSchema#long", foxml);
+						client.setExclusiveLiteral(pid, CDRProperty.hasSourceFileSize.getPredicate(),
+								CDRProperty.hasSourceFileSize.getNamespace(), size, "http://www.w3.org/2001/XMLSchema#long");
 					} catch (NumberFormatException e) {
 						LOG.error("FITS produced a non-integer value for size: " + size);
 					}
@@ -242,13 +241,13 @@ public class TechnicalMetadataEnhancement extends AbstractFedoraEnhancement {
 			if (FOXMLJDOMUtil.getDatastream(foxml, ContentModelHelper.Datastream.MD_TECHNICAL.getName()) == null) {
 				LOG.debug("Adding FITS output to MD_TECHNICAL");
 				String message = "Adding technical metadata derived by FITS";
-				service.getManagementClient().addManagedDatastream(pid,
+				client.addManagedDatastream(pid,
 						ContentModelHelper.Datastream.MD_TECHNICAL.getName(), false, message, new ArrayList<String>(),
 						"PREMIS Technical Metadata", false, "text/xml", premisTechURL);
 			} else {
 				LOG.debug("Replacing MD_TECHNICAL with new FITS output");
 				String message = "Replacing technical metadata derived by FITS";
-				service.getManagementClient().modifyDatastreamByReference(pid,
+				client.modifyDatastreamByReference(pid,
 						ContentModelHelper.Datastream.MD_TECHNICAL.getName(), false, message, new ArrayList<String>(),
 						"PREMIS Technical Metadata", "text/xml", null, null, premisTechURL);
 			}
@@ -259,8 +258,8 @@ public class TechnicalMetadataEnhancement extends AbstractFedoraEnhancement {
 
 			List<String> techrel = rels.get(ContentModelHelper.CDRProperty.techData.toString());
 			if (techrel == null || !techrel.contains(newDSPID.getURI())) {
-				service.getManagementClient().addObjectRelationship(pid,
-						ContentModelHelper.CDRProperty.techData.toString(), newDSPID);
+				client.addObjectRelationship(pid, CDRProperty.techData.getPredicate(),
+						CDRProperty.techData.getNamespace(), newDSPID);
 			}
 
 			LOG.debug("Finished MD_TECHNICAL updating for {}", pid.getPid());

--- a/services-worker/src/main/java/edu/unc/lib/dl/cdr/services/text/FullTextEnhancement.java
+++ b/services-worker/src/main/java/edu/unc/lib/dl/cdr/services/text/FullTextEnhancement.java
@@ -38,6 +38,7 @@ import edu.unc.lib.dl.fedora.FileSystemException;
 import edu.unc.lib.dl.fedora.NotFoundException;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.util.ContentModelHelper;
+import edu.unc.lib.dl.util.ContentModelHelper.CDRProperty;
 import edu.unc.lib.dl.xml.FOXMLJDOMUtil;
 import edu.unc.lib.dl.xml.JDOMNamespaceUtil;
 
@@ -83,15 +84,14 @@ public class FullTextEnhancement extends AbstractFedoraEnhancement {
 				String dsIrodsPath = null;
 
 				if (dsLocation != null) {
-					dsIrodsPath = service.getManagementClient().getIrodsPath(dsLocation);
+					dsIrodsPath = client.getIrodsPath(dsLocation);
 
 					String text = this.extractText(dsIrodsPath);
 					
 					// Instead of adding an empty full text DS, add flag to indicate this object has nothing to extract some e
 					if (text == null || text.trim().length() == 0) {
-						setExclusiveTripleValue(pid, ContentModelHelper.CDRProperty.fullText.getPredicate(),
-								ContentModelHelper.CDRProperty.fullText.getNamespace(),
-								"false", null, foxml);
+						client.setExclusiveLiteral(pid, CDRProperty.fullText.getPredicate(),
+								CDRProperty.fullText.getNamespace(), "false", null);
 						continue;
 					}
 
@@ -102,20 +102,20 @@ public class FullTextEnhancement extends AbstractFedoraEnhancement {
 							.getDatastream(pid, MD_FULL_TEXT.getName()) != null;
 					if (exists) {
 						String message = "Replacing full text metadata extracted by Apache Tika";
-						service.getManagementClient().modifyDatastreamByReference(pid,
+						client.modifyDatastreamByReference(pid,
 								MD_FULL_TEXT.getName(), false, message, new ArrayList<String>(),
 								MD_FULL_TEXT.getLabel(), "text/plain", null, null, textURL);
 					} else {
 						String message = "Adding full text metadata extracted by Apache Tika";
-						service.getManagementClient().addManagedDatastream(pid,
+						client.addManagedDatastream(pid,
 								MD_FULL_TEXT.getName(), false, message, new ArrayList<String>(),
 								MD_FULL_TEXT.getLabel(), false, "text/plain", textURL);
 					}
 
 					// Add full text relation
-					PID textPID = new PID(pid.getPid() + "/" + MD_FULL_TEXT.getName());
-					setExclusiveTripleRelation(pid, ContentModelHelper.CDRProperty.fullText.getPredicate(),
-							ContentModelHelper.CDRProperty.fullText.getNamespace(), textPID, foxml);
+					PID textPID = new PID(pid.getPid() + "/" + ContentModelHelper.Datastream.MD_FULL_TEXT.getName());
+					client.setExclusiveTripleRelation(pid, CDRProperty.fullText.getPredicate(),
+							CDRProperty.fullText.getNamespace(), textPID);
 				}
 			}
 		} catch (FileSystemException e) {

--- a/services-worker/src/main/resources/service-context.xml
+++ b/services-worker/src/main/resources/service-context.xml
@@ -71,7 +71,6 @@
 		<property name="username" value="${fedora.admin.username}" />
 		<property name="password" value="${fedora.admin.password}" />
 		<property name="accessClient" ref="accessClient"/>
-		<property name="tripleStoreQueryService" ref="tripleStoreQueryService"/>
 	</bean>
 	<bean id="forwardedManagementClient" class="edu.unc.lib.dl.fedora.ManagementClient"
 		init-method="init" destroy-method="destroy">
@@ -80,7 +79,6 @@
 		<property name="username" value="${fedora.appUser.username}" />
 		<property name="password" value="${fedora.appUser.password}" />
 		<property name="accessClient" ref="accessClient"/>
-		<property name="tripleStoreQueryService" ref="tripleStoreQueryService"/>
 		<property name="interceptors">
 			<list>
 				<bean class="edu.unc.lib.dl.acl.filter.GroupsToHttpHeaderInterceptor" />

--- a/services-worker/src/test/java/edu/unc/lib/dl/cdr/services/imaging/ImageEnhancementServiceITCase.java
+++ b/services-worker/src/test/java/edu/unc/lib/dl/cdr/services/imaging/ImageEnhancementServiceITCase.java
@@ -51,6 +51,7 @@ import edu.unc.lib.dl.fedora.ManagementClient.Format;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.fedora.types.Datastream;
 import edu.unc.lib.dl.util.ContentModelHelper;
+import edu.unc.lib.dl.util.ContentModelHelper.CDRProperty;
 import edu.unc.lib.dl.util.JMSMessageUtil;
 import edu.unc.lib.dl.util.TripleStoreQueryService;
 
@@ -89,7 +90,7 @@ public class ImageEnhancementServiceITCase {
 	@Resource
 	private ImageEnhancementService imageEnhancementService = null;
 
-	private Set<PID> samples = new HashSet<PID>();
+	private final Set<PID> samples = new HashSet<PID>();
 
 
 	/**
@@ -117,11 +118,11 @@ public class ImageEnhancementServiceITCase {
 					Collections.<String>emptyList(), dataFilename, true, mimetype, uploadURI);
 			PID dataFilePID = new PID(pid.getPid() + "/DATA_FILE");
 			this.getManagementClient().addObjectRelationship(pid,
-					ContentModelHelper.CDRProperty.sourceData.getURI().toString(), dataFilePID);
-			this.getManagementClient().addLiteralStatement(pid,
-					ContentModelHelper.CDRProperty.hasSourceMimeType.getURI().toString(), mimetype, null);
+					CDRProperty.sourceData.getPredicate(), CDRProperty.sourceData.getNamespace(), dataFilePID);
+			this.getManagementClient().addLiteralStatement(pid, CDRProperty.hasSourceMimeType.getPredicate(),
+					CDRProperty.hasSourceMimeType.getNamespace(), mimetype, null);
 		}
-		EnhancementMessage result = new EnhancementMessage(pid, JMSMessageUtil.servicesMessageNamespace, 
+		EnhancementMessage result = new EnhancementMessage(pid, JMSMessageUtil.servicesMessageNamespace,
 				JMSMessageUtil.ServicesActions.APPLY_SERVICE_STACK.getName());
 		samples.add(pid);
 		return result;
@@ -212,8 +213,8 @@ public class ImageEnhancementServiceITCase {
 
 		LOG.debug("Adding JP2 relationship again for kicks");
 		PID newDSPID = new PID(pidTIFF.getPid().getPid()+"/"+ ContentModelHelper.Datastream.IMAGE_JP2000.getName());
-		this.getManagementClient().addObjectRelationship(pidTIFF.getPid(),
-				"http://cdr.unc.edu/definitions/1.0/base-model.xml#derivedJP2", newDSPID);
+		this.getManagementClient().addObjectRelationship(pidTIFF.getPid(), CDRProperty.derivedJP2.getPredicate(),
+				CDRProperty.derivedJP2.getNamespace(), newDSPID);
 	}
 
 	public TripleStoreQueryService getTripleStoreQueryService() {

--- a/services-worker/src/test/java/edu/unc/lib/dl/cdr/services/imaging/ThumbnailEnhancementServiceITCase.java
+++ b/services-worker/src/test/java/edu/unc/lib/dl/cdr/services/imaging/ThumbnailEnhancementServiceITCase.java
@@ -49,6 +49,7 @@ import edu.unc.lib.dl.fedora.ManagementClient.Format;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.fedora.types.Datastream;
 import edu.unc.lib.dl.util.ContentModelHelper;
+import edu.unc.lib.dl.util.ContentModelHelper.CDRProperty;
 import edu.unc.lib.dl.util.JMSMessageUtil;
 import edu.unc.lib.dl.util.TripleStoreQueryService;
 
@@ -87,7 +88,7 @@ public class ThumbnailEnhancementServiceITCase {
 	@Resource
 	private ThumbnailEnhancementService thumbnailEnhancementService = null;
 
-	private Set<PID> samples = new HashSet<PID>();
+	private final Set<PID> samples = new HashSet<PID>();
 
 	/**
 	 * @throws java.lang.Exception
@@ -113,12 +114,13 @@ public class ThumbnailEnhancementServiceITCase {
 			this.getManagementClient().addManagedDatastream(pid, "DATA_FILE", false, "Thumbnail Test",
 					Collections.<String>emptyList(), dataFilename, true, mimetype, uploadURI);
 			PID dataFilePID = new PID(pid.getPid() + "/DATA_FILE");
-			this.getManagementClient().addObjectRelationship(pid,
-					ContentModelHelper.CDRProperty.sourceData.getURI().toString(), dataFilePID);
+			this.getManagementClient().addObjectRelationship(pid, CDRProperty.sourceData.getPredicate(),
+					CDRProperty.sourceData.getNamespace(), dataFilePID);
 			this.getManagementClient().addLiteralStatement(pid,
-					ContentModelHelper.CDRProperty.hasSourceMimeType.getURI().toString(), mimetype, null);
+					CDRProperty.hasSourceMimeType.getPredicate(),
+					CDRProperty.hasSourceMimeType.getNamespace(), mimetype, null);
 		}
-		EnhancementMessage result = new EnhancementMessage(pid, JMSMessageUtil.servicesMessageNamespace, 
+		EnhancementMessage result = new EnhancementMessage(pid, JMSMessageUtil.servicesMessageNamespace,
 				JMSMessageUtil.ServicesActions.APPLY_SERVICE_STACK.getName());
 		samples.add(pid);
 		return result;
@@ -150,7 +152,8 @@ public class ThumbnailEnhancementServiceITCase {
 
 		// FIXME setup collection with surrogate
 		EnhancementMessage pidCollYes = ingestSample("thumbnail-Coll-yes.xml", null, null);
-		this.managementClient.addObjectRelationship(pidCollYes.getPid(), ContentModelHelper.CDRProperty.hasSurrogate.getURI().toString(), pidTIFF.getPid());
+		this.managementClient.addObjectRelationship(pidCollYes.getPid(), CDRProperty.hasSurrogate.getPredicate(),
+				CDRProperty.hasSurrogate.getNamespace(), pidTIFF.getPid());
 
 		List<PID> results = this.getThumbnailEnhancementService().findCandidateObjects(50, 0);
 		for (PID p : results) {
@@ -172,7 +175,8 @@ public class ThumbnailEnhancementServiceITCase {
 
 		// setup collection with surrogate
 		EnhancementMessage pidCollYes = ingestSample("thumbnail-Coll-yes.xml", null, null);
-		this.managementClient.addObjectRelationship(pidCollYes.getPid(), ContentModelHelper.CDRProperty.hasSurrogate.getURI().toString(), pidTIFF.getPid());
+		this.managementClient.addObjectRelationship(pidCollYes.getPid(), CDRProperty.hasSurrogate.getPredicate(),
+				CDRProperty.hasSurrogate.getNamespace(), pidTIFF.getPid());
 
 		EnhancementMessage pidCollNo = ingestSample("thumbnail-Coll-no.xml", null, null);
 		// return false for a PID w/o sourcedata
@@ -214,7 +218,8 @@ public class ThumbnailEnhancementServiceITCase {
 		// ingest collection and tiff surrogate
 		EnhancementMessage pidCollYes = ingestSample("thumbnail-Coll-yes.xml", null, null);
 		EnhancementMessage pidTiff = ingestSample("thumbnail-TIFF.xml", "sample.tiff", "image/tiff");
-		this.managementClient.addObjectRelationship(pidCollYes.getPid(), ContentModelHelper.CDRProperty.hasSurrogate.getURI().toString(), pidTiff.getPid());
+		this.managementClient.addObjectRelationship(pidCollYes.getPid(), CDRProperty.hasSurrogate.getPredicate(),
+				CDRProperty.hasSurrogate.getNamespace(), pidTiff.getPid());
 
 
 		Enhancement<Element> en = this.getThumbnailEnhancementService().getEnhancement(pidCollYes);

--- a/services-worker/src/test/java/edu/unc/lib/dl/cdr/services/techmd/TechnicalMetadataEnhancementServiceITCase.java
+++ b/services-worker/src/test/java/edu/unc/lib/dl/cdr/services/techmd/TechnicalMetadataEnhancementServiceITCase.java
@@ -56,7 +56,7 @@ import edu.unc.lib.dl.fedora.ManagementClient.Context;
 import edu.unc.lib.dl.fedora.ManagementClient.Format;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.fedora.types.Datastream;
-import edu.unc.lib.dl.util.ContentModelHelper;
+import edu.unc.lib.dl.util.ContentModelHelper.CDRProperty;
 import edu.unc.lib.dl.util.JMSMessageUtil;
 import edu.unc.lib.dl.util.TripleStoreQueryService;
 
@@ -95,7 +95,7 @@ public class TechnicalMetadataEnhancementServiceITCase {
 	@Resource
 	private TechnicalMetadataEnhancementService technicalMetadataEnhancementService = null;
 
-	private Set<PID> samples = new HashSet<PID>();
+	private final Set<PID> samples = new HashSet<PID>();
 
 	/**
 	 * @throws java.lang.Exception
@@ -124,10 +124,10 @@ public class TechnicalMetadataEnhancementServiceITCase {
 			this.getManagementClient().addManagedDatastream(pid, "DATA_FILE", false, "Thumbnail Test",
 					altIDs, dataFilename, true, mimetype, uploadURI);
 			PID dataFilePID = new PID(pid.getPid() + "/DATA_FILE");
-			this.getManagementClient().addObjectRelationship(pid,
-					ContentModelHelper.CDRProperty.sourceData.getURI().toString(), dataFilePID);
+			this.getManagementClient().addObjectRelationship(pid, CDRProperty.sourceData.getPredicate(),
+					CDRProperty.sourceData.getNamespace(), dataFilePID);
 		}
-		EnhancementMessage result = new EnhancementMessage(pid, JMSMessageUtil.servicesMessageNamespace, 
+		EnhancementMessage result = new EnhancementMessage(pid, JMSMessageUtil.servicesMessageNamespace,
 				JMSMessageUtil.ServicesActions.APPLY_SERVICE_STACK.getName());
 		samples.add(pid);
 		return result;

--- a/services-worker/src/test/java/edu/unc/lib/dl/cdr/services/techmd/TechnicalMetadataEnhancementTest.java
+++ b/services-worker/src/test/java/edu/unc/lib/dl/cdr/services/techmd/TechnicalMetadataEnhancementTest.java
@@ -84,8 +84,8 @@ public class TechnicalMetadataEnhancementTest extends Assert {
 		verify(managementClient).addManagedDatastream(any(PID.class), eq(Datastream.MD_TECHNICAL.getName()),
 				anyBoolean(), anyString(), anyListOf(String.class), anyString(), anyBoolean(), anyString(), anyString());
 		
-		verify(managementClient).addLiteralStatement(any(PID.class), eq(CDRProperty.hasSourceMimeType.toString()),
-				eq("image/jpeg"), anyString());
+		verify(managementClient).setExclusiveLiteral(any(PID.class), eq(CDRProperty.hasSourceMimeType.getPredicate()),
+				eq(CDRProperty.hasSourceMimeType.getNamespace()), eq("image/jpeg"), anyString());
 	}
 	
 	@Test
@@ -104,7 +104,7 @@ public class TechnicalMetadataEnhancementTest extends Assert {
 				anyBoolean(), anyString(), anyListOf(String.class), anyString(), anyBoolean(), anyString(), anyString());
 		
 		// Check that the mimetype has had the encoding trimmed off
-		verify(managementClient).addLiteralStatement(any(PID.class), eq(CDRProperty.hasSourceMimeType.toString()),
-				eq("text/plain"), anyString());
+		verify(managementClient).setExclusiveLiteral(any(PID.class), eq(CDRProperty.hasSourceMimeType.getPredicate()),
+				eq(CDRProperty.hasSourceMimeType.getNamespace()), eq("text/plain"), anyString());
 	}
 }

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/modify/PublishRestController.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/modify/PublishRestController.java
@@ -39,7 +39,7 @@ import edu.unc.lib.dl.fedora.FedoraException;
 import edu.unc.lib.dl.fedora.ManagementClient;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.services.OperationsMessageSender;
-import edu.unc.lib.dl.util.ContentModelHelper;
+import edu.unc.lib.dl.util.ContentModelHelper.CDRProperty;
 
 @Controller
 public class PublishRestController {
@@ -73,8 +73,8 @@ public class PublishRestController {
 
 		try {
 			// Update relation
-			managementClient.setExclusiveLiteral(pid, ContentModelHelper.CDRProperty.isPublished.toString(),
-					(publish) ? "yes" : "no", null);
+			managementClient.setExclusiveLiteral(pid, CDRProperty.isPublished.getPredicate(),
+					CDRProperty.isPublished.getNamespace(), (publish) ? "yes" : "no", null);
 			result.put("timestamp", System.currentTimeMillis());
 			// Send message to trigger solr update
 			String messageId = messageSender.sendPublishOperation(username, Arrays.asList(pid), true);

--- a/services/src/main/webapp/WEB-INF/service-context.xml
+++ b/services/src/main/webapp/WEB-INF/service-context.xml
@@ -59,7 +59,6 @@
 		<property name="username" value="${fedora.admin.username}" />
 		<property name="password" value="${fedora.admin.password}" />
 		<property name="accessClient" ref="accessClient"/>
-		<property name="tripleStoreQueryService" ref="tripleStoreQueryService"/>
 	</bean>
 	<bean id="forwardedManagementClient" class="edu.unc.lib.dl.fedora.ManagementClient"
 		init-method="init" destroy-method="destroy">
@@ -68,7 +67,6 @@
 		<property name="username" value="${fedora.appUser.username}" />
 		<property name="password" value="${fedora.appUser.password}" />
 		<property name="accessClient" ref="accessClient"/>
-		<property name="tripleStoreQueryService" ref="tripleStoreQueryService"/>
 		<property name="interceptors">
 			<list>
 				<bean class="edu.unc.lib.dl.acl.filter.GroupsToHttpHeaderInterceptor" />

--- a/sword-server/src/main/java/edu/unc/lib/dl/cdr/sword/server/managers/ContainerManagerImpl.java
+++ b/sword-server/src/main/java/edu/unc/lib/dl/cdr/sword/server/managers/ContainerManagerImpl.java
@@ -43,7 +43,7 @@ import edu.unc.lib.dl.update.UIPException;
 import edu.unc.lib.dl.update.UIPProcessor;
 import edu.unc.lib.dl.update.UpdateException;
 import edu.unc.lib.dl.update.UpdateOperation;
-import edu.unc.lib.dl.util.ContentModelHelper;
+import edu.unc.lib.dl.util.ContentModelHelper.FedoraProperty;
 import edu.unc.lib.dl.util.ErrorURIRegistry;
 
 public class ContainerManagerImpl extends AbstractFedoraManager implements ContainerManager {
@@ -221,8 +221,8 @@ public class ContainerManagerImpl extends AbstractFedoraManager implements Conta
 		if (deposit.isInProgress() != Boolean.parseBoolean(state)) {
 			try {
 				log.debug("Updating active state of in-progress item");
-				managementClient.addLiteralStatement(targetPID, ContentModelHelper.FedoraProperty.Active.toString(),
-						"Active", null);
+				managementClient.addLiteralStatement(targetPID, FedoraProperty.Active.getFragment(),
+						FedoraProperty.Active.getNamespace(), "Active", null);
 				receipt.setVerboseDescription(targetPID.getPid() + " is " + ((deposit.isInProgress()) ? "" : "not")
 						+ " in-progress");
 			} catch (FedoraException e) {


### PR DESCRIPTION
* Created RDFXMLUtil to perform some of the basic RELS-EXT manipulation we frequently perform.
* Switched all relationship adding methods over to using optimstic locking.
* Removed relationship modifying methods from DigitalObjectManager, moved RELS-EXT updating method to ManagementClient.
* Normalized the parameters for relationship updating methods.
* Updated enhancements to use local client instead of referencing their services instance repeatedly, removed relationship setting methods, and switched to setting exclusive triples in a few cases where it makes more sense
* Removed some dead code and tests related to relationships