### PR TITLE
Cdr 1858 update set relations filter

### DIFF
--- a/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetRelationsFilter.java
+++ b/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetRelationsFilter.java
@@ -36,33 +36,33 @@ import edu.unc.lib.dl.rdf.Cdr;
  */
 public class SetRelationsFilter implements IndexDocumentFilter{
     private static final Logger log = LoggerFactory.getLogger(SetRelationsFilter.class);
-    
+
     private FileObject primaryObj;
-    
+
     @Override
     public void filter(DocumentIndexingPackage dip) throws IndexingException {
         log.debug("Applying setRelationsFilter");
-        
+
         List<String> relations = new ArrayList<String>();
 
         ContentObject contentObj = dip.getContentObject();
         // the object being indexed must be either a work object or a file object
         if (!(contentObj instanceof WorkObject || contentObj instanceof FileObject)) {
-        	    return;
+            return;
         }
         if (contentObj instanceof FileObject) {
-        	    primaryObj = (FileObject) contentObj;
+            primaryObj = (FileObject) contentObj;
         } else {
             primaryObj = ((WorkObject) contentObj).getPrimaryObject();
         }
         // store primary object relation
         relations.add(Cdr.primaryObject.toString() + "|" + primaryObj.getPid().getId());
-        
+
         // retrieve and store invalid terms
         List<String> invalidTerms = new ArrayList<>();
         StmtIterator it = contentObj.getResource().listProperties(Cdr.invalidTerm);
         while (it.hasNext()) {
-        	    invalidTerms.add(it.nextStatement().getLiteral().getString());
+            invalidTerms.add(it.nextStatement().getLiteral().getString());
         }
         String invalidTermPred = Cdr.invalidTerm.toString();
         if (invalidTerms != null) {

--- a/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetRelationsFilter.java
+++ b/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetRelationsFilter.java
@@ -17,6 +17,7 @@ package edu.unc.lib.dl.data.ingest.solr.filter;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import org.apache.jena.rdf.model.StmtIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,17 +47,16 @@ public class SetRelationsFilter implements IndexDocumentFilter{
         List<String> relations = new ArrayList<String>();
 
         ContentObject contentObj = dip.getContentObject();
-        // the object being indexed must be either a work object or a file object
-        if (!(contentObj instanceof WorkObject || contentObj instanceof FileObject)) {
-            return;
+        // determine whether the content object has/is a primary object
+        if (contentObj instanceof WorkObject || contentObj instanceof FileObject) {
+            if (contentObj instanceof FileObject) {
+                primaryObj = (FileObject) contentObj;
+            } else {
+                primaryObj = ((WorkObject) contentObj).getPrimaryObject();
+            }
+            // store primary object relation
+            relations.add(Cdr.primaryObject.toString() + "|" + primaryObj.getPid().getId());
         }
-        if (contentObj instanceof FileObject) {
-            primaryObj = (FileObject) contentObj;
-        } else {
-            primaryObj = ((WorkObject) contentObj).getPrimaryObject();
-        }
-        // store primary object relation
-        relations.add(Cdr.primaryObject.toString() + "|" + primaryObj.getPid().getId());
 
         // retrieve and store invalid terms
         List<String> invalidTerms = new ArrayList<>();

--- a/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetRelationsFilter.java
+++ b/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetRelationsFilter.java
@@ -17,83 +17,54 @@ package edu.unc.lib.dl.data.ingest.solr.filter;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-
+import org.apache.jena.rdf.model.StmtIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import edu.unc.lib.dl.data.ingest.solr.exception.IndexingException;
 import edu.unc.lib.dl.data.ingest.solr.indexing.DocumentIndexingPackage;
-import edu.unc.lib.dl.fedora.PID;
-import edu.unc.lib.dl.util.ContentModelHelper.CDRProperty;
-import edu.unc.lib.dl.util.ContentModelHelper.FedoraProperty;
+import edu.unc.lib.dl.fcrepo4.ContentObject;
+import edu.unc.lib.dl.fcrepo4.FileObject;
+import edu.unc.lib.dl.fcrepo4.WorkObject;
+import edu.unc.lib.dl.rdf.Cdr;
 
 /**
- * Populates the relations field with pertinent triples from RELS-Ext that are primarily intended for post retrieval
- * purposes.
+ * Populates the relations field with the primary object and invalid terms.
  *
- * @author bbpennel
+ * @author bbpennel, harring
  *
  */
 public class SetRelationsFilter implements IndexDocumentFilter{
     private static final Logger log = LoggerFactory.getLogger(SetRelationsFilter.class);
+    
+    private FileObject primaryObj;
+    
     @Override
     public void filter(DocumentIndexingPackage dip) throws IndexingException {
         log.debug("Applying setRelationsFilter");
-
+        
         List<String> relations = new ArrayList<String>();
-        Map<String, List<String>> triples = dip.getTriples();
 
-        // Retrieve the default web datastream
-        String defaultWebData = dip.getDefaultWebData();
-        if (defaultWebData != null) {
-            relations.add(CDRProperty.defaultWebData.getPredicate() + "|" + new PID(defaultWebData).getPid());
+        ContentObject contentObj = dip.getContentObject();
+        // the object being indexed must be either a work object or a file object
+        if (!(contentObj instanceof WorkObject || contentObj instanceof FileObject)) {
+        	    return;
         }
-
-        // Retrieve the default web object, from the cached version if possible.
-        DocumentIndexingPackage defaultWebObjectPackage = dip.getDefaultWebObject();
-        String defaultWebObject = null;
-        if (defaultWebObjectPackage != null) {
-            defaultWebObject = defaultWebObjectPackage.getPid().getPid();
+        if (contentObj instanceof FileObject) {
+        	    primaryObj = (FileObject) contentObj;
         } else {
-            List<String> defaultWebObjectTriples = triples.get(CDRProperty.defaultWebObject.toString());
-            if (defaultWebObjectTriples != null) {
-                defaultWebObject = defaultWebObjectTriples.get(0);
-            }
+            primaryObj = ((WorkObject) contentObj).getPrimaryObject();
         }
-        if (defaultWebObject != null) {
-            relations.add(CDRProperty.defaultWebObject.getPredicate() + "|" + (new PID(defaultWebObject)).getPid());
+        // store primary object relation
+        relations.add(Cdr.primaryObject.toString() + "|" + primaryObj.getPid().getId());
+        
+        // retrieve and store invalid terms
+        List<String> invalidTerms = new ArrayList<>();
+        StmtIterator it = contentObj.getResource().listProperties(Cdr.invalidTerm);
+        while (it.hasNext()) {
+        	    invalidTerms.add(it.nextStatement().getLiteral().getString());
         }
-
-        // Retrieve original content datastream name for items with a main content payload
-        List<String> sourceData = triples.get(CDRProperty.sourceData.toString());
-        if (sourceData != null) {
-            relations.add(CDRProperty.sourceData.getPredicate() + "|" + ((new PID(sourceData.get(0)).getPid())));
-        }
-
-        // Retrieve and store label
-        List<String> label = triples.get(FedoraProperty.label.toString());
-        if (label != null) {
-            dip.getDocument().setLabel(label.get(0));
-        }
-
-        // Retrieve the default sort order for a container if specified
-        List<String> defaultSortOrder = triples.get(CDRProperty.sortOrder.toString());
-        if (defaultSortOrder != null) {
-            String sortOrder = defaultSortOrder.get(0);
-            sortOrder = sortOrder.substring(sortOrder.indexOf('#') + 1);
-            relations.add(CDRProperty.sortOrder.getPredicate() + "|" + sortOrder);
-        }
-
-        // Retrieve and store embargo
-        List<String> embargoUntil = triples.get(CDRProperty.embargoUntil.toString());
-        if (embargoUntil != null) {
-            relations.add(CDRProperty.embargoUntil.getPredicate() + "|" + embargoUntil.get(0));
-        }
-
-        // Retrieve and store invalid terms
-        List<String> invalidTerms = triples.get(CDRProperty.invalidTerm.toString());
-        String invalidTermPred = CDRProperty.invalidTerm.getPredicate();
+        String invalidTermPred = Cdr.invalidTerm.toString();
         if (invalidTerms != null) {
             for (String invalidTermTriple : invalidTerms) {
                 relations.add(invalidTermPred + "|" + invalidTermTriple);

--- a/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetRelationsFilter.java
+++ b/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetRelationsFilter.java
@@ -47,14 +47,12 @@ public class SetRelationsFilter implements IndexDocumentFilter{
         List<String> relations = new ArrayList<String>();
 
         ContentObject contentObj = dip.getContentObject();
-        // determine whether the content object has/is a primary object
-        if (contentObj instanceof WorkObject || contentObj instanceof FileObject) {
-            if (contentObj instanceof FileObject) {
-                primaryObj = (FileObject) contentObj;
-            } else {
-                primaryObj = ((WorkObject) contentObj).getPrimaryObject();
-            }
-            // store primary object relation
+
+        // if the content obj is a work obj, set relation on its primary object
+        if (contentObj instanceof WorkObject) {
+            primaryObj = ((WorkObject) contentObj).getPrimaryObject();
+
+            // store primary-object relation
             relations.add(Cdr.primaryObject.toString() + "|" + primaryObj.getPid().getId());
         }
 
@@ -67,6 +65,7 @@ public class SetRelationsFilter implements IndexDocumentFilter{
         String invalidTermPred = Cdr.invalidTerm.toString();
         if (invalidTerms != null) {
             for (String invalidTermTriple : invalidTerms) {
+                // store invalid-term relation
                 relations.add(invalidTermPred + "|" + invalidTermTriple);
             }
         }

--- a/solr-ingest/src/test/java/edu/unc/lib/dl/data/ingest/solr/filter/SetRelationsFilterTest.java
+++ b/solr-ingest/src/test/java/edu/unc/lib/dl/data/ingest/solr/filter/SetRelationsFilterTest.java
@@ -88,7 +88,7 @@ public class SetRelationsFilterTest {
         when(dip.getDocument()).thenReturn(idb);
         when(dip.getPid()).thenReturn(pid);
         when(pid.getId()).thenReturn("id");
-        
+
         when(workObj.getPrimaryObject()).thenReturn(fileObj);
         when(workObj.getPid()).thenReturn(pid);
         when(fileObj.getPid()).thenReturn(pid);
@@ -115,18 +115,6 @@ public class SetRelationsFilterTest {
         assertTrue(listCaptor.getValue().contains("http://cdr.unc.edu/definitions/model#primaryObject|" + primObjPid));
     }
 
-    @Test
-    public void setPrimaryObjectFromFileObjectTest() throws Exception {
-        when(dip.getContentObject()).thenReturn(fileObj);
-        String primObjPid = "pofromfileobj";
-        when(pid.getId()).thenReturn(primObjPid);
-
-        filter.filter(dip);
-
-        verify(idb).setRelations(listCaptor.capture());
-        assertTrue(listCaptor.getValue().contains("http://cdr.unc.edu/definitions/model#primaryObject|" + primObjPid));
-    }
-    
     @Test
     public void setInvalidTermsTest() throws Exception {
         when(dip.getContentObject()).thenReturn(workObj);

--- a/solr-ingest/src/test/java/edu/unc/lib/dl/data/ingest/solr/filter/SetRelationsFilterTest.java
+++ b/solr-ingest/src/test/java/edu/unc/lib/dl/data/ingest/solr/filter/SetRelationsFilterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2008 The University of North Carolina at Chapel Hill
+ * Copyright 2017 The University of North Carolina at Chapel Hill
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,111 +15,126 @@
  */
 package edu.unc.lib.dl.data.ingest.solr.filter;
 
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-import java.io.File;
-import java.io.FileInputStream;
+import java.util.List;
 
-import org.jdom2.Document;
-import org.jdom2.input.SAXBuilder;
-import org.junit.Assert;
+import org.apache.jena.rdf.model.Literal;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.rdf.model.StmtIterator;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 
 import edu.unc.lib.dl.data.ingest.solr.indexing.DocumentIndexingPackage;
 import edu.unc.lib.dl.data.ingest.solr.indexing.DocumentIndexingPackageDataLoader;
 import edu.unc.lib.dl.data.ingest.solr.indexing.DocumentIndexingPackageFactory;
+import edu.unc.lib.dl.fcrepo4.ContentObject;
+import edu.unc.lib.dl.fcrepo4.FileObject;
+import edu.unc.lib.dl.fcrepo4.WorkObject;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.rdf.Cdr;
 import edu.unc.lib.dl.search.solr.model.IndexDocumentBean;
-import edu.unc.lib.dl.util.TripleStoreQueryService;
 
 /**
- *
- * @author bbpennel
- * @date Apr 16, 2014
+ * @author harring
  */
-public class SetRelationsFilterTest extends Assert {
+public class SetRelationsFilterTest {
 
-    private DocumentIndexingPackageDataLoader loader;
-    private DocumentIndexingPackageFactory factory;
+    private static final String INVALID_TERM = "some_invalid_term";
+
     @Mock
-    private TripleStoreQueryService tsqs;
+    private DocumentIndexingPackageDataLoader loader;
+    @Mock
+    private DocumentIndexingPackage dip;
+    @Mock
+    private IndexDocumentBean idb;
+    @Mock
+    private PID pid;
+    @Mock
+    private WorkObject workObj;
+    @Mock
+    private FileObject fileObj;
+    @Mock
+    private ContentObject contentObj;
+    @Mock
+    private Resource resource;
+    @Mock
+    private StmtIterator it;
+    @Mock
+    private Statement stmt;
+    @Mock
+    private Literal literal;
+    @Captor
+    private ArgumentCaptor<List<String>> listCaptor;
+
+    private DocumentIndexingPackageFactory factory;
+
+    private SetRelationsFilter filter;
 
     @Before
     public void setup() throws Exception {
         initMocks(this);
-        loader = new DocumentIndexingPackageDataLoader();
+
         factory = new DocumentIndexingPackageFactory();
         factory.setDataLoader(loader);
-        loader.setFactory(factory);
-        loader.setTsqs(tsqs);
+
+        when(dip.getDocument()).thenReturn(idb);
+        when(dip.getPid()).thenReturn(pid);
+        when(pid.getId()).thenReturn("id");
+        
+        when(workObj.getPrimaryObject()).thenReturn(fileObj);
+        when(workObj.getPid()).thenReturn(pid);
+        when(fileObj.getPid()).thenReturn(pid);
+        when(workObj.getResource()).thenReturn(resource);
+        when(fileObj.getResource()).thenReturn(resource);
+        when(resource.listProperties(Cdr.invalidTerm)).thenReturn(it);
+        when(it.hasNext()).thenReturn(true, false);
+        when(it.nextStatement()).thenReturn(stmt);
+        when(stmt.getLiteral()).thenReturn(literal);
+        when(literal.getString()).thenReturn(INVALID_TERM);
+
+        filter = new SetRelationsFilter();
     }
 
     @Test
-    public void aggregateRelations() throws Exception {
-        DocumentIndexingPackage dip = factory.createDip("info:fedora/uuid:aggregate");
-        SAXBuilder builder = new SAXBuilder();
-        Document foxml = builder.build(new FileInputStream(new File(
-                "src/test/resources/foxml/aggregateSplitDepartments.xml")));
-        dip.setFoxml(foxml);
+    public void setPrimaryObjectFromWorkTest() throws Exception {
+        when(dip.getContentObject()).thenReturn(workObj);
+        String primObjPid = "pofromwork";
+        when(pid.getId()).thenReturn(primObjPid);
 
-        IndexDocumentBean idb = dip.getDocument();
-        SetRelationsFilter filter = new SetRelationsFilter();
         filter.filter(dip);
 
-        assertTrue(idb.getRelations().contains("defaultWebObject|uuid:a4fa0296-1ce7-42a1-b74d-0222afd98194"));
-        assertEquals(
-                idb.getLabel(),
-                "A Comparison of Machine Learning Algorithms for Chemical Toxicity Classification Using a Simulated Multi-Scale Data Model");
+        verify(idb).setRelations(listCaptor.capture());
+        assertTrue(listCaptor.getValue().contains("http://cdr.unc.edu/definitions/model#primaryObject|" + primObjPid));
     }
 
     @Test
-    public void itemWithOriginalRelations() throws Exception {
-        DocumentIndexingPackage dip = factory.createDip("info:fedora/uuid:item");
-        SAXBuilder builder = new SAXBuilder();
-        Document foxml = builder.build(new FileInputStream(new File(
-                "src/test/resources/foxml/imageNoMODS.xml")));
-        dip.setFoxml(foxml);
+    public void setPrimaryObjectFromFileObjectTest() throws Exception {
+        when(dip.getContentObject()).thenReturn(fileObj);
+        String primObjPid = "pofromfileobj";
+        when(pid.getId()).thenReturn(primObjPid);
 
-        IndexDocumentBean idb = dip.getDocument();
-        SetRelationsFilter filter = new SetRelationsFilter();
         filter.filter(dip);
 
-        assertTrue(idb.getRelations().contains("defaultWebData|uuid:37c23b03-0ca4-4487-a1c5-92c28cadc71b/DATA_FILE"));
-        assertEquals(idb.getLabel(), "A1100-A800 NS final.jpg");
-        assertTrue(idb.getRelations().contains("sourceData|uuid:37c23b03-0ca4-4487-a1c5-92c28cadc71b/DATA_FILE"));
+        verify(idb).setRelations(listCaptor.capture());
+        assertTrue(listCaptor.getValue().contains("http://cdr.unc.edu/definitions/model#primaryObject|" + primObjPid));
     }
-
+    
     @Test
-    public void embargoedRelation() throws Exception {
-        DocumentIndexingPackage dip = factory.createDip("info:fedora/uuid:item");
-        SAXBuilder builder = new SAXBuilder();
-        Document foxml = builder.build(new FileInputStream(new File(
-                "src/test/resources/foxml/embargoed.xml")));
-        dip.setFoxml(foxml);
+    public void setInvalidTermsTest() throws Exception {
+        when(dip.getContentObject()).thenReturn(workObj);
 
-        IndexDocumentBean idb = dip.getDocument();
-        SetRelationsFilter filter = new SetRelationsFilter();
         filter.filter(dip);
 
-        assertTrue(idb.getRelations().contains("embargo-until|2074-02-03T00:00:00"));
-        assertTrue(idb.getRelations().size() > 1);
+        verify(idb).setRelations(listCaptor.capture());
+        assertTrue(listCaptor.getValue().contains("http://cdr.unc.edu/definitions/model#invalidTerm|" + INVALID_TERM));
     }
 
-
-    @Test
-    public void orderedContainerRelations() throws Exception {
-        DocumentIndexingPackage dip = factory.createDip("info:fedora/uuid:aggregate");
-        SAXBuilder builder = new SAXBuilder();
-        Document foxml = builder.build(new FileInputStream(new File(
-                "src/test/resources/foxml/folderSmall.xml")));
-        dip.setFoxml(foxml);
-
-        IndexDocumentBean idb = dip.getDocument();
-        SetRelationsFilter filter = new SetRelationsFilter();
-        filter.filter(dip);
-
-        assertTrue(idb.getRelations().contains("sortOrder|ordered"));
-        assertEquals(idb.getLabel(), "Field notes");
-    }
 }


### PR DESCRIPTION
@ben let me know if you see any improvements i can make. i’ll be back in the office on 7/6 and can make tweaks before the sprint finishes.

in particular, i’m not clear if we want to throw an indexing exception when there is no primary object (e.g., if somehow a folder object were to be passed to the filter, which seems unlikely) or simply return, as i have it now.