### PR TITLE
Include more information in deposit notification emails

### DIFF
--- a/deposit/src/main/java/edu/unc/lib/deposit/work/DepositEmailHandler.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/work/DepositEmailHandler.java
@@ -1,6 +1,10 @@
 package edu.unc.lib.deposit.work;
 
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.mail.MessagingException;
@@ -8,21 +12,58 @@ import javax.mail.internet.MimeMessage;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 
+import com.hp.hpl.jena.query.Dataset;
+import com.hp.hpl.jena.query.ReadWrite;
+import com.hp.hpl.jena.rdf.model.Bag;
+import com.hp.hpl.jena.rdf.model.Model;
 import com.samskivert.mustache.Template;
 
+import edu.unc.lib.dl.acl.util.AccessGroupConstants;
+import edu.unc.lib.dl.acl.util.AccessGroupSet;
+import edu.unc.lib.dl.acl.util.ObjectAccessControlsBean;
+import edu.unc.lib.dl.acl.util.UserRole;
+import edu.unc.lib.dl.fedora.FedoraAccessControlService;
+import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.util.DepositStatusFactory;
 import edu.unc.lib.dl.util.RedisWorkerConstants.DepositField;
 import edu.unc.lib.dl.util.RedisWorkerConstants.DepositState;
 
 public class DepositEmailHandler {
+
+	protected SimpleDateFormat embargoDateFormat = new SimpleDateFormat("yyyy-MM-dd");
+	
 	private static final Logger LOG = LoggerFactory.getLogger(DepositEmailHandler.class);
+
+	private DepositStatusFactory depositStatusFactory;
 	
 	private String baseUrl;
 	private JavaMailSender mailSender = null;
-	private String fromAddress = null;
+	private String administratorEmail = null;
+
+	private Template completedHtmlTemplate = null;
+	private Template completedTextTemplate = null;
+
+	private Template failedHtmlTemplate = null;
+	private Template failedTextTemplate = null;
+
+	@Autowired
+	private Dataset dataset;
+	
+	@Autowired
+	private FedoraAccessControlService accessControlService;
+
+	protected DepositStatusFactory getDepositStatusFactory() {
+		return depositStatusFactory;
+	}
+
+	public void setDepositStatusFactory(
+			DepositStatusFactory depositStatusFactory) {
+		this.depositStatusFactory = depositStatusFactory;
+	}
 	
 	public String getBaseUrl() {
 		return baseUrl;
@@ -40,86 +81,172 @@ public class DepositEmailHandler {
 		this.mailSender = mailSender;
 	}
 
-	public String getFromAddress() {
-		return fromAddress;
+	public String getAdministratorEmail() {
+		return administratorEmail;
 	}
 
-	public void setFromAddress(String fromAddress) {
-		this.fromAddress = fromAddress;
+	public void setAdministratorEmail(String administratorEmail) {
+		this.administratorEmail = administratorEmail;
 	}
 
-	public Template getHtmlTemplate() {
-		return htmlTemplate;
+	public Template getCompletedHtmlTemplate() {
+		return completedHtmlTemplate;
 	}
 
-	public void setHtmlTemplate(Template htmlTemplate) {
-		this.htmlTemplate = htmlTemplate;
+	public void setCompletedHtmlTemplate(Template completedHtmlTemplate) {
+		this.completedHtmlTemplate = completedHtmlTemplate;
 	}
 
-	public Template getTextTemplate() {
-		return textTemplate;
+	public Template getCompletedTextTemplate() {
+		return completedTextTemplate;
 	}
 
-	public void setTextTemplate(Template textTemplate) {
-		this.textTemplate = textTemplate;
-	}
-	
-	private DepositStatusFactory depositStatusFactory;
-
-	protected DepositStatusFactory getDepositStatusFactory() {
-		return depositStatusFactory;
+	public void setCompletedTextTemplate(Template completedTextTemplate) {
+		this.completedTextTemplate = completedTextTemplate;
 	}
 
-	public void setDepositStatusFactory(
-			DepositStatusFactory depositStatusFactory) {
-		this.depositStatusFactory = depositStatusFactory;
+	public Template getFailedHtmlTemplate() {
+		return failedHtmlTemplate;
 	}
 
-	private Template htmlTemplate = null;
-	private Template textTemplate = null;
+	public void setFailedHtmlTemplate(Template failedHtmlTemplate) {
+		this.failedHtmlTemplate = failedHtmlTemplate;
+	}
+
+	public Template getFailedTextTemplate() {
+		return failedTextTemplate;
+	}
+
+	public void setFailedTextTemplate(Template failedTextTemplate) {
+		this.failedTextTemplate = failedTextTemplate;
+	}
 
 	public DepositEmailHandler() {
 	}
 
 	public void sendDepositResults(String depositUUID) {
+		if (this.getDepositStatusFactory().getState(depositUUID).equals(DepositState.failed.name())) {
+			sendFailed(depositUUID);
+		} else {
+			sendCompleted(depositUUID);
+		}
+	}
+	
+	private void sendFailed(String depositUUID) {
+		LOG.info("Sending deposit failed email for {}", depositUUID);
+		
 		Map<String, String> status = this.getDepositStatusFactory().get(depositUUID);
 		
-		if (!status.containsKey(DepositField.depositorEmail.name())) {
-			LOG.info("No depositor email for {}", depositUUID);
-			return;
-		} else {
-			LOG.info("Sending deposit results email for {} to {}", depositUUID, status.get(DepositField.depositorEmail.name()));
-		}
-
-		// prepare template data
 		Map<String, Object> data = new HashMap<String, Object>();
-		
 		data.putAll(status);
-		
 		data.put("baseUrl", this.getBaseUrl());
-		
-		boolean failed = status.get(DepositField.state.name()).equals(DepositState.failed.name());
-		data.put("failed", Boolean.valueOf(failed));
-		
-		// execute template, address and send
-		String html = htmlTemplate.execute(data);
-		String text = textTemplate.execute(data);
+
+		String html = failedHtmlTemplate.execute(data);
+		String text = failedTextTemplate.execute(data);
 		
 		MimeMessage mimeMessage = mailSender.createMimeMessage();
+		
 		try {
 			MimeMessageHelper message = new MimeMessageHelper(mimeMessage, MimeMessageHelper.MULTIPART_MODE_MIXED);
-			String addy = status.get(DepositField.depositorEmail.name());
-			message.addTo(addy);
-			if (failed) {
-				message.setSubject("CDR deposit failed: " + status.get(DepositField.fileName.name()));
-			} else {
-				message.setSubject("CDR deposit complete: " + status.get(DepositField.fileName.name()));
+
+			String depositorEmail = status.get(DepositField.depositorEmail.name());
+
+			if (depositorEmail != null) {
+				message.addTo(depositorEmail);
 			}
-			message.setFrom(getFromAddress());
+			
+			if (getAdministratorEmail() != null) {
+				message.addTo(getAdministratorEmail());
+			}
+			
+			message.setSubject("CDR deposit failed");
+			message.setFrom(getAdministratorEmail());
 			message.setText(text, html);
+			
 			this.mailSender.send(mimeMessage);
 		} catch (MessagingException e) {
 			LOG.error("Cannot send notification email", e);
+		}
+	}
+	
+	private void sendCompleted(String depositUUID) {
+		LOG.info("Sending deposit completed email for {}", depositUUID);
+		
+		Map<String, String> status = this.getDepositStatusFactory().get(depositUUID);
+
+		String depositorEmail = status.get(DepositField.depositorEmail.name());
+		
+		if (depositorEmail == null) {
+			return;
+		}
+		
+		// If there is a "main object" in this deposit (it has exactly one top-level object), try linking to that.
+		// If there isn't, use the container. With this scheme, there is the possibility that we could have multiple
+		// top-level objects that are not public, but a container that is public, in which case the email wouldn't
+		// make sense. However, form deposits currently always have a "main object".
+		
+		String objectPid = getMainObjectPidForDeposit(depositUUID).toString();
+		
+		if (objectPid == null) {
+			objectPid = status.get(DepositField.containerId.name());
+		}
+		
+		ObjectAccessControlsBean accessControls = accessControlService.getObjectAccessControls(new PID(objectPid));
+		Date embargoUntil = accessControls.getLastActiveEmbargoUntilDate();
+		boolean hasPatronRoleForPublicGroup = accessControls.getRoles(new AccessGroupSet(AccessGroupConstants.PUBLIC_GROUP)).contains(UserRole.patron);
+		
+		Map<String, Object> data = new HashMap<String, Object>();
+		data.putAll(status);
+		data.put("baseUrl", this.getBaseUrl());
+		data.put("objectPid", objectPid);
+		
+		if (embargoUntil != null) {
+			data.put("emgargoUntil", embargoDateFormat.format(embargoUntil));
+			data.put("isEmbargoed", new Boolean(true));
+		} else if (hasPatronRoleForPublicGroup) {
+			data.put("isOpen", new Boolean(true));
+		} else {
+			data.put("isClosed", new Boolean(true));
+		}
+
+		String html = completedHtmlTemplate.execute(data);
+		String text = completedTextTemplate.execute(data);
+		
+		MimeMessage mimeMessage = mailSender.createMimeMessage();
+		
+		try {
+			MimeMessageHelper message = new MimeMessageHelper(mimeMessage, MimeMessageHelper.MULTIPART_MODE_MIXED);
+			
+			message.addTo(depositorEmail);
+			message.setSubject("CDR deposit complete");
+			message.setFrom(getAdministratorEmail());
+			message.setText(text, html);
+			
+			this.mailSender.send(mimeMessage);
+		} catch (MessagingException e) {
+			LOG.error("Cannot send notification email", e);
+		}
+		
+	}
+	
+	private String getMainObjectPidForDeposit(String depositUUID) {
+		PID depositPID = new PID("uuid:" + depositUUID);
+		
+		String uri = depositPID.getURI();
+		this.dataset.begin(ReadWrite.READ);
+		Model model = this.dataset.getNamedModel(uri).begin();
+
+		String depositPid = depositPID.getURI();
+		Bag depositBag = model.getBag(depositPid);
+		
+		List<String> topLevelPids = new ArrayList<String>();
+		DepositGraphUtils.walkChildrenDepthFirst(depositBag, topLevelPids, false);
+		
+		// There is a "main object" if the deposit has exactly one top-level object.
+		if (topLevelPids.size() == 1) {
+			return new PID(topLevelPids.get(0)).toString();
+		} else {
+			return null;
 		}
 	}
 

--- a/deposit/src/main/resources/completed_html.txt
+++ b/deposit/src/main/resources/completed_html.txt
@@ -29,7 +29,10 @@
   
   {{#ingestedObjects}}<p>{{ingestedObjects}} item(s) successfully deposited.</p>{{/ingestedObjects}}
   
-  {{#isOpen}}<p>Your materials are now <a href="{{baseUrl}}/record/{{objectPid}}">available on the CDR</a>.</p>{{/isOpen}}
+  {{#isOpen}}
+  <p>Your materials are now available in the CDR:</p>
+  <p><a href="{{baseUrl}}/record/{{objectPid}}">{{baseUrl}}/record/{{objectPid}}</a></p>
+  {{/isOpen}}
   
   {{#isEmbargoed}}<p>Your materials are embargoed until {{embargoUntil}}.</p>{{/isEmbargoed}}
   

--- a/deposit/src/main/resources/completed_html.txt
+++ b/deposit/src/main/resources/completed_html.txt
@@ -1,0 +1,41 @@
+{{!
+
+    Copyright 2008 The University of North Carolina at Chapel Hill
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+}}
+<html>
+<head>
+  <title>
+    CDR deposit complete{{#fileName}}: {{fileName}}{{/fileName}}
+  </title>
+</head>
+<body>
+
+  <img style="float: right;" alt="UNC Libraries logo" src="{{baseUrl}}/static/images/email_logo.png"/>
+
+  <h3>CDR deposit complete{{#fileName}}: {{fileName}}{{/fileName}}</h3>
+  
+  {{#ingestedObjects}}<p>{{ingestedObjects}} item(s) successfully deposited.</p>{{/ingestedObjects}}
+  
+  {{#isOpen}}<p>Your materials are now <a href="{{baseUrl}}/record/{{objectPid}}">available on the CDR</a>.</p>{{/isOpen}}
+  
+  {{#isEmbargoed}}<p>Your materials are embargoed until {{embargoUntil}}.</p>{{/isEmbargoed}}
+  
+  {{#isClosed}}<p>Materials requiring review will be made accessible upon approval by the relevant department.</p>{{/isClosed}}
+  
+  <p>Thank you for contributing to the <a href="{{baseUrl}}">Carolina Digital Repository</a>, a service of the <a href="http://www.lib.unc.edu/">University of North Carolina at Chapel Hill Libraries</a>.</p>
+
+</body>
+</html>

--- a/deposit/src/main/resources/completed_text.txt
+++ b/deposit/src/main/resources/completed_text.txt
@@ -21,7 +21,9 @@ CDR deposit complete{{#fileName}}: {{fileName}}{{/fileName}}
 {{#ingestedObjects}}{{ingestedObjects}} item(s) successfully deposited.
 
 {{/ingestedObjects}}
-{{#isOpen}}Your materials are now available on the CDR: {{baseUrl}}/record/{{objectPid}}
+{{#isOpen}}Your materials are now available in the CDR:
+
+{{baseUrl}}/record/{{objectPid}}
 
 {{/isOpen}}
 {{#isEmbargoed}}Your materials are embargoed until {{embargoUntil}}.

--- a/deposit/src/main/resources/completed_text.txt
+++ b/deposit/src/main/resources/completed_text.txt
@@ -1,0 +1,36 @@
+{{!
+
+    Copyright 2008 The University of North Carolina at Chapel Hill
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+}}
+
+CDR deposit complete{{#fileName}}: {{fileName}}{{/fileName}}
+
+{{#ingestedObjects}}{{ingestedObjects}} item(s) successfully deposited.
+
+{{/ingestedObjects}}
+{{#isOpen}}Your materials are now available on the CDR: {{baseUrl}}/record/{{objectPid}}
+
+{{/isOpen}}
+{{#isEmbargoed}}Your materials are embargoed until {{embargoUntil}}.
+
+{{/isEmbargoed}}
+{{#isClosed}}Materials requiring review will be made accessible upon approval by the relevant department.
+
+{{/isClosed}}
+Thank you for contributing to the Carolina Digital Repository, a service of the University of North Carolina at Chapel Hill Libraries.
+
+    Carolina Digital Repository: {{baseUrl}}
+      UNC Chapel Hill Libraries: http://www.lib.unc.edu/

--- a/deposit/src/main/resources/failed_html.txt
+++ b/deposit/src/main/resources/failed_html.txt
@@ -18,24 +18,24 @@
 <html>
 <head>
   <title>
-    {{^failed}}CDR deposit complete{{#fileName}}: {{fileName}}{{/fileName}}{{/failed}}
-    {{#failed}}CDR deposit failed{{#fileName}}: {{fileName}}{{/fileName}}{{/failed}}
+    CDR deposit failed{{#fileName}}: {{fileName}}{{/fileName}}
   </title>
 </head>
 <body>
+
   <img style="float: right;" alt="UNC Libraries logo" src="{{baseUrl}}/static/images/email_logo.png"/>
-  {{^failed}}
-  <h3>CDR deposit complete{{#fileName}}: {{fileName}}{{/fileName}}</h3>
-  {{#ingestedObjects}}<p>{{ingestedObjects}} item(s) successfully deposited.</p>{{/ingestedObjects}}
-  {{/failed}}
-  {{#failed}}
+
   <h3>CDR deposit failed{{#fileName}}: {{fileName}}{{/fileName}}</h3>
+  
   <p>There was an error processing your deposit.</p>
+  
   {{#errorMessage}}
     <div style="background: yellow">{{errorMessage}}</div>
   {{/errorMessage}}
-  {{/failed}}
+  
   <p>For details, see the <a href="{{baseUrl}}/admin/statusMonitor">status monitor</a>.</p>
+  
   <p>Thank you for contributing to the <a href="{{baseUrl}}">Carolina Digital Repository</a>, a service of the <a href="http://www.lib.unc.edu/">University of North Carolina at Chapel Hill Libraries</a>.</p>
+
 </body>
 </html>

--- a/deposit/src/main/resources/failed_text.txt
+++ b/deposit/src/main/resources/failed_text.txt
@@ -15,16 +15,13 @@
     limitations under the License.
 
 }}
-{{^failed}}CDR deposit complete{{#fileName}}: {{fileName}}{{/fileName}}{{/failed}}
-{{#failed}}CDR deposit failed{{#fileName}}: {{fileName}}{{/fileName}}{{/failed}}
 
-{{^failed}}{{#ingestedObjects}}{{ingestedObjects}} item(s) successfully deposited.{{/ingestedObjects}}{{/failed}}
-{{#failed}}
+CDR deposit failed{{#fileName}}: {{fileName}}{{/fileName}}
+
 There was an error processing your deposit.
 {{#errorMessage}}
   {{errorMessage}}
 {{/errorMessage}}
-{{/failed}}
 
 For details, see the status monitor:
 

--- a/deposit/src/main/resources/service-context.xml
+++ b/deposit/src/main/resources/service-context.xml
@@ -125,11 +125,13 @@
 
 	<bean id="depositEmailHandler" class="edu.unc.lib.deposit.work.DepositEmailHandler" >
 		<property name="depositStatusFactory" ref="depositStatusFactory" />
-		<property name="baseUrl" value="${baseUrl:https://www.example.com}" />
+		<property name="baseUrl" value="${baseUrl}" />
 		<property name="mailSender" ref="mailSender" />
-		<property name="fromAddress" value="${from.email:no-reply@example.com}" />
-		<property name="htmlTemplate" ref="htmlTemplate" />
-		<property name="textTemplate" ref="textTemplate" />
+		<property name="administratorEmail" value="${administrator.email}" />
+		<property name="completedHtmlTemplate" ref="completedHtmlTemplate" />
+		<property name="completedTextTemplate" ref="completedTextTemplate" />
+		<property name="failedHtmlTemplate" ref="failedHtmlTemplate" />
+		<property name="failedTextTemplate" ref="failedTextTemplate" />
 	</bean>
 	
 	<bean id="depositMessageHandler" class="edu.unc.lib.deposit.work.DepositMessageHandler" >
@@ -440,19 +442,38 @@
 	
 	<bean id="mustacheCompiler" class="com.samskivert.mustache.Mustache" factory-method="compiler"/>
 
-	<bean id="htmlTemplate" factory-bean="mustacheCompiler"
+	<bean id="completedHtmlTemplate" factory-bean="mustacheCompiler"
 		factory-method="compile">
 		<constructor-arg>
 			<bean class="java.io.InputStreamReader">
-				<constructor-arg type="java.io.InputStream" value="classpath:email_html.txt" />
+				<constructor-arg type="java.io.InputStream" value="classpath:completed_html.txt" />
 			</bean>
 		</constructor-arg>
 	</bean>
-	<bean id="textTemplate" factory-bean="mustacheCompiler"
+	
+	<bean id="completedTextTemplate" factory-bean="mustacheCompiler"
 		factory-method="compile">
 		<constructor-arg>
 			<bean class="java.io.InputStreamReader">
-				<constructor-arg type="java.io.InputStream" value="${deposit.email.template:classpath:email_text.txt}" />
+				<constructor-arg type="java.io.InputStream" value="${classpath:completed_text.txt}" />
+			</bean>
+		</constructor-arg>
+	</bean>
+
+	<bean id="failedHtmlTemplate" factory-bean="mustacheCompiler"
+		factory-method="compile">
+		<constructor-arg>
+			<bean class="java.io.InputStreamReader">
+				<constructor-arg type="java.io.InputStream" value="classpath:failed_html.txt" />
+			</bean>
+		</constructor-arg>
+	</bean>
+	
+	<bean id="failedTextTemplate" factory-bean="mustacheCompiler"
+		factory-method="compile">
+		<constructor-arg>
+			<bean class="java.io.InputStreamReader">
+				<constructor-arg type="java.io.InputStream" value="${classpath:failed_text.txt}" />
 			</bean>
 		</constructor-arg>
 	</bean>

--- a/deposit/src/test/resources/service-context.xml
+++ b/deposit/src/test/resources/service-context.xml
@@ -129,9 +129,11 @@
 		<property name="depositStatusFactory" ref="depositStatusFactory" />
 		<property name="baseUrl" value="${baseUrl:https://www.example.com}" />
 		<property name="mailSender" ref="mailSender" />
-		<property name="fromAddress" value="${from.email:no-reply@example.com}" />
-		<property name="htmlTemplate" ref="htmlTemplate" />
-		<property name="textTemplate" ref="textTemplate" />
+		<property name="administratorEmail" value="${from.email:no-reply@example.com}" />
+		<property name="completedHtmlTemplate" ref="completedHtmlTemplate" />
+		<property name="completedTextTemplate" ref="completedTextTemplate" />
+		<property name="failedHtmlTemplate" ref="failedHtmlTemplate" />
+		<property name="failedTextTemplate" ref="failedTextTemplate" />
 	</bean>
 	
 	<bean id="depositMessageHandler" class="edu.unc.lib.deposit.work.DepositMessageHandler" >
@@ -148,6 +150,12 @@
 		factory-method="mock">
 		<constructor-arg index="0"
 			value="edu.unc.lib.dl.fedora.ManagementClient" />
+	</bean>
+	
+	<bean id="accessControlService" class="org.mockito.Mockito"
+		factory-method="mock">
+		<constructor-arg index="0"
+			value="edu.unc.lib.dl.fedora.FedoraAccessControlService" />
 	</bean>
 
 	<bean class="edu.unc.lib.dl.schematron.SchematronValidator" name="schematronValidator"
@@ -359,19 +367,38 @@
 	
 	<bean id="mustacheCompiler" class="com.samskivert.mustache.Mustache" factory-method="compiler"/>
 
-	<bean id="htmlTemplate" factory-bean="mustacheCompiler"
+	<bean id="completedHtmlTemplate" factory-bean="mustacheCompiler"
 		factory-method="compile">
 		<constructor-arg>
 			<bean class="java.io.InputStreamReader">
-				<constructor-arg type="java.io.InputStream" value="classpath:email_html.txt" />
+				<constructor-arg type="java.io.InputStream" value="classpath:completed_html.txt" />
 			</bean>
 		</constructor-arg>
 	</bean>
-	<bean id="textTemplate" factory-bean="mustacheCompiler"
+	
+	<bean id="completedTextTemplate" factory-bean="mustacheCompiler"
 		factory-method="compile">
 		<constructor-arg>
 			<bean class="java.io.InputStreamReader">
-				<constructor-arg type="java.io.InputStream" value="${deposit.email.template:classpath:email_text.txt}" />
+				<constructor-arg type="java.io.InputStream" value="${classpath:completed_text.txt}" />
+			</bean>
+		</constructor-arg>
+	</bean>
+
+	<bean id="failedHtmlTemplate" factory-bean="mustacheCompiler"
+		factory-method="compile">
+		<constructor-arg>
+			<bean class="java.io.InputStreamReader">
+				<constructor-arg type="java.io.InputStream" value="classpath:failed_html.txt" />
+			</bean>
+		</constructor-arg>
+	</bean>
+	
+	<bean id="failedTextTemplate" factory-bean="mustacheCompiler"
+		factory-method="compile">
+		<constructor-arg>
+			<bean class="java.io.InputStreamReader">
+				<constructor-arg type="java.io.InputStream" value="${classpath:failed_text.txt}" />
 			</bean>
 		</constructor-arg>
 	</bean>


### PR DESCRIPTION
- Link to materials if public, display the embargo date if embargoed, or note that the materials may need to be reviewed if not embargoed and not public. If there is more than one top-level object, we link to the container.
- Split the deposit email templates into "completed" and "failed".
- Send a message to the administrator when a deposit fails.