### PR TITLE
Camel rename package and move processors into more descriptive packages

### DIFF
--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/cdrEvents/CdrEventRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/cdrEvents/CdrEventRouter.java
@@ -22,8 +22,8 @@ import org.apache.camel.BeanInject;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.builder.RouteBuilder;
 
-import edu.unc.lib.dl.services.camel.CdrEventProcessor;
-import edu.unc.lib.dl.services.camel.CdrEventToSolrUpdateProcessor;
+import edu.unc.lib.dl.services.camel.cdrEvents.processor.CdrEventProcessor;
+import edu.unc.lib.dl.services.camel.solr.processor.CdrEventToSolrUpdateProcessor;
 import edu.unc.lib.dl.util.JMSMessageUtil.CDRActions;
 
 /**

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/enhancements/processor/AddDerivativeProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/enhancements/processor/AddDerivativeProcessor.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.unc.lib.dl.services.camel;
+package edu.unc.lib.dl.services.camel.enhancements.processor;
 
 import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
 

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/enhancements/processor/BinaryMetadataProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/enhancements/processor/BinaryMetadataProcessor.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.unc.lib.dl.services.camel;
+package edu.unc.lib.dl.services.camel.enhancements.processor;
 
 import static edu.unc.lib.dl.rdf.Ebucore.hasMimeType;
 import static edu.unc.lib.dl.rdf.Premis.hasMessageDigest;

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/enhancements/processor/FulltextProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/enhancements/processor/FulltextProcessor.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.unc.lib.dl.services.camel;
+package edu.unc.lib.dl.services.camel.enhancements.processor;
 
 import static edu.unc.lib.dl.services.camel.headers.CdrFcrepoHeaders.CdrBinaryPath;
 import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/enhancements/processor/GetBinaryProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/enhancements/processor/GetBinaryProcessor.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.unc.lib.dl.services.camel;
+package edu.unc.lib.dl.services.camel.enhancements.processor;
 
 import static edu.unc.lib.dl.services.camel.headers.CdrFcrepoHeaders.CdrBinaryPath;
 import static edu.unc.lib.dl.services.camel.headers.CdrFcrepoHeaders.CdrBinaryUri;

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/fulltext/FulltextRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/fulltext/FulltextRouter.java
@@ -19,7 +19,7 @@ import org.apache.camel.BeanInject;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.builder.RouteBuilder;
 
-import edu.unc.lib.dl.services.camel.FulltextProcessor;
+import edu.unc.lib.dl.services.camel.enhancements.processor.FulltextProcessor;
 
 /**
  * Routes ingests with full text available through a pipeline to extract

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/images/ImageEnhancementsRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/images/ImageEnhancementsRouter.java
@@ -19,7 +19,7 @@ import org.apache.camel.BeanInject;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.builder.RouteBuilder;
 
-import edu.unc.lib.dl.services.camel.AddDerivativeProcessor;
+import edu.unc.lib.dl.services.camel.enhancements.processor.AddDerivativeProcessor;
 
 /**
  * Router which triggers the creation of thumbnails when applicable binaries

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/replication/ReplicationRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/replication/ReplicationRouter.java
@@ -19,7 +19,7 @@ import org.apache.camel.BeanInject;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.builder.RouteBuilder;
 
-import edu.unc.lib.dl.services.camel.ReplicationProcessor;
+import edu.unc.lib.dl.services.camel.replication.processor.ReplicationProcessor;
 
 /**
  * Routes binary files for replication to remote storage devices

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/replication/processor/ReplicationDestinationUnavailableException.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/replication/processor/ReplicationDestinationUnavailableException.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.unc.lib.dl.services.camel;
+package edu.unc.lib.dl.services.camel.replication.processor;
 /**
  * 
  * @author harring

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/replication/processor/ReplicationException.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/replication/processor/ReplicationException.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.unc.lib.dl.services.camel;
+package edu.unc.lib.dl.services.camel.replication.processor;
 /**
  * 
  * @author harring

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/replication/processor/ReplicationProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/replication/processor/ReplicationProcessor.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.unc.lib.dl.services.camel;
+package edu.unc.lib.dl.services.camel.replication.processor;
 
 import static edu.unc.lib.dl.services.camel.headers.CdrFcrepoHeaders.CdrBinaryChecksum;
 import static edu.unc.lib.dl.services.camel.headers.CdrFcrepoHeaders.CdrBinaryMimeType;

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/routing/MetaServicesRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/routing/MetaServicesRouter.java
@@ -23,9 +23,9 @@ import org.apache.camel.PropertyInject;
 import org.apache.camel.builder.RouteBuilder;
 
 import edu.unc.lib.dl.rdf.Cdr;
-import edu.unc.lib.dl.services.camel.BinaryMetadataProcessor;
-import edu.unc.lib.dl.services.camel.CleanupBinaryProcessor;
-import edu.unc.lib.dl.services.camel.GetBinaryProcessor;
+import edu.unc.lib.dl.services.camel.enhancements.processor.BinaryMetadataProcessor;
+import edu.unc.lib.dl.services.camel.enhancements.processor.CleanupBinaryProcessor;
+import edu.unc.lib.dl.services.camel.enhancements.processor.GetBinaryProcessor;
 
 /**
  * Meta router which sequences all service routes to run on events.

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/solr/SolrRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/solr/SolrRouter.java
@@ -20,7 +20,7 @@ import org.apache.camel.BeanInject;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.builder.RouteBuilder;
 
-import edu.unc.lib.dl.services.camel.SolrIngestProcessor;
+import edu.unc.lib.dl.services.camel.solr.processor.SolrIngestProcessor;
 
 /**
  * Router which triggers the full indexing of individual objects to Solr.

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/solr/processor/CdrEventToSolrUpdateProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/solr/processor/CdrEventToSolrUpdateProcessor.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package edu.unc.lib.dl.services.camel;
+package edu.unc.lib.dl.services.camel.solr.processor;
 
 import static edu.unc.lib.dl.services.camel.headers.CdrFcrepoHeaders.CdrSolrUpdateAction;
 import static edu.unc.lib.dl.util.JMSMessageUtil.CDRActions.ADD;

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/solr/processor/SolrIngestProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/solr/processor/SolrIngestProcessor.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package edu.unc.lib.dl.services.camel;
+package edu.unc.lib.dl.services.camel.solr.processor;
 
 import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
 

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/solr/processor/SolrUpdateProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/solr/processor/SolrUpdateProcessor.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.unc.lib.dl.services.camel;
+package edu.unc.lib.dl.services.camel.solr.processor;
 
 import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.ATOM_NS;
 

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/solrUpdate/SolrUpdateRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/solrUpdate/SolrUpdateRouter.java
@@ -21,7 +21,7 @@ import org.apache.camel.BeanInject;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.builder.RouteBuilder;
 
-import edu.unc.lib.dl.services.camel.SolrUpdateProcessor;
+import edu.unc.lib.dl.services.camel.solr.processor.SolrUpdateProcessor;
 
 /**
  * Route for performing solr updates for update requests.

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/cdrEvents/CdrEventRouterTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/cdrEvents/CdrEventRouterTest.java
@@ -32,8 +32,8 @@ import org.junit.Test;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-import edu.unc.lib.dl.services.camel.CdrEventProcessor;
-import edu.unc.lib.dl.services.camel.CdrEventToSolrUpdateProcessor;
+import edu.unc.lib.dl.services.camel.cdrEvents.processor.CdrEventProcessor;
+import edu.unc.lib.dl.services.camel.solr.processor.CdrEventToSolrUpdateProcessor;
 import edu.unc.lib.dl.util.JMSMessageUtil.CDRActions;
 
 /**

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/cdrEvents/processor/CdrEventProcessorTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/cdrEvents/processor/CdrEventProcessorTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.unc.lib.dl.services.camel;
+package edu.unc.lib.dl.services.camel.cdrEvents.processor;
 
 import static edu.unc.lib.dl.services.camel.headers.CdrFcrepoHeaders.CdrSolrUpdateAction;
 import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.ATOM_NS;
@@ -39,6 +39,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 
+import edu.unc.lib.dl.services.camel.cdrEvents.processor.CdrEventProcessor;
 import edu.unc.lib.dl.util.JMSMessageUtil.CDRActions;
 
 /**

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/cdrEvents/processor/CdrEventRoutingIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/cdrEvents/processor/CdrEventRoutingIT.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.unc.lib.dl.services.camel;
+package edu.unc.lib.dl.services.camel.cdrEvents.processor;
 
 import static edu.unc.lib.dl.util.IndexingActionType.ADD_SET_TO_PARENT;
 import static edu.unc.lib.dl.util.IndexingActionType.UPDATE_STATUS;
@@ -50,6 +50,7 @@ import edu.unc.lib.dl.data.ingest.solr.action.IndexingAction;
 import edu.unc.lib.dl.fcrepo4.PIDs;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.services.OperationsMessageSender;
+import edu.unc.lib.dl.services.camel.solr.processor.SolrUpdateProcessor;
 import edu.unc.lib.dl.test.TestHelper;
 import edu.unc.lib.dl.util.IndexingActionType;
 

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/enhancements/processor/AddDerivativeProcessorTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/enhancements/processor/AddDerivativeProcessorTest.java
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.unc.lib.dl.services.camel;
+package edu.unc.lib.dl.services.camel.enhancements.processor;
 
+import static edu.unc.lib.dl.services.camel.headers.CdrFcrepoHeaders.CdrBinaryMimeType;
 import static edu.unc.lib.dl.services.camel.headers.CdrFcrepoHeaders.CdrBinaryPath;
 import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.times;
@@ -25,44 +25,49 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-import java.io.BufferedReader;
 import java.io.BufferedWriter;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.stream.Collectors;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
+import org.apache.camel.component.exec.ExecResult;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.exceptions.base.MockitoException;
 
 import edu.unc.lib.dl.fcrepo4.BinaryObject;
 import edu.unc.lib.dl.fcrepo4.FileObject;
 import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.rdf.PcdmUse;
+import edu.unc.lib.dl.services.camel.enhancements.processor.AddDerivativeProcessor;
 
-public class FulltextProcessorTest {
-    private FulltextProcessor processor;
-    private final String slug = "full_text";
-    private final String fileName = "full_text.txt";
-    private final String testText = "Test text, see if it can be extracted.";
+public class AddDerivativeProcessorTest {
+
+    private final String fileName = "small_thumb";
+    private final String slug = "small_thumbnail";
+    private final String fileExtension = "PNG";
+    private final String mimetype = "image/png";
     private int maxRetries = 3;
     private long retryDelay = 10;
     private File file;
-    private final static String MIMETYPE = "text/plain";
-    private final static String BINARY_URI =
-            "http://fedora/content/45/66/76/67/45667667-ed3f-41fc-94cc-7764fc266075/datafs/original_file";
+
+    private AddDerivativeProcessor processor;
+
+    private String extensionlessPath;
+
+    private String extensionlessName;
 
     @Mock
     private BinaryObject binary;
     @Mock
     private FileObject parent;
+    @Mock
+    private ExecResult result;
 
     @Mock
     private RepositoryObjectLoader repoObjLoader;
@@ -73,70 +78,67 @@ public class FulltextProcessorTest {
     @Mock
     private Message message;
 
-    @Captor
-    private ArgumentCaptor<InputStream> inputStreamCaptor;
-
     @Before
     public void init() throws Exception {
         initMocks(this);
-        processor = new FulltextProcessor(repoObjLoader, slug, fileName, maxRetries, retryDelay);
-        file = File.createTempFile(fileName, "txt");
+        processor = new AddDerivativeProcessor(repoObjLoader, slug, fileExtension, mimetype, maxRetries, retryDelay);
+        file = File.createTempFile(fileName, ".PNG");
         file.deleteOnExit();
         when(exchange.getIn()).thenReturn(message);
 
         when(repoObjLoader.getBinaryObject(any(PID.class))).thenReturn(binary);
 
-        when(message.getHeader(eq(FCREPO_URI))).thenReturn(BINARY_URI);
+        when(message.getHeader(eq(FCREPO_URI)))
+                .thenReturn("http://fedora/test/original_file");
 
+        when(message.getHeader(eq(CdrBinaryMimeType)))
+                .thenReturn("image/png");
 
         try (BufferedWriter writeFile = new BufferedWriter(new FileWriter(file))) {
-            writeFile.write(testText);
+            writeFile.write("fake image");
         }
-        String filePath = file.getAbsolutePath().toString();
+
+        extensionlessPath = file.getAbsolutePath().split("\\.")[0];
         when(message.getHeader(eq(CdrBinaryPath)))
-                .thenReturn(filePath);
+                .thenReturn(extensionlessPath);
+        extensionlessName = new File(extensionlessPath).getName();
+
+        when(result.getStdout()).thenReturn(new ByteArrayInputStream(extensionlessPath.getBytes()));
+        when(message.getBody()).thenReturn(result);
     }
 
     @Test
-    public void extractFulltextTest() throws Exception {
+    public void createEnhancementTest() throws Exception {
 
+        when(repoObjLoader.getBinaryObject(any(PID.class))).thenReturn(binary);
         when(binary.getParent()).thenReturn(parent);
+        when(message.getBody()).thenReturn(result);
 
         processor.process(exchange);
 
-        verify(parent).addDerivative(eq(slug), inputStreamCaptor.capture(),
-                eq(fileName), eq(MIMETYPE), eq(PcdmUse.ExtractedText));
-        InputStream request = inputStreamCaptor.getValue();
-        String extractedText = new BufferedReader(new InputStreamReader(request))
-                .lines().collect(Collectors.joining("\n"));
-
-        assertEquals(testText, extractedText);
+        verify(parent).addDerivative(eq(slug), any(InputStream.class), eq(extensionlessName),
+                eq("image/png"), eq(PcdmUse.ThumbnailImage));
     }
 
     @Test
-    public void extractFulltextRetryTest() throws Exception {
+    public void createEnhancementRetryTest() throws Exception {
 
         when(binary.getParent())
-                .thenThrow(new RuntimeException())
+                .thenThrow(new MockitoException("Can't add derivative"))
                 .thenReturn(parent);
 
         processor.process(exchange);
 
-        verify(parent).addDerivative(eq(slug), inputStreamCaptor.capture(), eq(fileName),
-                eq(MIMETYPE), eq(PcdmUse.ExtractedText));
-        InputStream request = inputStreamCaptor.getValue();
-        String extractedText = new BufferedReader(new InputStreamReader(request))
-                .lines().collect(Collectors.joining("\n"));
-
-        // Throws error on first pass and then retries.
         verify(binary, times(2)).getParent();
-        assertEquals(testText, extractedText);
+        verify(parent).addDerivative(eq(slug), any(InputStream.class), eq(extensionlessName),
+                eq("image/png"), eq(PcdmUse.ThumbnailImage));
     }
 
     @Test(expected = RuntimeException.class)
-    public void extractFulltextRetryFailTest() throws Exception {
+    public void createEnhancementRetryFailTest() throws Exception {
 
-        when(binary.getParent()).thenThrow(new RuntimeException());
+        when(binary.getParent())
+                .thenThrow(new RuntimeException());
 
         try {
             processor.process(exchange);

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/enhancements/processor/BinaryMetadataProcessorTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/enhancements/processor/BinaryMetadataProcessorTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.unc.lib.dl.services.camel;
+package edu.unc.lib.dl.services.camel.enhancements.processor;
 
 import static edu.unc.lib.dl.services.camel.headers.CdrFcrepoHeaders.CdrBinaryChecksum;
 import static edu.unc.lib.dl.services.camel.headers.CdrFcrepoHeaders.CdrBinaryMimeType;
@@ -48,6 +48,7 @@ import org.mockito.Mock;
 import edu.unc.lib.dl.rdf.Ebucore;
 import edu.unc.lib.dl.rdf.Fcrepo4Repository;
 import edu.unc.lib.dl.rdf.Premis;
+import edu.unc.lib.dl.services.camel.enhancements.processor.BinaryMetadataProcessor;
 
 /**
  *

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/enhancements/processor/CleanupBinaryProcessorTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/enhancements/processor/CleanupBinaryProcessorTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.unc.lib.dl.services.camel;
+package edu.unc.lib.dl.services.camel.enhancements.processor;
 
 import static edu.unc.lib.dl.services.camel.headers.CdrFcrepoHeaders.CdrBinaryPath;
 import static org.junit.Assert.assertFalse;
@@ -34,6 +34,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mock;
+
+import edu.unc.lib.dl.services.camel.enhancements.processor.CleanupBinaryProcessor;
 
 /**
  *

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/enhancements/processor/FulltextProcessorTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/enhancements/processor/FulltextProcessorTest.java
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.unc.lib.dl.services.camel;
+package edu.unc.lib.dl.services.camel.enhancements.processor;
 
-import static edu.unc.lib.dl.services.camel.headers.CdrFcrepoHeaders.CdrBinaryMimeType;
 import static edu.unc.lib.dl.services.camel.headers.CdrFcrepoHeaders.CdrBinaryPath;
 import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.times;
@@ -25,48 +25,45 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+import java.io.BufferedReader;
 import java.io.BufferedWriter;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.stream.Collectors;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
-import org.apache.camel.component.exec.ExecResult;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.exceptions.base.MockitoException;
 
 import edu.unc.lib.dl.fcrepo4.BinaryObject;
 import edu.unc.lib.dl.fcrepo4.FileObject;
 import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.rdf.PcdmUse;
+import edu.unc.lib.dl.services.camel.enhancements.processor.FulltextProcessor;
 
-public class AddDerivativeProcessorTest {
-
-    private final String fileName = "small_thumb";
-    private final String slug = "small_thumbnail";
-    private final String fileExtension = "PNG";
-    private final String mimetype = "image/png";
+public class FulltextProcessorTest {
+    private FulltextProcessor processor;
+    private final String slug = "full_text";
+    private final String fileName = "full_text.txt";
+    private final String testText = "Test text, see if it can be extracted.";
     private int maxRetries = 3;
     private long retryDelay = 10;
     private File file;
-
-    private AddDerivativeProcessor processor;
-
-    private String extensionlessPath;
-
-    private String extensionlessName;
+    private final static String MIMETYPE = "text/plain";
+    private final static String BINARY_URI =
+            "http://fedora/content/45/66/76/67/45667667-ed3f-41fc-94cc-7764fc266075/datafs/original_file";
 
     @Mock
     private BinaryObject binary;
     @Mock
     private FileObject parent;
-    @Mock
-    private ExecResult result;
 
     @Mock
     private RepositoryObjectLoader repoObjLoader;
@@ -77,67 +74,70 @@ public class AddDerivativeProcessorTest {
     @Mock
     private Message message;
 
+    @Captor
+    private ArgumentCaptor<InputStream> inputStreamCaptor;
+
     @Before
     public void init() throws Exception {
         initMocks(this);
-        processor = new AddDerivativeProcessor(repoObjLoader, slug, fileExtension, mimetype, maxRetries, retryDelay);
-        file = File.createTempFile(fileName, ".PNG");
+        processor = new FulltextProcessor(repoObjLoader, slug, fileName, maxRetries, retryDelay);
+        file = File.createTempFile(fileName, "txt");
         file.deleteOnExit();
         when(exchange.getIn()).thenReturn(message);
 
         when(repoObjLoader.getBinaryObject(any(PID.class))).thenReturn(binary);
 
-        when(message.getHeader(eq(FCREPO_URI)))
-                .thenReturn("http://fedora/test/original_file");
+        when(message.getHeader(eq(FCREPO_URI))).thenReturn(BINARY_URI);
 
-        when(message.getHeader(eq(CdrBinaryMimeType)))
-                .thenReturn("image/png");
 
         try (BufferedWriter writeFile = new BufferedWriter(new FileWriter(file))) {
-            writeFile.write("fake image");
+            writeFile.write(testText);
         }
-
-        extensionlessPath = file.getAbsolutePath().split("\\.")[0];
+        String filePath = file.getAbsolutePath().toString();
         when(message.getHeader(eq(CdrBinaryPath)))
-                .thenReturn(extensionlessPath);
-        extensionlessName = new File(extensionlessPath).getName();
-
-        when(result.getStdout()).thenReturn(new ByteArrayInputStream(extensionlessPath.getBytes()));
-        when(message.getBody()).thenReturn(result);
+                .thenReturn(filePath);
     }
 
     @Test
-    public void createEnhancementTest() throws Exception {
+    public void extractFulltextTest() throws Exception {
 
-        when(repoObjLoader.getBinaryObject(any(PID.class))).thenReturn(binary);
         when(binary.getParent()).thenReturn(parent);
-        when(message.getBody()).thenReturn(result);
 
         processor.process(exchange);
 
-        verify(parent).addDerivative(eq(slug), any(InputStream.class), eq(extensionlessName),
-                eq("image/png"), eq(PcdmUse.ThumbnailImage));
+        verify(parent).addDerivative(eq(slug), inputStreamCaptor.capture(),
+                eq(fileName), eq(MIMETYPE), eq(PcdmUse.ExtractedText));
+        InputStream request = inputStreamCaptor.getValue();
+        String extractedText = new BufferedReader(new InputStreamReader(request))
+                .lines().collect(Collectors.joining("\n"));
+
+        assertEquals(testText, extractedText);
     }
 
     @Test
-    public void createEnhancementRetryTest() throws Exception {
+    public void extractFulltextRetryTest() throws Exception {
 
         when(binary.getParent())
-                .thenThrow(new MockitoException("Can't add derivative"))
+                .thenThrow(new RuntimeException())
                 .thenReturn(parent);
 
         processor.process(exchange);
 
+        verify(parent).addDerivative(eq(slug), inputStreamCaptor.capture(), eq(fileName),
+                eq(MIMETYPE), eq(PcdmUse.ExtractedText));
+        InputStream request = inputStreamCaptor.getValue();
+        String extractedText = new BufferedReader(new InputStreamReader(request))
+                .lines().collect(Collectors.joining("\n"));
+
+        // Throws error on first pass and then retries.
         verify(binary, times(2)).getParent();
-        verify(parent).addDerivative(eq(slug), any(InputStream.class), eq(extensionlessName),
-                eq("image/png"), eq(PcdmUse.ThumbnailImage));
+        assertEquals(testText, extractedText);
     }
 
     @Test(expected = RuntimeException.class)
-    public void createEnhancementRetryFailTest() throws Exception {
+    public void extractFulltextRetryFailTest() throws Exception {
 
-        when(binary.getParent())
-                .thenThrow(new RuntimeException());
+        when(binary.getParent()).thenThrow(new RuntimeException());
 
         try {
             processor.process(exchange);

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/enhancements/processor/GetBinaryProcessorIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/enhancements/processor/GetBinaryProcessorIT.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.unc.lib.dl.services.camel;
+package edu.unc.lib.dl.services.camel.enhancements.processor;
 
 import static edu.unc.lib.dl.services.camel.headers.CdrFcrepoHeaders.CdrBinaryPath;
 import static edu.unc.lib.dl.services.camel.headers.CdrFcrepoHeaders.CdrBinaryUri;
@@ -55,6 +55,7 @@ import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
 import edu.unc.lib.dl.fcrepo4.RepositoryPIDMinter;
 import edu.unc.lib.dl.fcrepo4.WorkObject;
 import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.services.camel.enhancements.processor.GetBinaryProcessor;
 import edu.unc.lib.dl.test.TestHelper;
 import edu.unc.lib.dl.util.URIUtil;
 

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/enhancements/processor/GetBinaryProcessorTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/enhancements/processor/GetBinaryProcessorTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.unc.lib.dl.services.camel;
+package edu.unc.lib.dl.services.camel.enhancements.processor;
 
 import static edu.unc.lib.dl.services.camel.headers.CdrFcrepoHeaders.CdrBinaryPath;
 import static edu.unc.lib.dl.services.camel.headers.CdrFcrepoHeaders.CdrBinaryUri;
@@ -44,6 +44,7 @@ import org.mockito.Mock;
 import edu.unc.lib.dl.fcrepo4.BinaryObject;
 import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
 import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.services.camel.enhancements.processor.GetBinaryProcessor;
 import edu.unc.lib.dl.test.TestHelper;
 
 /**

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/fulltext/FulltextRouterTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/fulltext/FulltextRouterTest.java
@@ -39,7 +39,7 @@ import org.junit.Test;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-import edu.unc.lib.dl.services.camel.FulltextProcessor;
+import edu.unc.lib.dl.services.camel.enhancements.processor.FulltextProcessor;
 
 public class FulltextRouterTest extends CamelSpringTestSupport {
     private static final String ENHANCEMENT_ROUTE = "CdrServiceFulltextExtraction";

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/replication/processor/ReplicationProcessorIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/replication/processor/ReplicationProcessorIT.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.unc.lib.dl.services.camel;
+package edu.unc.lib.dl.services.camel.replication.processor;
 
 import static edu.unc.lib.dl.services.camel.headers.CdrFcrepoHeaders.CdrBinaryChecksum;
 import static edu.unc.lib.dl.services.camel.headers.CdrFcrepoHeaders.CdrBinaryMimeType;
@@ -50,6 +50,9 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import edu.unc.lib.dl.fcrepo4.BinaryObject;
 import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
 import edu.unc.lib.dl.fcrepo4.RepositoryPathConstants;
+import edu.unc.lib.dl.services.camel.replication.processor.ReplicationDestinationUnavailableException;
+import edu.unc.lib.dl.services.camel.replication.processor.ReplicationException;
+import edu.unc.lib.dl.services.camel.replication.processor.ReplicationProcessor;
 import edu.unc.lib.dl.test.TestHelper;
 import edu.unc.lib.dl.util.URIUtil;
 

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/replication/processor/ReplicationProcessorTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/replication/processor/ReplicationProcessorTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.unc.lib.dl.services.camel;
+package edu.unc.lib.dl.services.camel.replication.processor;
 
 import static edu.unc.lib.dl.services.camel.headers.CdrFcrepoHeaders.CdrBinaryChecksum;
 import static edu.unc.lib.dl.services.camel.headers.CdrFcrepoHeaders.CdrBinaryMimeType;
@@ -48,6 +48,9 @@ import org.mockito.Mock;
 import edu.unc.lib.dl.fcrepo4.BinaryObject;
 import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
 import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.services.camel.replication.processor.ReplicationDestinationUnavailableException;
+import edu.unc.lib.dl.services.camel.replication.processor.ReplicationException;
+import edu.unc.lib.dl.services.camel.replication.processor.ReplicationProcessor;
 
 public class ReplicationProcessorTest {
     private ReplicationProcessor processor;

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/routing/MetaServicesRouterTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/routing/MetaServicesRouterTest.java
@@ -39,9 +39,9 @@ import org.junit.Test;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-import edu.unc.lib.dl.services.camel.BinaryMetadataProcessor;
-import edu.unc.lib.dl.services.camel.CleanupBinaryProcessor;
-import edu.unc.lib.dl.services.camel.GetBinaryProcessor;
+import edu.unc.lib.dl.services.camel.enhancements.processor.BinaryMetadataProcessor;
+import edu.unc.lib.dl.services.camel.enhancements.processor.CleanupBinaryProcessor;
+import edu.unc.lib.dl.services.camel.enhancements.processor.GetBinaryProcessor;
 import edu.unc.lib.dl.rdf.Cdr;
 
 /**

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solr/SolrRouterTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solr/SolrRouterTest.java
@@ -38,7 +38,7 @@ import org.junit.Test;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-import edu.unc.lib.dl.services.camel.SolrIngestProcessor;
+import edu.unc.lib.dl.services.camel.solr.processor.SolrIngestProcessor;
 
 /**
  *

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solr/processor/CdrEventToSolrUpdateProcessorTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solr/processor/CdrEventToSolrUpdateProcessorTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.unc.lib.dl.services.camel;
+package edu.unc.lib.dl.services.camel.solr.processor;
 
 import static edu.unc.lib.dl.services.camel.headers.CdrFcrepoHeaders.CdrSolrUpdateAction;
 import static edu.unc.lib.dl.util.IndexingActionType.ADD_SET_TO_PARENT;
@@ -56,6 +56,7 @@ import org.springframework.jms.core.MessageCreator;
 
 import edu.unc.lib.dl.fcrepo4.PIDs;
 import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.services.camel.solr.processor.CdrEventToSolrUpdateProcessor;
 import edu.unc.lib.dl.util.IndexingActionType;
 import edu.unc.lib.dl.util.JMSMessageUtil.CDRActions;
 

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solr/processor/SolrIngestProcessorTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solr/processor/SolrIngestProcessorTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.unc.lib.dl.services.camel;
+package edu.unc.lib.dl.services.camel.solr.processor;
 
 import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
 import static org.mockito.Matchers.any;
@@ -37,6 +37,7 @@ import edu.unc.lib.dl.data.ingest.solr.indexing.DocumentIndexingPipeline;
 import edu.unc.lib.dl.data.ingest.solr.indexing.SolrUpdateDriver;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.search.solr.model.IndexDocumentBean;
+import edu.unc.lib.dl.services.camel.solr.processor.SolrIngestProcessor;
 import edu.unc.lib.dl.test.TestHelper;
 
 /**

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solrUpdate/SolrUpdateRouterTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solrUpdate/SolrUpdateRouterTest.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-import edu.unc.lib.dl.services.camel.SolrUpdateProcessor;
+import edu.unc.lib.dl.services.camel.solr.processor.SolrUpdateProcessor;
 
 /**
  *

--- a/services-camel/src/test/resources/cdr-event-routing-it-context.xml
+++ b/services-camel/src/test/resources/cdr-event-routing-it-context.xml
@@ -58,14 +58,14 @@
     <property name="jmsTemplate" ref="cdrEventsJmsTemplate" />
   </bean>
   
-  <bean id="cdrEventProcessor" class="edu.unc.lib.dl.services.camel.CdrEventProcessor">
+  <bean id="cdrEventProcessor" class="edu.unc.lib.dl.services.camel.cdrEvents.processor.CdrEventProcessor">
     </bean>
     
-    <bean id="cdrEventToSolrUpdateProcessor" class="edu.unc.lib.dl.services.camel.CdrEventToSolrUpdateProcessor">
+    <bean id="cdrEventToSolrUpdateProcessor" class="edu.unc.lib.dl.services.camel.solr.processor.CdrEventToSolrUpdateProcessor">
         <property name="jmsTemplate" ref="solrUpdateJmsTemplate" />
     </bean>
     
-    <bean id="solrUpdateProcessor" class="edu.unc.lib.dl.services.camel.SolrUpdateProcessor">
+    <bean id="solrUpdateProcessor" class="edu.unc.lib.dl.services.camel.solr.processor.SolrUpdateProcessor">
     </bean>
   
   <camel:camelContext id="cdrServiceCdrEvents">

--- a/services-camel/src/test/resources/cdr-events-context.xml
+++ b/services-camel/src/test/resources/cdr-events-context.xml
@@ -14,11 +14,11 @@
 		http://camel.apache.org/schema/spring/camel-spring.xsd">
 	
 	<bean id="cdrEventToSolrUpdateProcessor" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="edu.unc.lib.dl.services.camel.CdrEventToSolrUpdateProcessor" />
+		<constructor-arg value="edu.unc.lib.dl.services.camel.solr.processor.CdrEventToSolrUpdateProcessor" />
 	</bean>
 	
 	<bean id="cdrEventProcessor" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="edu.unc.lib.dl.services.camel.CdrEventProcessor" />
+		<constructor-arg value="edu.unc.lib.dl.services.camel.cdrEvents.processor.CdrEventProcessor" />
 	</bean>
 	
 	<camel:camelContext id="CdrServiceCdrEvents">

--- a/services-camel/src/test/resources/fulltext-context.xml
+++ b/services-camel/src/test/resources/fulltext-context.xml
@@ -14,7 +14,7 @@
 		http://camel.apache.org/schema/spring/camel-spring.xsd">
 	
 	<bean id="fulltextProcessor" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="edu.unc.lib.dl.services.camel.FulltextProcessor" />
+		<constructor-arg value="edu.unc.lib.dl.services.camel.enhancements.processor.FulltextProcessor" />
 	</bean>
 
 	<camel:camelContext id="CdrServiceFulltextExtraction">

--- a/services-camel/src/test/resources/images-context.xml
+++ b/services-camel/src/test/resources/images-context.xml
@@ -14,15 +14,15 @@
 		http://camel.apache.org/schema/spring/camel-spring.xsd">
 	
 	<bean id="addSmallThumbnailProcessor" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="edu.unc.lib.dl.services.camel.AddDerivativeProcessor" />
+		<constructor-arg value="edu.unc.lib.dl.services.camel.enhancements.processor.AddDerivativeProcessor" />
 	</bean>
 	
 	<bean id="addLargeThumbnailProcessor" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="edu.unc.lib.dl.services.camel.AddDerivativeProcessor" />
+		<constructor-arg value="edu.unc.lib.dl.services.camel.enhancements.processor.AddDerivativeProcessor" />
 	</bean>
 	
 	<bean id="addAccessCopyProcessor" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="edu.unc.lib.dl.services.camel.AddDerivativeProcessor" />
+		<constructor-arg value="edu.unc.lib.dl.services.camel.enhancements.processor.AddDerivativeProcessor" />
 	</bean>
 
 	<camel:camelContext id="CdrServiceEnhancements">

--- a/services-camel/src/test/resources/metaservices-context.xml
+++ b/services-camel/src/test/resources/metaservices-context.xml
@@ -14,15 +14,15 @@
 		http://camel.apache.org/schema/spring/camel-spring.xsd">
 	
 	<bean id="binaryMetadataProcessor" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="edu.unc.lib.dl.services.camel.BinaryMetadataProcessor" />
+		<constructor-arg value="edu.unc.lib.dl.services.camel.enhancements.processor.BinaryMetadataProcessor" />
 	</bean>
 	
 	<bean id="getBinaryProcessor" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="edu.unc.lib.dl.services.camel.GetBinaryProcessor" />
+		<constructor-arg value="edu.unc.lib.dl.services.camel.enhancements.processor.GetBinaryProcessor" />
 	</bean>
 	
 	<bean id="cleanupBinaryProcessor" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="edu.unc.lib.dl.services.camel.CleanupBinaryProcessor" />
+		<constructor-arg value="edu.unc.lib.dl.services.camel.enhancements.processor.CleanupBinaryProcessor" />
 	</bean>
 
 	<camel:camelContext id="CdrMetaServicesRouter">

--- a/services-camel/src/test/resources/replication-context.xml
+++ b/services-camel/src/test/resources/replication-context.xml
@@ -14,7 +14,7 @@
 		http://camel.apache.org/schema/spring/camel-spring.xsd">
 	
 	<bean id="replicationProcessor" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="edu.unc.lib.dl.services.camel.ReplicationProcessor" />
+		<constructor-arg value="edu.unc.lib.dl.services.camel.replication.processor.ReplicationProcessor" />
 	</bean>
 
 	<camel:camelContext id="CdrServiceReplication">

--- a/services-camel/src/test/resources/solr-ingest-context.xml
+++ b/services-camel/src/test/resources/solr-ingest-context.xml
@@ -21,7 +21,7 @@
 	</bean>
 	
 	<bean id="solrIngestProcessor" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="edu.unc.lib.dl.services.camel.SolrIngestProcessor" />
+		<constructor-arg value="edu.unc.lib.dl.services.camel.solr.processor.SolrIngestProcessor" />
 	</bean>
 	
 	<camel:camelContext id="CdrServiceSolr">

--- a/services-camel/src/test/resources/solr-update-context.xml
+++ b/services-camel/src/test/resources/solr-update-context.xml
@@ -8,7 +8,7 @@
 		http://camel.apache.org/schema/spring/camel-spring.xsd">
 	
 	<bean id="solrUpdateProcessor" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="edu.unc.lib.dl.services.camel.SolrUpdateProcessor" />
+		<constructor-arg value="edu.unc.lib.dl.services.camel.solr.processor.SolrUpdateProcessor" />
 	</bean>
 
 	<camel:camelContext id="CdrServiceSolrUpdate">


### PR DESCRIPTION
Don't know if we want to split this up, but it seemed to make sense to do them together. See https://github.com/UNC-Libraries/Carolina-Digital-Repository/pull/647 for pull request that just updates the camel namespace.