### PR TITLE
Fix selector for @displayLabel on originInfo dates

### DIFF
--- a/static/recordTransformations/modsToFullRecord.xsl
+++ b/static/recordTransformations/modsToFullRecord.xsl
@@ -344,7 +344,7 @@
 	</xsl:template>
 <!-- mods:originInfo dates -->	
 	<xsl:template name="modsOriginDates">
-		<xsl:for-each-group select="*[local-name() = 'originInfo']/*[contains(local-name(), 'date') or local-name() = 'copyrightDate']" group-by="@displayLabel, local-name(.[not(@displayLabel)])[. != '']">
+		<xsl:for-each-group select="*[local-name() = 'originInfo']/*[contains(local-name(), 'date') or local-name() = 'copyrightDate']" group-by="../@displayLabel, local-name(.[not(../@displayLabel)])[. != '']">
 			<xsl:variable name="groupKey" select="current-grouping-key()"/>	
 			<tr>
 				<th>


### PR DESCRIPTION
The group-by attribute of the for-each-group element in the "modsOriginDates" template incorrectly selected the displayLabel attribute on dateIssued, dateCreated, etc. elements, rather than on the originInfo element containing them.