### PR TITLE
Fix thumbnail links to front page

### DIFF
--- a/access/src/main/webapp/WEB-INF/jsp/common/thumbnail.jsp
+++ b/access/src/main/webapp/WEB-INF/jsp/common/thumbnail.jsp
@@ -45,6 +45,9 @@
 		<c:when test="${param.target == 'list'}">
 			<c:out value="list/${thumbnailObject.id}" />
 		</c:when>
+		<c:otherwise>
+			<c:out value="record/${thumbnailObject.id}" />
+		</c:otherwise>
 	</c:choose>
 </c:set>
 

--- a/access/src/main/webapp/WEB-INF/jsp/fullRecord/collectionRecord.jsp
+++ b/access/src/main/webapp/WEB-INF/jsp/fullRecord/collectionRecord.jsp
@@ -38,6 +38,7 @@
 	<div class="contentarea">
 		<c:set var="thumbnailObject" value="${briefObject}" scope="request" />
 		<c:import url="common/thumbnail.jsp">
+			<c:param name="target" value="record" />
 			<c:param name="size" value="large" />
 		</c:import>
 		<c:if test="${cdr:hasAccess(accessGroupSet, briefObject, 'editDescription')}">

--- a/access/src/main/webapp/WEB-INF/jsp/fullRecord/listAccessRecord.jsp
+++ b/access/src/main/webapp/WEB-INF/jsp/fullRecord/listAccessRecord.jsp
@@ -34,6 +34,7 @@
 	<div class="contentarea">
 		<c:set var="thumbnailObject" value="${briefObject}" scope="request" />
 		<c:import url="common/thumbnail.jsp">
+			<c:param name="target" value="record" />
 			<c:param name="size" value="large" />
 		</c:import>
 		


### PR DESCRIPTION
When there is no target specified for a thumbnail, default to setting the href to its record page. Provide a target for the fullRecord templates that were missing it.