### PR TITLE
Add mods column to csv export

### DIFF
--- a/admin/src/main/java/edu/unc/lib/dl/admin/controller/ExportController.java
+++ b/admin/src/main/java/edu/unc/lib/dl/admin/controller/ExportController.java
@@ -66,7 +66,7 @@ public class ExportController extends AbstractSolrSearchController {
 				SearchFieldKeys.STATUS.name(), SearchFieldKeys.DATASTREAM.name(),
 				SearchFieldKeys.ANCESTOR_PATH.name(), SearchFieldKeys.CONTENT_MODEL.name(),
 				SearchFieldKeys.DATE_ADDED.name(), SearchFieldKeys.DATE_UPDATED.name(),
-				SearchFieldKeys.LABEL.name()));
+				SearchFieldKeys.LABEL.name(), SearchFieldKeys.CONTENT_STATUS.name()));
 		searchState.setSortType("export");
 		searchState.setRowsPerPage(searchSettings.maxPerPage);
 		
@@ -177,8 +177,13 @@ public class ExportController extends AbstractSolrSearchController {
 			printer.print("");
 		}
 		
+		// Whether or not the object has a MODS description
+		
+		printer.print(object.getContentStatus());
+		
 		printer.println();
 		
 	}
+	
 	
 }

--- a/admin/src/main/java/edu/unc/lib/dl/admin/controller/ExportController.java
+++ b/admin/src/main/java/edu/unc/lib/dl/admin/controller/ExportController.java
@@ -99,7 +99,7 @@ public class ExportController extends AbstractSolrSearchController {
 		// Vitals: object type, pid, title, path, label, depth
 		
 		printer.print(object.getResourceType());
-		printer.print(object.getPid());
+		//printer.print(object.getPid());
 		printer.print(object.getTitle());
 		printer.print(object.getAncestorNames());
 		

--- a/admin/src/main/java/edu/unc/lib/dl/admin/controller/ExportController.java
+++ b/admin/src/main/java/edu/unc/lib/dl/admin/controller/ExportController.java
@@ -41,6 +41,7 @@ import edu.unc.lib.dl.search.solr.model.SearchRequest;
 import edu.unc.lib.dl.search.solr.model.SearchResultResponse;
 import edu.unc.lib.dl.search.solr.model.SearchState;
 import edu.unc.lib.dl.search.solr.model.Datastream;
+import edu.unc.lib.dl.search.solr.util.FacetConstants;
 import edu.unc.lib.dl.search.solr.util.SearchFieldKeys;
 import edu.unc.lib.dl.ui.controller.AbstractSolrSearchController;
 import edu.unc.lib.dl.util.ContentModelHelper;
@@ -49,9 +50,6 @@ import edu.unc.lib.dl.util.ResourceType;
 @Controller
 @RequestMapping("export")
 public class ExportController extends AbstractSolrSearchController {
-	
-	private static final String DESCRIBED = "Described";
-	private static final String NOT_DESCRIBED = "Not Described";
 	
 	protected SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd kk:mm:ss");
 
@@ -182,10 +180,10 @@ public class ExportController extends AbstractSolrSearchController {
 		
 		// Description: does object have a MODS description?
 		
-		if (object.getContentStatus().contains(NOT_DESCRIBED)) {
-			printer.print(NOT_DESCRIBED);
-		} else if (object.getContentStatus().contains(DESCRIBED)) {
-			printer.print(DESCRIBED);
+		if (object.getContentStatus().contains(FacetConstants.CONTENT_NOT_DESCRIBED) ){
+			printer.print(FacetConstants.CONTENT_NOT_DESCRIBED);
+		} else if (object.getContentStatus().contains(FacetConstants.CONTENT_DESCRIBED)) {
+			printer.print(FacetConstants.CONTENT_DESCRIBED));
 		} else {
 			printer.print("");
 		}

--- a/admin/src/main/java/edu/unc/lib/dl/admin/controller/ExportController.java
+++ b/admin/src/main/java/edu/unc/lib/dl/admin/controller/ExportController.java
@@ -91,7 +91,7 @@ public class ExportController extends AbstractSolrSearchController {
 	}
 	
 	private void printHeaders(CSVPrinter printer) throws IOException {
-		printer.printRecord("Object Type", "PID", "Title", "Path", "Label", "Depth", "Deleted", "Date Added", "Date Updated", "MIME Type", "Checksum", "File Size (bytes)", "Number of Children");
+		printer.printRecord("Object Type", "PID", "Title", "Path", "Label", "Depth", "Deleted", "Date Added", "Date Updated", "MIME Type", "Checksum", "File Size (bytes)", "Number of Children", "Content Status");
 	}
 	
 	private void printObject(CSVPrinter printer, BriefObjectMetadata object) throws IOException {
@@ -177,9 +177,9 @@ public class ExportController extends AbstractSolrSearchController {
 			printer.print("");
 		}
 		
-		// Whether or not the object has a MODS description
+		// Content status: has a MODS description?
 		
-		printer.print(object.getContentStatus());
+		printer.print(object.getContentStatus().toString());
 		
 		printer.println();
 		

--- a/admin/src/main/java/edu/unc/lib/dl/admin/controller/ExportController.java
+++ b/admin/src/main/java/edu/unc/lib/dl/admin/controller/ExportController.java
@@ -99,7 +99,7 @@ public class ExportController extends AbstractSolrSearchController {
 		// Vitals: object type, pid, title, path, label, depth
 		
 		printer.print(object.getResourceType());
-		//printer.print(object.getPid());
+		printer.print(object.getPid());
 		printer.print(object.getTitle());
 		printer.print(object.getAncestorNames());
 		

--- a/admin/src/main/java/edu/unc/lib/dl/admin/controller/ExportController.java
+++ b/admin/src/main/java/edu/unc/lib/dl/admin/controller/ExportController.java
@@ -50,6 +50,9 @@ import edu.unc.lib.dl.util.ResourceType;
 @RequestMapping("export")
 public class ExportController extends AbstractSolrSearchController {
 	
+	private static final String DESCRIBED = "Described";
+	private static final String NOT_DESCRIBED = "Not Described";
+	
 	protected SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd kk:mm:ss");
 
 	@RequestMapping(value = "{pid}", method = RequestMethod.GET)
@@ -91,7 +94,7 @@ public class ExportController extends AbstractSolrSearchController {
 	}
 	
 	private void printHeaders(CSVPrinter printer) throws IOException {
-		printer.printRecord("Object Type", "PID", "Title", "Path", "Label", "Depth", "Deleted", "Date Added", "Date Updated", "MIME Type", "Checksum", "File Size (bytes)", "Number of Children", "Content Status");
+		printer.printRecord("Object Type", "PID", "Title", "Path", "Label", "Depth", "Deleted", "Date Added", "Date Updated", "MIME Type", "Checksum", "File Size (bytes)", "Number of Children", "Description");
 	}
 	
 	private void printObject(CSVPrinter printer, BriefObjectMetadata object) throws IOException {
@@ -177,9 +180,15 @@ public class ExportController extends AbstractSolrSearchController {
 			printer.print("");
 		}
 		
-		// Content status: has a MODS description?
+		// Description: does object have a MODS description?
 		
-		printer.print(object.getContentStatus().toString());
+		if (object.getContentStatus().contains(NOT_DESCRIBED)) {
+			printer.print(NOT_DESCRIBED);
+		} else if (object.getContentStatus().contains(DESCRIBED)) {
+			printer.print(DESCRIBED);
+		} else {
+			printer.print("");
+		}
 		
 		printer.println();
 		

--- a/solr-search/src/main/java/edu/unc/lib/dl/search/solr/model/BriefObjectMetadataBean.java
+++ b/solr-search/src/main/java/edu/unc/lib/dl/search/solr/model/BriefObjectMetadataBean.java
@@ -270,6 +270,7 @@ public class BriefObjectMetadataBean extends IndexDocumentBean implements BriefO
 		sb.append("dateAdded: " + dateAdded + "\n");
 		sb.append("dateUpdated: " + dateUpdated + "\n");
 		sb.append("timestamp: " + timestamp + "\n");
+		sb.append("contentStatus: " + contentStatus + "\n");
 		return sb.toString();
 	}
 


### PR DESCRIPTION
I have deployed to QA and the exported .csv file now has a column for content status that is populated with appropriate values.