### PR TITLE
Required fields followup

### DIFF
--- a/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/indexing/SolrUpdateDriver.java
+++ b/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/indexing/SolrUpdateDriver.java
@@ -70,6 +70,14 @@ public class SolrUpdateDriver {
     }
 
     public void addDocument(IndexDocumentBean idb) throws IndexingException {
+        Map<String, Object> fields = idb.getFields();
+
+        for (String field : solrSettings.getRequiredFields()) {
+            if (!fields.containsKey(field)) {
+                throw new IndexingException("Required indexing field {" + field + "} was not present");
+            }
+        }
+
         try {
             log.info("Queuing {} for full indexing", idb.getId());
             // Providing a version value, indicating that it doesn't matter if record exists
@@ -92,12 +100,6 @@ public class SolrUpdateDriver {
      */
     public void updateDocument(IndexDocumentBean idb) throws IndexingException {
         Map<String, Object> fields = idb.getFields();
-
-        for (String field : solrSettings.getRequiredFields()) {
-            if (!fields.containsKey(field)) {
-                throw new IndexingException("Required indexing field {" + field + "} was not present");
-            }
-        }
 
         try {
             log.info("Queuing {} for atomic updating", idb.getId());

--- a/solr-ingest/src/test/java/edu/unc/lib/dl/data/ingest/solr/action/BaseEmbeddedSolrTest.java
+++ b/solr-ingest/src/test/java/edu/unc/lib/dl/data/ingest/solr/action/BaseEmbeddedSolrTest.java
@@ -16,6 +16,7 @@
 package edu.unc.lib.dl.data.ingest.solr.action;
 
 import java.io.File;
+import java.util.Properties;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
@@ -30,9 +31,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import edu.unc.lib.dl.data.ingest.solr.indexing.SolrUpdateDriver;
+import edu.unc.lib.dl.search.solr.util.SolrSettings;
 
 public class BaseEmbeddedSolrTest extends Assert {
     private static final Logger log = LoggerFactory.getLogger(BaseEmbeddedSolrTest.class);
+
+    protected SolrSettings solrSettings;
 
     protected EmbeddedSolrServer server;
 
@@ -53,9 +57,15 @@ public class BaseEmbeddedSolrTest extends Assert {
 
         server = new EmbeddedSolrServer(container, "access");
 
+        Properties solrProps = new Properties();
+        solrProps.load(this.getClass().getResourceAsStream("/solr.properties"));
+        solrSettings = new SolrSettings();
+        solrSettings.setProperties(solrProps);
+
         driver = new SolrUpdateDriver();
         driver.setSolrClient(server);
         driver.setUpdateSolrClient(server);
+        driver.setSolrSettings(solrSettings);
     }
 
     protected SolrDocumentList getDocumentList(String query, String fieldList) throws Exception {

--- a/solr-ingest/src/test/java/edu/unc/lib/dl/data/ingest/solr/action/IndexTreeInplaceActionTest.java
+++ b/solr-ingest/src/test/java/edu/unc/lib/dl/data/ingest/solr/action/IndexTreeInplaceActionTest.java
@@ -18,8 +18,6 @@ package edu.unc.lib.dl.data.ingest.solr.action;
 import static edu.unc.lib.dl.fcrepo4.RepositoryPaths.getContentRootPid;
 import static edu.unc.lib.dl.util.IndexingActionType.RECURSIVE_ADD;
 
-import java.util.Properties;
-
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.junit.Before;
@@ -36,7 +34,6 @@ import edu.unc.lib.dl.data.ingest.solr.exception.IndexingException;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.search.solr.service.SolrSearchService;
 import edu.unc.lib.dl.search.solr.util.SearchSettings;
-import edu.unc.lib.dl.search.solr.util.SolrSettings;
 import edu.unc.lib.dl.test.TestHelpers;
 
 /**
@@ -49,18 +46,13 @@ public class IndexTreeInplaceActionTest extends UpdateTreeActionTest {
 
     @Mock
     private SearchSettings searchSettings;
-    private SolrSettings solrSettings;
+
     private SolrSearchService solrSearchService;
     @Mock
     private GlobalPermissionEvaluator globalPermissionEvaluator;
 
     @Before
     public void setupInplace() throws Exception {
-        Properties solrProps = new Properties();
-        solrProps.load(this.getClass().getResourceAsStream("/solr.properties"));
-        solrSettings = new SolrSettings();
-        solrSettings.setProperties(solrProps);
-
         ((IndexTreeInplaceAction) action).setSolrSettings(solrSettings);
 
         solrSearchService = new SolrSearchService();

--- a/solr-ingest/src/test/java/edu/unc/lib/dl/data/ingest/solr/indexing/SolrUpdateDriverTest.java
+++ b/solr-ingest/src/test/java/edu/unc/lib/dl/data/ingest/solr/indexing/SolrUpdateDriverTest.java
@@ -40,6 +40,8 @@ import edu.unc.lib.dl.search.solr.util.SolrSettings;
  */
 public class SolrUpdateDriverTest {
     @Mock
+    private SolrClient solrClient;
+    @Mock
     private SolrClient updateSolrClient;
     @Mock
     private IndexDocumentBean idb;
@@ -70,6 +72,7 @@ public class SolrUpdateDriverTest {
 
         driver = new SolrUpdateDriver();
         driver.setUpdateSolrClient(updateSolrClient);
+        driver.setSolrClient(solrClient);
         driver.setSolrSettings(solrSettings);
 
         when(solrSettings.getRequiredFields()).thenReturn(REQUIRED_INDEXING_FIELDS);
@@ -79,7 +82,7 @@ public class SolrUpdateDriverTest {
     public void testRequiredIndexingFieldsMissing() throws Exception {
         when(idb.getFields()).thenReturn(missingFields);
 
-        driver.updateDocument(idb);
+        driver.addDocument(idb);
     }
 
     @Test
@@ -90,7 +93,7 @@ public class SolrUpdateDriverTest {
 
         when(idb.getFields()).thenReturn(allFields);
 
-        driver.updateDocument(idb);
-        verify(updateSolrClient).add(any(SolrInputDocument.class));
+        driver.addDocument(idb);
+        verify(solrClient).addBean(any(IndexDocumentBean.class));
     }
 }


### PR DESCRIPTION
Driver only checking req fields when indexing full doc.  Provides required fields info to tests that needed it.