### PR TITLE
Fix infinite authz exception in admin

### DIFF
--- a/admin/src/main/java/edu/unc/lib/dl/admin/controller/EditLabelController.java
+++ b/admin/src/main/java/edu/unc/lib/dl/admin/controller/EditLabelController.java
@@ -3,8 +3,9 @@ package edu.unc.lib.dl.admin.controller;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.annotation.Resource;
+
 import org.jdom2.Element;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,8 +20,8 @@ import edu.unc.lib.dl.ingest.IngestException;
 import edu.unc.lib.dl.util.PremisEventLogger;
 
 @Controller
-public class EditLabelController {	
-	@Autowired
+public class EditLabelController {
+	@Resource(name="managementClient")
 	private ManagementClient client;
 	
 	@RequestMapping(value = "editlabel/{pid}", method = RequestMethod.POST)

--- a/admin/src/main/java/edu/unc/lib/dl/admin/controller/ExportXMLController.java
+++ b/admin/src/main/java/edu/unc/lib/dl/admin/controller/ExportXMLController.java
@@ -91,7 +91,7 @@ public class ExportXMLController {
 	@Resource
 	@Qualifier("forwardedAccessClient")
 	private AccessClient client;
-	@Autowired
+	@Resource(name="forwardedManagementClient")
 	private ManagementClient managementClient;
 	@Autowired
 	private AccessControlService aclService;

--- a/admin/src/main/webapp/WEB-INF/access-fedora-context.xml
+++ b/admin/src/main/webapp/WEB-INF/access-fedora-context.xml
@@ -34,6 +34,16 @@
 			value="${mulgara.protocol}://${mulgara.host}${mulgara.port}/${mulgara.context}/services/ItqlBeanService" />
 		<property name="serverModelUri" value="rmi://${mulgara.model.uri}/server1#" />
 	</bean>
+	
+	<bean id="managementClient" class="edu.unc.lib.dl.fedora.ManagementClient"
+		init-method="init" destroy-method="destroy">
+		<property name="fedoraContextUrl"
+			value="${fedora.protocol}://${fedora.host}${fedora.port}/${fedora.context}" />
+		<property name="username" value="${fedora.admin.username}" />
+		<property name="password" value="${fedora.admin.password}" />
+		<property name="accessClient" ref="accessClient"></property>
+	</bean>
+	
 	<bean id="forwardedManagementClient" class="edu.unc.lib.dl.fedora.ManagementClient"
 		init-method="init" destroy-method="destroy">
 		<property name="fedoraContextUrl"
@@ -47,6 +57,7 @@
 		</property>
 		<property name="accessClient" ref="forwardedAccessClient"></property>
 	</bean>
+	
 	<bean id="forwardedAccessClient" class="edu.unc.lib.dl.fedora.AccessClient"
 		init-method="init">
 		<property name="fedoraContextUrl"
@@ -59,6 +70,7 @@
 			</list>
 		</property>
 	</bean>
+	
 	<bean id="accessClient" class="edu.unc.lib.dl.fedora.AccessClient" init-method="init">
 		<property name="fedoraContextUrl"
 			value="${fedora.protocol:https}://${fedora.host:localhost}${fedora.port:443}/${fedora.context:fedora}" />

--- a/admin/src/main/webapp/WEB-INF/uiapp-servlet.xml
+++ b/admin/src/main/webapp/WEB-INF/uiapp-servlet.xml
@@ -154,6 +154,8 @@
 	<bean id="vocabManager" class="edu.unc.lib.dl.util.VocabularyHelperManager">
 		<property name="helperClasses" ref="vocabHelperClassMap" />
 		<property name="collectionsPID" ref="collectionsPid" />
+		<property name="managementClient" ref="managementClient" />
+		<property name="accessClient" ref="accessClient" />
 	</bean>
 	
 	<bean id="mailSender" class="org.springframework.mail.javamail.JavaMailSenderImpl">

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/util/VocabularyHelperManager.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/util/VocabularyHelperManager.java
@@ -444,4 +444,12 @@ public class VocabularyHelperManager {
 	public void setCollectionsPID(PID collectionsPID) {
 		this.collectionsPID = collectionsPID;
 	}
+
+	public void setManagementClient(ManagementClient managementClient) {
+		this.managementClient = managementClient;
+	}
+
+	public void setAccessClient(AccessClient accessClient) {
+		this.accessClient = accessClient;
+	}
 }


### PR DESCRIPTION
Fixing an authorization exception in the admin ui which occurs when a user with insufficient privileges to access vocabulary objects is the first user to attempt to edit descriptions