### PR TITLE
Remove staging-areas module

### DIFF
--- a/deposit/pom.xml
+++ b/deposit/pom.xml
@@ -108,11 +108,6 @@
 			<version>0.3</version>
 		</dependency>
 		<dependency>
-			<groupId>edu.unc.lib.cdr</groupId>
-			<artifactId>staging-areas</artifactId>
-			<version>0.0.1-SNAPSHOT</version>
-		</dependency>
-		<dependency>
 			<groupId>commons-daemon</groupId>
 			<artifactId>commons-daemon</artifactId>
 			<version>${commons-daemon.version}</version>
@@ -309,8 +304,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/deposit/src/main/java/edu/unc/lib/deposit/normalize/AbstractFileServerToBagJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/normalize/AbstractFileServerToBagJob.java
@@ -32,7 +32,6 @@ import org.jdom2.Element;
 import org.jdom2.output.XMLOutputter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import com.hp.hpl.jena.rdf.model.Bag;
 import com.hp.hpl.jena.rdf.model.Model;
@@ -46,7 +45,6 @@ import edu.unc.lib.dl.rdf.Cdr;
 import edu.unc.lib.dl.rdf.CdrDeposit;
 import edu.unc.lib.dl.util.RedisWorkerConstants.DepositField;
 import edu.unc.lib.dl.xml.JDOMNamespaceUtil;
-import edu.unc.lib.staging.Stages;
 
 /**
  * Abstract deposit normalization job which processes walks file system paths to interpret them into n3 and MODS for
@@ -57,9 +55,6 @@ import edu.unc.lib.staging.Stages;
 public abstract class AbstractFileServerToBagJob extends AbstractDepositJob {
 	private static final Logger log = LoggerFactory
 			.getLogger(AbstractFileServerToBagJob.class);
-	
-	@Autowired
-	public Stages stages;
 	
 	private Map<String, Bag> pathToFolderBagCache;
 	
@@ -249,9 +244,4 @@ public abstract class AbstractFileServerToBagJob extends AbstractDepositJob {
 			
 		}
 	}
-
-	public void setStages(Stages stages) {
-		this.stages = stages;
-	}
-
 }

--- a/deposit/src/main/java/edu/unc/lib/deposit/normalize/DirectoryToBagJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/normalize/DirectoryToBagJob.java
@@ -24,7 +24,6 @@ import static edu.unc.lib.dl.util.ContentModelHelper.Model.SIMPLE;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
@@ -49,7 +48,6 @@ import edu.unc.lib.dl.util.ContentModelHelper.DepositRelationship;
 import edu.unc.lib.dl.util.ContentModelHelper.FedoraProperty;
 import edu.unc.lib.dl.util.RedisWorkerConstants.DepositField;
 import edu.unc.lib.dl.util.SoftwareAgentConstants.SoftwareAgent;
-import edu.unc.lib.staging.StagingException;
 
 /**
  * Normalizes a simple directory submission into n3 for deposit
@@ -135,15 +133,7 @@ public class DirectoryToBagJob extends AbstractFileServerToBagJob {
 				
 				// Find staged path for the file
 				Path storedPath = Paths.get(file.getAbsolutePath());
-				try {
-					URI stagedURI = stages.getStagedURI(storedPath.toUri());
-					
-					if (stagedURI != null) {
-						model.add(fileResource, locationProp, stagedURI.toString());
-					}
-				} catch (StagingException e) {
-					failJob(e, "Unable to get staged path for file {}", storedPath);
-				}
+				model.add(fileResource, locationProp, storedPath.toUri().toString());
 			} else {
 				Bag folderBag = getFolderBag(sourceBag, filePathString);
 				model.add(folderBag, labelProp, filename);

--- a/deposit/src/main/java/edu/unc/lib/deposit/staging/StagingException.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/staging/StagingException.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2016 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.deposit.staging;
+
+/**
+ * Exception thrown when a staging configuration or lookup problem occurs
+ * 
+ * @author bbpennel
+ *
+ */
+public class StagingException extends RuntimeException {
+
+	private static final long serialVersionUID = -4749841917768967399L;
+
+	public StagingException(String message) {
+		super(message);
+	}
+	
+	public StagingException(String message, Exception e) {
+		super(message, e);
+	}
+
+}

