### PR TITLE
Fix header word spacing for safari

### DIFF
--- a/static/css/cdr_common.css
+++ b/static/css/cdr_common.css
@@ -395,3 +395,12 @@ li {
 .resource_icon.folder { background-position: -16px 0px; }
 .resource_icon.aggregate { background-position: -32px 0px; }
 .resource_icon.file { background-position: -48px 0px; }
+
+/** Logo word spacing in Safari **/
+
+@media screen and (min-color-index:0) and(-webkit-min-device-pixel-ratio:0) 
+{ @media {
+  #cdr-logo {
+    word-spacing: -2px;
+    }
+}}


### PR DESCRIPTION
added media query to fix word spacing bug in safari