### PR TITLE
Removed display of last modified field from result entries

### DIFF
--- a/access/src/main/webapp/WEB-INF/jsp/searchResults/browseResultEntry.jsp
+++ b/access/src/main/webapp/WEB-INF/jsp/searchResults/browseResultEntry.jsp
@@ -72,9 +72,6 @@
 				</c:forEach>
 			</p>
 		</c:if>
-		<c:if test="${metadata.resourceType != 'Collection' || metadata.resourceType != 'Folder'}">
-			<p>${searchSettings.searchFieldLabels['DATE_UPDATED']}: <fmt:formatDate pattern="yyyy-MM-dd" value="${metadata.dateUpdated}"/></p>
-		</c:if>
 		<p><c:out value="${metadata['abstractText']}"/></p>
 	</div>
 </div>

--- a/access/src/main/webapp/WEB-INF/jsp/searchResults/searchResultEntry.jsp
+++ b/access/src/main/webapp/WEB-INF/jsp/searchResults/searchResultEntry.jsp
@@ -103,11 +103,6 @@
 							</p>
 						</c:if>
 					</div>
-					<c:if test="${metadata.resourceType != 'Collection' || metadata.resourceType != 'Folder'}">
-						<div class="halfwidth">
-							<p>${searchSettings.searchFieldLabels['DATE_UPDATED']}: <fmt:formatDate pattern="yyyy-MM-dd" value="${metadata.dateUpdated}" /></p> 
-						</div>
-					</c:if>
 					<c:if test="${not empty metadata.abstractText}">
 						<div class="clear"></div>
 						<p>${searchSettings.searchFieldLabels['ABSTRACT']}: 

--- a/access/src/main/webapp/WEB-INF/jsp/searchResults/selectedContainerEntry.jsp
+++ b/access/src/main/webapp/WEB-INF/jsp/searchResults/selectedContainerEntry.jsp
@@ -62,9 +62,6 @@
 					</c:forEach>
 				</p>
 			</c:if>
-			<c:if test="${metadata.resourceType != 'Collection' || metadata.resourceType != 'Folder'}">
-				<p>${searchSettings.searchFieldLabels['DATE_UPDATED']}: <fmt:formatDate pattern="yyyy-MM-dd" value="${metadata.dateUpdated}"/></p>
-			</c:if>
 			<c:set var="embargoDate" value="${metadata.activeEmbargo}"/>
 			<c:if test="${not empty embargoDate}"><p>Embargoed Until: <fmt:formatDate pattern="yyyy-MM-dd" value="${embargoDate}" /></p></c:if>
 			


### PR DESCRIPTION
While the issue was that the operator was backwards (|| instead of &&), it turns out that ONLY folders and collections were displaying last updated fields, so there's no reason to keep the code that displayed them in