--- a/deposit/src/main/java/edu/unc/lib/deposit/staging/StagingPolicy.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/staging/StagingPolicy.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2016 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.deposit.staging;
+
+/**
+ * Staging policy for a single staging location
+ * 
+ * @author bbpennel
+ *
+ */
+public class StagingPolicy {
+	public static enum CleanupPolicy {
+		DELETE_INGESTED_FILES,
+		DO_NOTHING,
+		DELETE_INGESTED_FILES_EMPTY_FOLDERS,
+		DELETE_INGESTED_DEPOSIT_FOLDERS
+	}
+
+	private String path;
+	private String name;
+	private CleanupPolicy cleanupPolicy;
+
+	public String getPath() {
+		return path;
+	}
+
+	public void setPath(String path) {
+		this.path = path;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public CleanupPolicy getCleanupPolicy() {
+		return cleanupPolicy;
+	}
+
+	public void setCleanupPolicy(CleanupPolicy cleanupPolicy) {
+		this.cleanupPolicy = cleanupPolicy;
+	}
+}

--- a/deposit/src/main/java/edu/unc/lib/deposit/staging/StagingPolicy.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/staging/StagingPolicy.java
@@ -25,8 +25,7 @@ public class StagingPolicy {
 	public static enum CleanupPolicy {
 		DELETE_INGESTED_FILES,
 		DO_NOTHING,
-		DELETE_INGESTED_FILES_EMPTY_FOLDERS,
-		DELETE_INGESTED_DEPOSIT_FOLDERS
+		DELETE_INGESTED_FILES_EMPTY_FOLDERS
 	}
 
 	private String path;

--- a/deposit/src/main/java/edu/unc/lib/deposit/staging/StagingPolicyManager.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/staging/StagingPolicyManager.java
@@ -67,7 +67,7 @@ public class StagingPolicyManager {
 		for (StagingPolicy policy : policies) {
 			String path = policy.getPath();
 
-			// If path was no absolute, resolve it against the base path
+			// If path was not absolute, resolve it against the base path
 			if (!Paths.get(path).isAbsolute()) {
 				policy.setPath(URIUtil.join(basePath, path));
 			}
@@ -119,7 +119,7 @@ public class StagingPolicyManager {
 	 * @param fileUri
 	 * @return
 	 */
-	public boolean inValidStagingLocation(URI fileUri) {
+	public boolean isValidStagingLocation(URI fileUri) {
 		try {
 			getStagingPolicy(fileUri);
 			return true;

--- a/deposit/src/main/java/edu/unc/lib/deposit/staging/StagingPolicyManager.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/staging/StagingPolicyManager.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright 2016 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.deposit.staging;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.codehaus.jackson.map.ObjectMapper;
+
+import edu.unc.lib.deposit.staging.StagingPolicy.CleanupPolicy;
+import edu.unc.lib.dl.util.URIUtil;
+
+/**
+ * Manager for staging policies, which assists in determining if file paths are
+ * located within accepted staging locations according to the provided policies,
+ * and provides access to those policies. Loaded from a policy configuration
+ * json file
+ * 
+ * @author bbpennel
+ *
+ */
+public class StagingPolicyManager {
+
+	private String basePath;
+
+	private String configPath;
+
+	private List<StagingPolicy> policies;
+
+	public StagingPolicyManager() {
+	}
+
+	public void init() {
+		loadConfig();
+	}
+
+	private void loadConfig() throws StagingException {
+		File configFile = new File(configPath);
+
+		ObjectMapper mapper = new ObjectMapper();
+
+		try {
+			// Load the policy configuration from the provided json
+			policies = mapper.readValue(configFile, mapper.getTypeFactory()
+					.constructCollectionType(List.class, StagingPolicy.class));
+		} catch (IOException e) {
+			throw new StagingException("Failed to load staging configuration from " + configPath, e);
+		}
+
+		// Verify and resolve any staging location paths
+		for (StagingPolicy policy : policies) {
+			String path = policy.getPath();
+
+			// If path was no absolute, resolve it against the base path
+			if (!Paths.get(path).isAbsolute()) {
+				policy.setPath(URIUtil.join(basePath, path));
+			}
+
+			// Abort loading if one of the paths is invalid
+			if (!Paths.get(policy.getPath()).toFile().exists()) {
+				throw new StagingException("Unable to resolve staging location " + policy.getPath());
+			}
+		}
+	}
+
+	/**
+	 * Get the staging policy which applies to the given file uri, or throw a
+	 * staging exception if no policy is found
+	 * 
+	 * @param fileUri
+	 * @return
+	 * @throws StagingException
+	 */
+	public StagingPolicy getStagingPolicy(URI fileUri) throws StagingException {
+		String path = fileUri.getPath();
+
+		for (StagingPolicy policy : policies) {
+			String policyPath = policy.getPath();
+			if (path.startsWith(policyPath)) {
+				return policy;
+			}
+		}
+
+		throw new StagingException("No staging policy available for " + fileUri);
+	}
+
+	/**
+	 * Get the cleanup policy which applies to the given file uri, or throw a
+	 * staging exception if no policy is found
+	 * 
+	 * @param fileUri
+	 * @return
+	 * @throws StagingException
+	 */
+	public CleanupPolicy getCleanupPolicy(URI fileUri) throws StagingException {
+		return getStagingPolicy(fileUri).getCleanupPolicy();
+	}
+
+	/**
+	 * Returns true if the given file uri is contained by at least one of the
+	 * staging locations registered with this manager
+	 * 
+	 * @param fileUri
+	 * @return
+	 */
+	public boolean inValidStagingLocation(URI fileUri) {
+		try {
+			getStagingPolicy(fileUri);
+			return true;
+		} catch (StagingException e) {
+			return false;
+		}
+	}
+	
+	public String getBasePath() {
+		return basePath;
+	}
+
+	public void setBasePath(String basePath) {
+		this.basePath = basePath;
+	}
+
+	public String getConfigPath() {
+		return configPath;
+	}
+
+	public void setConfigPath(String configPath) {
+		this.configPath = configPath;
+	}
+}

--- a/deposit/src/main/java/edu/unc/lib/deposit/validate/ValidateFileAvailabilityJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/validate/ValidateFileAvailabilityJob.java
@@ -35,8 +35,6 @@ import edu.unc.lib.dl.rdf.CdrDeposit;
 /**
  * Verifies that files referenced by this deposit for ingest are present and
  * available
- * 
- * @author daines
  *
  */
 public class ValidateFileAvailabilityJob extends AbstractDepositJob {
@@ -54,7 +52,7 @@ public class ValidateFileAvailabilityJob extends AbstractDepositJob {
 
 		setTotalClicks(hrefs.size());
 
-		// Verify that the deposit is still running before preceeding with check
+		// Verify that the deposit is still running before proceeding with check
 		verifyRunning();
 
 		// Iterate through local file hrefs and verify that each one exists

--- a/deposit/src/main/java/edu/unc/lib/deposit/validate/ValidateFileAvailabilityJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/validate/ValidateFileAvailabilityJob.java
@@ -1,12 +1,24 @@
+/**
+ * Copyright 2016 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package edu.unc.lib.deposit.validate;
 
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 
 import com.hp.hpl.jena.rdf.model.Model;
@@ -18,84 +30,64 @@ import com.hp.hpl.jena.rdf.model.Statement;
 import com.hp.hpl.jena.rdf.model.StmtIterator;
 
 import edu.unc.lib.deposit.work.AbstractDepositJob;
-import edu.unc.lib.dl.fcrepo4.PIDs;
-import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.rdf.CdrDeposit;
-import edu.unc.lib.staging.Stages;
-import edu.unc.lib.staging.StagingException;
 
+/**
+ * Verifies that files referenced by this deposit for ingest are present and
+ * available
+ * 
+ * @author daines
+ *
+ */
 public class ValidateFileAvailabilityJob extends AbstractDepositJob {
-
-	private Stages stages;
-	
-	public Stages getStages() {
-		return stages;
-	}
-
-	public void setStages(Stages stages) {
-		this.stages = stages;
-	}
-
-	public ValidateFileAvailabilityJob(String uuid, String depositUUID) {
-		super(uuid, depositUUID);
-	}
 
 	@Override
 	public void runJob() {
-		Map<PID, String> hrefs = new HashMap<PID, String>();
+
 		Set<String> failures = new HashSet<String>();
 
 		Model model = getReadOnlyModel();
-		Property fileLocation = CdrDeposit.stagingLocation;
-		StmtIterator i = model.listStatements(new SimpleSelector((Resource) null, fileLocation, (RDFNode) null));
-		while (i.hasNext()) {
-			Statement s = i.nextStatement();
-			PID p = PIDs.get(s.getSubject().getURI());
-			String href = s.getObject().asLiteral().getString();
-			hrefs.put(p, href);
-		}
+		// Construct a map of objects to file paths to verify
+		Set<String> hrefs = new HashSet<String>();
+		addLocations(hrefs, model, CdrDeposit.stagingLocation);
+		addLocations(hrefs, model, CdrDeposit.hasDatastream);
 
 		setTotalClicks(hrefs.size());
 
-		for (Entry<PID, String> href : hrefs.entrySet()) {
-			verifyRunning();
+		// Verify that the deposit is still running before preceeding with check
+		verifyRunning();
 
-			URI manifestURI;
-			URI storageURI = null;
+		// Iterate through local file hrefs and verify that each one exists
+		for (String href : hrefs) {
+			URI manifestURI = null;
 			try {
-				manifestURI = new URI(href.getValue());
-				if (manifestURI.getScheme() == null) {
-					storageURI = manifestURI;
-				} else {
-					storageURI = getStages().getStorageURI(manifestURI);
-				}
+				manifestURI = new URI(href);
 			} catch (URISyntaxException e) {
-				failJob(e, "Unable to parse manifest URI: {0}", href.getValue());
-			} catch (StagingException e) {
-				failJob(e, "Unable to resolve staging location for file: {0}", href.getValue());
+				failJob(e, "Unable to parse manifest URI: {0}", href);
 			}
-			
-			if (storageURI.getScheme() == null || storageURI.getScheme().contains("file")) {
-				if (!storageURI.isAbsolute()) {
-					storageURI = getDepositDirectory().toURI().resolve(storageURI);
+
+			if (manifestURI.getScheme() == null || manifestURI.getScheme().contains("file")) {
+				if (!manifestURI.isAbsolute()) {
+					manifestURI = getDepositDirectory().toURI().resolve(manifestURI);
 				}
-				
-				File file = new File(storageURI.getPath());
-				
+
+				File file = new File(manifestURI.getPath());
+
 				if (!file.exists()) {
-					failures.add(storageURI.toString());
+					failures.add(manifestURI.toString());
 				}
 			}
-			
+
 			addClicks(1);
 		}
-		
+
+		// Generate failure message of all missing files and fail job
 		if (failures.size() > 0) {
-			StringBuilder sb = new StringBuilder("Some of the files referenced by the deposit could not be found:\n");
+			StringBuilder sb = new StringBuilder("Some files referenced by the deposit could not be found:\n");
 			for (String uri : failures) {
-				sb.append(uri).append(" - ").append(uri).append("\n");
+				sb.append(" - ").append(uri).append("\n");
 			}
-			
+
 			if (failures.size() == 1) {
 				failJob("1 file referenced by the deposit could not be found.", sb.toString());
 			} else {
@@ -104,4 +96,13 @@ public class ValidateFileAvailabilityJob extends AbstractDepositJob {
 		}
 	}
 
+	private void addLocations(Set<String> hrefs, Model model, Property property) {
+		Property fileLocation = CdrDeposit.stagingLocation;
+		StmtIterator i = model.listStatements(new SimpleSelector((Resource) null, fileLocation, (RDFNode) null));
+		while (i.hasNext()) {
+			Statement s = i.nextStatement();
+			String href = s.getObject().asLiteral().getString();
+			hrefs.add(href);
+		}
+	}
 }

--- a/deposit/src/test/java/edu/unc/lib/deposit/CleanupDepositJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/CleanupDepositJobTest.java
@@ -56,9 +56,6 @@ import edu.unc.lib.dl.util.URIUtil;
  */
 public class CleanupDepositJobTest extends AbstractDepositJobTest {
 
-	private File depositsDir;
-	private File depositDir;
-
 	private File stagesDir;
 
 	private File stagingFolder;
@@ -88,15 +85,13 @@ public class CleanupDepositJobTest extends AbstractDepositJobTest {
 
 	private void createJob() throws Exception {
 		// Create a deposit directory with a manifest file in it
-		depositDir = new File(depositsDir, depositUUID);
-		depositDir.mkdir();
 		File manifestFile = new File(depositDir, "manifest.txt");
 		manifestFile.createNewFile();
 
 		// Initialize the job
 		job = new CleanupDepositJob(jobUUID, depositUUID);
-		job.setStagingManager(stagingManager);
-		setField(job, "depositsDirectory", depositsDir);
+		job.setStagingPolicyManager(stagingManager);
+		setField(job, "depositsDirectory", depositsDirectory);
 		setField(job, "jobStatusFactory", jobStatusFactory);
 		setField(job, "depositStatusFactory", depositStatusFactory);
 		setField(job, "dataset", dataset);

--- a/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/AbstractDepositJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/AbstractDepositJobTest.java
@@ -26,9 +26,13 @@ import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mock;
 
+import com.hp.hpl.jena.query.Dataset;
+import com.hp.hpl.jena.tdb.TDBFactory;
+
 import edu.unc.lib.dl.fcrepo4.PIDs;
 import edu.unc.lib.dl.fcrepo4.Repository;
 import edu.unc.lib.dl.fcrepo4.RepositoryObjectDataLoader;
+import edu.unc.lib.dl.fcrepo4.RepositoryPathConstants;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.reporting.ActivityMetricsClient;
 import edu.unc.lib.dl.util.DepositStatusFactory;
@@ -63,6 +67,9 @@ public class AbstractDepositJobTest {
 	protected String jobUUID;
 	
 	protected String depositUUID;
+	protected PID depositPid;
+	
+	protected Dataset dataset;
 
 	@Before
 	public void initBase() throws Exception {
@@ -78,6 +85,9 @@ public class AbstractDepositJobTest {
 		depositUUID = UUID.randomUUID().toString();
 		depositDir = new File(depositsDirectory, depositUUID);
 		depositDir.mkdir();
+		depositPid = PIDs.get(RepositoryPathConstants.DEPOSIT_RECORD_BASE, depositUUID);
+		
+		dataset = TDBFactory.createDataset();
 	}
 
 	protected PID makePid(String qualifier) {

--- a/deposit/src/test/java/edu/unc/lib/deposit/normalize/DirectoryToBagJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/normalize/DirectoryToBagJobTest.java
@@ -26,22 +26,17 @@ import static edu.unc.lib.dl.util.ContentModelHelper.Model.CONTAINER;
 import static edu.unc.lib.dl.util.ContentModelHelper.Model.SIMPLE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import com.hp.hpl.jena.query.Dataset;
 import com.hp.hpl.jena.rdf.model.Bag;
@@ -52,7 +47,6 @@ import com.hp.hpl.jena.tdb.TDBFactory;
 
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.util.RedisWorkerConstants.DepositField;
-import edu.unc.lib.staging.Stages;
 
 public class DirectoryToBagJobTest extends AbstractNormalizationJobTest {
 	
@@ -62,8 +56,6 @@ public class DirectoryToBagJobTest extends AbstractNormalizationJobTest {
 	private DirectoryToBagJob job;
 
 	private Map<String, String> status;
-	
-	private Stages stages;
 	
 	private File depositDirectory;
 
@@ -80,8 +72,6 @@ public class DirectoryToBagJobTest extends AbstractNormalizationJobTest {
 		File testFile = new File(testDirectory, "lorem.txt");
 		testFile.createNewFile();
 		
-		stages = mock(Stages.class);
-		
 		status = new HashMap<String, String>();
 
 		when(depositStatusFactory.get(anyString())).thenReturn(status);
@@ -91,7 +81,6 @@ public class DirectoryToBagJobTest extends AbstractNormalizationJobTest {
 		job = new DirectoryToBagJob();
 		job.setDepositUUID(depositUUID);
 		job.setDepositDirectory(depositDir);
-		job.setStages(stages);
 		setField(job, "dataset", dataset);
 		setField(job, "depositsDirectory", depositDirectory);
 		setField(job, "depositStatusFactory", depositStatusFactory);
@@ -104,18 +93,6 @@ public class DirectoryToBagJobTest extends AbstractNormalizationJobTest {
 		status.put(DepositField.sourcePath.name(), depositDirectory.getAbsolutePath());
 		status.put(DepositField.fileName.name(), "Test File");
 		status.put(DepositField.extras.name(), "{\"accessionNumber\" : \"123456\", \"mediaId\" : \"789\"}");
-		
-		when(stages.getStagedURI(any(URI.class))).thenAnswer(new Answer<URI>() {
-			public URI answer(InvocationOnMock invocation) throws URISyntaxException {
-				Object[] args = invocation.getArguments();
-				URI uri = (URI) args[0];
-				String path = uri.toString();
-				int index = path.lastIndexOf("/paths");
-				path = path.substring(index + 6);
-				
-				return new URI("tag:" + path);
-			}
-		});
 
 		job.run();
 

--- a/deposit/src/test/java/edu/unc/lib/deposit/staging/StagingPolicyManagerTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/staging/StagingPolicyManagerTest.java
@@ -117,11 +117,11 @@ public class StagingPolicyManagerTest {
 	}
 
 	@Test
-	public void inValidStagingLocationTest() {
+	public void isValidStagingLocationTest() {
 		manager.init();
 
-		assertTrue(manager.inValidStagingLocation(validUri));
+		assertTrue(manager.isValidStagingLocation(validUri));
 
-		assertFalse(manager.inValidStagingLocation(unregisteredUri));
+		assertFalse(manager.isValidStagingLocation(unregisteredUri));
 	}
 }

--- a/deposit/src/test/java/edu/unc/lib/deposit/staging/StagingPolicyManagerTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/staging/StagingPolicyManagerTest.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2016 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.deposit.staging;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.net.URI;
+import java.nio.file.Paths;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import edu.unc.lib.deposit.staging.StagingPolicy.CleanupPolicy;
+
+/**
+ * 
+ * @author bbpennel
+ *
+ */
+public class StagingPolicyManagerTest {
+
+	private File depositsDirectory;
+	@Rule
+	public final TemporaryFolder tmpFolder = new TemporaryFolder();
+
+	private File stagingLoc1;
+	private File stagingLoc2;
+	private File unregisteredLoc;
+
+	private URI validUri;
+	private URI unregisteredUri;
+
+	private StagingPolicyManager manager;
+
+	@Before
+	public void init() throws Exception {
+		depositsDirectory = tmpFolder.newFolder("deposits");
+
+		manager = new StagingPolicyManager();
+		manager.setBasePath(depositsDirectory.getAbsolutePath());
+		manager.setConfigPath("src/test/resources/staging_config.json");
+
+		stagingLoc1 = new File(depositsDirectory, "staging_location1");
+		stagingLoc1.mkdir();
+		stagingLoc2 = new File(depositsDirectory, "staging_location2");
+		stagingLoc2.mkdir();
+		unregisteredLoc = new File(depositsDirectory, "unregistered");
+		unregisteredLoc.mkdir();
+
+		validUri = Paths.get(stagingLoc1.getAbsolutePath(), "file.txt").toUri();
+		unregisteredUri = Paths.get(unregisteredLoc.getAbsolutePath(), "gone.txt").toUri();
+	}
+
+	@Test(expected = StagingException.class)
+	public void missingLocationInitTest() {
+		stagingLoc2.delete();
+
+		manager.init();
+	}
+
+	@Test
+	public void getStagingPolicyTest() {
+		manager.init();
+
+		StagingPolicy policy = manager.getStagingPolicy(validUri);
+
+		assertNotNull(policy);
+		assertEquals("Stage1", policy.getName());
+		assertEquals(CleanupPolicy.DELETE_INGESTED_FILES_EMPTY_FOLDERS, policy.getCleanupPolicy());
+		assertNotNull(policy.getPath());
+	}
+
+	@Test(expected = StagingException.class)
+	public void getStagingPolicyUnregisteredPathTest() {
+		manager.init();
+
+		manager.getStagingPolicy(
+				Paths.get(unregisteredLoc.getAbsolutePath(), "file.txt").toUri());
+	}
+
+	@Test
+	public void getCleanupPolicyTest() {
+		manager.init();
+
+		CleanupPolicy policy1 = manager.getCleanupPolicy(validUri);
+		assertEquals(CleanupPolicy.DELETE_INGESTED_FILES_EMPTY_FOLDERS, policy1);
+
+		URI validUri2 = Paths.get(stagingLoc2.getAbsolutePath(), "image.png").toUri();
+		CleanupPolicy policy2 = manager.getCleanupPolicy(validUri2);
+		assertEquals(CleanupPolicy.DO_NOTHING, policy2);
+	}
+
+	@Test(expected = StagingException.class)
+	public void getCleanupPolicyForUnregistedPathTest() {
+		manager.init();
+
+		manager.getCleanupPolicy(unregisteredUri);
+	}
+
+	@Test
+	public void inValidStagingLocationTest() {
+		manager.init();
+
+		assertTrue(manager.inValidStagingLocation(validUri));
+
+		assertFalse(manager.inValidStagingLocation(unregisteredUri));
+	}
+}

--- a/deposit/src/test/java/edu/unc/lib/deposit/validate/ValidateFileAvailabilityJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/validate/ValidateFileAvailabilityJobTest.java
@@ -58,9 +58,6 @@ public class ValidateFileAvailabilityJobTest extends AbstractDepositJobTest {
 
 	private ValidateFileAvailabilityJob job;
 
-	private String examplesPath = "src/test/resources/examples";
-	private File examplesFile;
-
 	@Before
 	public void init() throws Exception {
 		initMocks(this);
@@ -83,7 +80,7 @@ public class ValidateFileAvailabilityJobTest extends AbstractDepositJobTest {
 
 		depositPid = job.getDepositPID();
 
-		examplesFile = new File(examplesPath);
+		File examplesFile = new File("src/test/resources/examples");
 		FileUtils.copyDirectory(examplesFile, depositDir);
 	}
 
@@ -118,9 +115,9 @@ public class ValidateFileAvailabilityJobTest extends AbstractDepositJobTest {
 		workBag.addProperty(RDF.type, Cdr.Work);
 
 		depBag.add(workBag);
-		addFileObject(workBag, Paths.get(examplesFile.getAbsolutePath(), "pdf.pdf")
+		addFileObject(workBag, Paths.get(depositDir.getAbsolutePath(), "pdf.pdf")
 				.toAbsolutePath().toString());
-		addFileObject(workBag, Paths.get(examplesFile.getAbsolutePath(), "text.txt")
+		addFileObject(workBag, Paths.get(depositDir.getAbsolutePath(), "text.txt")
 				.toAbsolutePath().toString());
 
 		job.closeModel();

--- a/deposit/src/test/java/edu/unc/lib/deposit/validate/ValidateFileAvailabilityJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/validate/ValidateFileAvailabilityJobTest.java
@@ -1,0 +1,175 @@
+/**
+ * Copyright 2016 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.deposit.validate;
+
+import static edu.unc.lib.dl.test.TestHelpers.setField;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.io.File;
+import java.nio.file.Paths;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.hp.hpl.jena.query.Dataset;
+import com.hp.hpl.jena.rdf.model.Bag;
+import com.hp.hpl.jena.rdf.model.Model;
+import com.hp.hpl.jena.rdf.model.Resource;
+import com.hp.hpl.jena.tdb.TDBFactory;
+import com.hp.hpl.jena.vocabulary.RDF;
+
+import edu.unc.lib.deposit.fcrepo4.AbstractDepositJobTest;
+import edu.unc.lib.deposit.work.JobFailedException;
+import edu.unc.lib.deposit.work.JobInterruptedException;
+import edu.unc.lib.dl.fcrepo4.RepositoryPathConstants;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.rdf.Cdr;
+import edu.unc.lib.dl.rdf.CdrDeposit;
+import edu.unc.lib.dl.util.RedisWorkerConstants.DepositState;
+
+/**
+ * 
+ * @author bbpennel
+ *
+ */
+public class ValidateFileAvailabilityJobTest extends AbstractDepositJobTest {
+
+	private PID depositPid;
+
+	private ValidateFileAvailabilityJob job;
+
+	private String examplesPath = "src/test/resources/examples";
+	private File examplesFile;
+
+	@Before
+	public void init() throws Exception {
+		initMocks(this);
+
+		Dataset dataset = TDBFactory.createDataset();
+
+		job = new ValidateFileAvailabilityJob();
+		job.setJobUUID(jobUUID);
+		job.setDepositUUID(depositUUID);
+		job.setDepositDirectory(depositDir);
+		job.setRepository(repository);
+		setField(job, "dataset", dataset);
+		setField(job, "depositsDirectory", depositsDirectory);
+		setField(job, "depositStatusFactory", depositStatusFactory);
+		setField(job, "jobStatusFactory", jobStatusFactory);
+		job.init();
+
+		when(depositStatusFactory.getState(anyString()))
+				.thenReturn(DepositState.running);
+
+		depositPid = job.getDepositPID();
+
+		examplesFile = new File(examplesPath);
+		FileUtils.copyDirectory(examplesFile, depositDir);
+	}
+
+	@Test
+	public void multipleRelativePresentTest() {
+		Model model = job.getWritableModel();
+		Bag depBag = model.createBag(depositPid.getRepositoryPath());
+
+		PID workPid = makePid(RepositoryPathConstants.CONTENT_BASE);
+		Bag workBag = model.createBag(workPid.getRepositoryPath());
+		workBag.addProperty(RDF.type, Cdr.Work);
+
+		depBag.add(workBag);
+		addFileObject(workBag, "pdf.pdf");
+		addFileObject(workBag, "text.txt");
+
+		job.closeModel();
+
+		job.run();
+
+		verify(jobStatusFactory).setTotalCompletion(eq(jobUUID), eq(2));
+		verify(jobStatusFactory, times(2)).incrCompletion(eq(jobUUID), eq(1));
+	}
+
+	@Test
+	public void absolutePresentTest() {
+		Model model = job.getWritableModel();
+		Bag depBag = model.createBag(depositPid.getRepositoryPath());
+
+		PID workPid = makePid(RepositoryPathConstants.CONTENT_BASE);
+		Bag workBag = model.createBag(workPid.getRepositoryPath());
+		workBag.addProperty(RDF.type, Cdr.Work);
+
+		depBag.add(workBag);
+		addFileObject(workBag, Paths.get(examplesFile.getAbsolutePath(), "pdf.pdf")
+				.toAbsolutePath().toString());
+		addFileObject(workBag, Paths.get(examplesFile.getAbsolutePath(), "text.txt")
+				.toAbsolutePath().toString());
+
+		job.closeModel();
+
+		job.run();
+
+		verify(jobStatusFactory).setTotalCompletion(eq(jobUUID), eq(2));
+		verify(jobStatusFactory, times(2)).incrCompletion(eq(jobUUID), eq(1));
+	}
+
+	@Test(expected = JobFailedException.class)
+	public void missingFileTest() {
+		Model model = job.getWritableModel();
+		Bag depBag = model.createBag(depositPid.getRepositoryPath());
+
+		addFileObject(depBag, "missing.pdf");
+		addFileObject(depBag, "text.txt");
+
+		job.closeModel();
+
+		job.run();
+	}
+
+	@Test(expected = JobInterruptedException.class)
+	public void interruptedTest() {
+		when(depositStatusFactory.getState(anyString()))
+				.thenReturn(DepositState.paused);
+
+		Model model = job.getWritableModel();
+		Bag depBag = model.createBag(depositPid.getRepositoryPath());
+
+		addFileObject(depBag, "pdf.pdf");
+
+		job.closeModel();
+
+		job.run();
+
+		verify(jobStatusFactory, never()).incrCompletion(eq(jobUUID), eq(1));
+	}
+
+	private PID addFileObject(Bag parent, String stagingLocation) {
+		PID filePid = makePid(RepositoryPathConstants.CONTENT_BASE);
+
+		Resource fileResc = parent.getModel().createResource(filePid.getRepositoryPath());
+		fileResc.addProperty(RDF.type, Cdr.FileObject);
+		fileResc.addProperty(CdrDeposit.stagingLocation, stagingLocation);
+
+		parent.add(fileResc);
+
+		return filePid;
+	}
+}

--- a/deposit/src/test/java/edu/unc/lib/deposit/validate/VirusScanJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/validate/VirusScanJobTest.java
@@ -44,11 +44,9 @@ import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
-import com.hp.hpl.jena.query.Dataset;
 import com.hp.hpl.jena.rdf.model.Bag;
 import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.Resource;
-import com.hp.hpl.jena.tdb.TDBFactory;
 import com.hp.hpl.jena.vocabulary.RDF;
 import com.philvarner.clamavj.ClamScan;
 import com.philvarner.clamavj.ScanResult;
@@ -71,7 +69,7 @@ import edu.unc.lib.dl.util.URIUtil;
  * @author bbpennel
  *
  */
-public class VirusScanJobTest extends AbstractDepositJobTest{
+public class VirusScanJobTest extends AbstractDepositJobTest {
 
 	private PID depositPid;
 
@@ -86,8 +84,6 @@ public class VirusScanJobTest extends AbstractDepositJobTest{
 	@Before
 	public void init() throws Exception {
 		initMocks(this);
-
-		Dataset dataset = TDBFactory.createDataset();
 
 		job = new VirusScanJob();
 		job.setJobUUID(jobUUID);

--- a/deposit/src/test/java/edu/unc/lib/deposit/validate/VirusScanJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/validate/VirusScanJobTest.java
@@ -1,0 +1,254 @@
+/**
+ * Copyright 2016 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.deposit.validate;
+
+import static edu.unc.lib.dl.test.TestHelpers.setField;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.UUID;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import com.hp.hpl.jena.query.Dataset;
+import com.hp.hpl.jena.rdf.model.Bag;
+import com.hp.hpl.jena.rdf.model.Model;
+import com.hp.hpl.jena.rdf.model.Resource;
+import com.hp.hpl.jena.tdb.TDBFactory;
+import com.hp.hpl.jena.vocabulary.RDF;
+import com.philvarner.clamavj.ClamScan;
+import com.philvarner.clamavj.ScanResult;
+import com.philvarner.clamavj.ScanResult.Status;
+
+import edu.unc.lib.deposit.fcrepo4.AbstractDepositJobTest;
+import edu.unc.lib.deposit.work.JobFailedException;
+import edu.unc.lib.dl.fcrepo4.RepositoryPathConstants;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.rdf.Cdr;
+import edu.unc.lib.dl.rdf.CdrDeposit;
+import edu.unc.lib.dl.rdf.Premis;
+import edu.unc.lib.dl.util.DepositConstants;
+import edu.unc.lib.dl.util.RDFModelUtil;
+import edu.unc.lib.dl.util.RedisWorkerConstants.DepositState;
+import edu.unc.lib.dl.util.URIUtil;
+
+/**
+ * 
+ * @author bbpennel
+ *
+ */
+public class VirusScanJobTest extends AbstractDepositJobTest{
+
+	private PID depositPid;
+
+	private VirusScanJob job;
+
+	@Mock
+	private ClamScan clamScan;
+
+	@Mock
+	private ScanResult scanResult;
+
+	@Before
+	public void init() throws Exception {
+		initMocks(this);
+
+		Dataset dataset = TDBFactory.createDataset();
+
+		job = new VirusScanJob();
+		job.setJobUUID(jobUUID);
+		job.setDepositUUID(depositUUID);
+		job.setDepositDirectory(depositDir);
+		job.setRepository(repository);
+		job.setClamScan(clamScan);
+		setField(job, "dataset", dataset);
+		setField(job, "depositsDirectory", depositsDirectory);
+		setField(job, "depositStatusFactory", depositStatusFactory);
+		setField(job, "jobStatusFactory", jobStatusFactory);
+		job.init();
+
+		when(depositStatusFactory.getState(anyString()))
+				.thenReturn(DepositState.running);
+
+		depositPid = job.getDepositPID();
+
+		when(repository.mintPremisEventPid(any(PID.class))).thenAnswer(new Answer<PID>() {
+			@Override
+			public PID answer(InvocationOnMock invocation) throws Throwable {
+				PID pid = mock(PID.class);
+				String path = URIUtil.join(FEDORA_BASE, "event", UUID.randomUUID().toString());
+				when(pid.getRepositoryPath()).thenReturn(path);
+				return pid;
+			}
+		});
+
+		when(clamScan.scan(any(File.class))).thenReturn(scanResult);
+
+		File examplesFile = new File("src/test/resources/examples");
+		FileUtils.copyDirectory(examplesFile, depositDir);
+	}
+
+	@Test
+	public void passScanTest() throws Exception {
+		when(scanResult.getStatus()).thenReturn(Status.PASSED);
+
+		Model model = job.getWritableModel();
+		Bag depBag = model.createBag(depositPid.getRepositoryPath());
+
+		PID file1Pid = addFileObject(depBag, "pdf.pdf");
+		PID file2Pid = addFileObject(depBag, "text.txt");
+
+		job.closeModel();
+
+		job.run();
+
+		verify(jobStatusFactory).setTotalCompletion(eq(jobUUID), eq(2));
+		verify(jobStatusFactory, times(2)).incrCompletion(eq(jobUUID), eq(1));
+
+		verifyPremisEvents(file1Pid);
+		verifyPremisEvents(file2Pid);
+		verifyPremisEvents(depositPid);
+	}
+
+	@Test
+	public void failOneScanTest() throws Exception {
+		// Fail the text scan, but not the pdf
+		when(scanResult.getStatus()).thenReturn(Status.PASSED);
+		ScanResult result2 = mock(ScanResult.class);
+		when(result2.getStatus()).thenReturn(Status.FAILED);
+		File pdfFile = new File(depositDir, "pdf.pdf");
+		File textFile = new File(depositDir, "text.txt");
+		doReturn(scanResult).when(clamScan).scan(argThat(new FileArgumentMatcher(pdfFile)));
+		doReturn(result2).when(clamScan).scan(argThat(new FileArgumentMatcher(textFile)));
+
+		Model model = job.getWritableModel();
+		Bag depBag = model.createBag(depositPid.getRepositoryPath());
+
+		PID file1Pid = addFileObject(depBag, pdfFile.getName());
+		PID file2Pid = addFileObject(depBag, textFile.getName());
+
+		job.closeModel();
+
+		try {
+			job.run();
+			fail();
+		} catch(JobFailedException e) {
+			// Both files should have been scanned
+			verify(jobStatusFactory).setTotalCompletion(eq(jobUUID), eq(2));
+			verify(jobStatusFactory, times(2)).incrCompletion(eq(jobUUID), eq(1));
+
+			// Only the file that passed should have a premis log
+			verifyPremisEvents(file1Pid);
+			verifyPremisEventNotExist(file2Pid);
+			verifyPremisEventNotExist(depositPid);
+		}
+	}
+
+	@Test
+	public void errorScanTest() throws Exception {
+		// Fail the text scan, but not the pdf
+		when(scanResult.getStatus()).thenReturn(Status.ERROR);
+		Exception mockE = mock(Exception.class);
+		when(mockE.getLocalizedMessage()).thenReturn("Something isn't work");
+		when(scanResult.getException()).thenReturn(mockE);
+
+		Model model = job.getWritableModel();
+		Bag depBag = model.createBag(depositPid.getRepositoryPath());
+
+		File pdfFile = new File(depositDir, "pdf.pdf");
+		PID file1Pid = addFileObject(depBag, pdfFile.getName());
+
+		job.closeModel();
+
+		try {
+			job.run();
+			fail();
+		} catch(Error e) {
+			// No files should have completed scanning
+			verify(jobStatusFactory).setTotalCompletion(eq(jobUUID), eq(1));
+			verify(jobStatusFactory, never()).incrCompletion(anyString(), anyInt());
+
+			// No premis logs should have been created
+			verifyPremisEventNotExist(file1Pid);
+			verifyPremisEventNotExist(depositPid);
+		}
+	}
+
+	private PID addFileObject(Bag parent, String stagingLocation) {
+		PID filePid = makePid(RepositoryPathConstants.CONTENT_BASE);
+
+		Resource fileResc = parent.getModel().createResource(filePid.getRepositoryPath());
+		fileResc.addProperty(RDF.type, Cdr.FileObject);
+		fileResc.addProperty(CdrDeposit.stagingLocation, stagingLocation);
+
+		parent.add(fileResc);
+
+		return filePid;
+	}
+
+	private void verifyPremisEvents(PID pid) throws Exception {
+		File file = new File(job.getDepositDirectory(),
+				DepositConstants.EVENTS_DIR + "/" + pid.getUUID() + ".ttl");
+		assertTrue("Event file for " + pid + " not present", file.exists());
+
+		Model model = RDFModelUtil.createModel(new FileInputStream(file));
+		Resource resc = model.listResourcesWithProperty(Premis.hasEventType).nextResource();
+		assertTrue("Event type not assigned", resc.hasProperty(Premis.hasEventType,
+				Premis.VirusCheck));
+	}
+
+	private void verifyPremisEventNotExist(PID pid) {
+		File file = new File(job.getDepositDirectory(),
+				DepositConstants.EVENTS_DIR + "/" + pid.getUUID() + ".ttl");
+		assertFalse("Event file for " + pid + " should not be present", file.exists());
+	}
+
+	private class FileArgumentMatcher extends ArgumentMatcher<File> {
+		private File file;
+
+		public FileArgumentMatcher(File file) {
+			this.file = file;
+		}
+
+		@Override
+		public boolean matches(Object argument) {
+			File compareFile = (File) argument;
+			return file.getAbsolutePath().equals(compareFile.getAbsolutePath());
+		}
+
+	}
+}

--- a/deposit/src/test/resources/staging_config.json
+++ b/deposit/src/test/resources/staging_config.json
@@ -1,0 +1,12 @@
+[
+	{
+		"path":"staging_location1/",
+		"name":"Stage1",
+		"cleanupPolicy":"DELETE_INGESTED_FILES_EMPTY_FOLDERS"
+	},
+	{
+		"path":"staging_location2/",
+		"name":"Stage2",
+		"cleanupPolicy":"DO_NOTHING"
+	}
+]

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/FedoraPID.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/FedoraPID.java
@@ -144,4 +144,9 @@ public class FedoraPID extends PID {
 	public String toString() {
 		return getQualifiedId();
 	}
+	
+	@Override
+	public int hashCode() {
+		return repositoryPath.hashCode();
+	}
 }

--- a/persistence/pom.xml
+++ b/persistence/pom.xml
@@ -185,11 +185,6 @@
 			<version>1.0.0</version>
 		</dependency>
 		<dependency>
-			<groupId>edu.unc.lib.cdr</groupId>
-			<artifactId>staging-areas</artifactId>
-			<version>0.0.1-SNAPSHOT</version>
-		</dependency>
-		<dependency>
 			<groupId>com.samskivert</groupId>
 			<artifactId>jmustache</artifactId>
 			<version>1.9</version>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,6 @@
 		<module>admin</module>
 		<module>access-common</module>
 		<module>deposit</module>
-		<module>staging-areas</module>
 		<module>clamavj</module>
 		<module>spoof</module>
 	</modules>


### PR DESCRIPTION
Removes staging areas module from usage in the CDR, adds new but significantly reduced staging policy classes to deposit app, updates deposit jobs and tests accordingly, adds missing unit tests for deposit jobs that involved staging.