### PR TITLE
Bxc-2141-4 Services config fixes

### DIFF
--- a/access/pom.xml
+++ b/access/pom.xml
@@ -41,7 +41,7 @@
                     <stopKey>STOP</stopKey>
                 <webApp>
                     <webInfIncludeJarPattern>.*access-common-.*</webInfIncludeJarPattern>
-                    <contextPath>/access</contextPath>
+                    <contextPath>/</contextPath>
                     <allowDuplicateFragmentNames>true</allowDuplicateFragmentNames>
                     <extraClasspath>${basedir}/target/test-classes/</extraClasspath>
                 </webApp>
@@ -120,7 +120,7 @@
         <dependency>
             <groupId>taglibs</groupId>
             <artifactId>standard</artifactId>
-            <version>${javax.servlet.jstl.version}</version>
+            <version>${taglibs.standard.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/access/src/main/webapp/WEB-INF/access-fedora-context.xml
+++ b/access/src/main/webapp/WEB-INF/access-fedora-context.xml
@@ -123,13 +123,11 @@
     
     <!--  -->
     <bean id="serverAddress" class="java.lang.String">
-        <constructor-arg
-            value="${fcrepo.baseUrl}" />
+        <constructor-arg value="${fcrepo.baseUrl}" />
     </bean>
     
     <bean id="baseAddress" class="java.lang.String">
-        <constructor-arg
-            value="${fcrepo.baseUrl}rest/" />
+        <constructor-arg value="${fcrepo.baseUrl}rest/" />
     </bean>
     
     <bean id="fcrepoClientFactory" class="edu.unc.lib.dl.fcrepo4.FcrepoClientFactory" factory-method="factory">

--- a/access/src/test/resources/service-context.xml
+++ b/access/src/test/resources/service-context.xml
@@ -34,7 +34,7 @@
     </bean>
     <bean id="fedoraUtil" class="edu.unc.lib.dl.ui.util.FedoraUtil">
         <property name="fedoraUrl"
-            value="${fedora.protocol}://${fedora.host}${fedora.port}/${fedora.context}" />
+            value="${baseAddress}" />
     </bean>
     <bean id="fedoraContentService" class="edu.unc.lib.dl.ui.service.FedoraContentService">
         <property name="accessClient" ref="accessClient" />
@@ -42,7 +42,7 @@
 
     <bean id="applicationPathSettings" class="edu.unc.lib.dl.ui.util.ApplicationPathSettings">
         <property name="fedoraPath"
-            value="${fedora.protocol}://${fedora.host}${fedora.port}/${fedora.context}" />
+            value="${baseAddress}" />
         <property name="solrPath"
             value="${solr.protocol}://${solr.host}${solr.port}/${solr.context}" />
         <property name="lorisPath" value="${loris.base.url}" />

--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -124,7 +124,7 @@
         <dependency>
             <groupId>taglibs</groupId>
             <artifactId>standard</artifactId>
-            <version>${javax.servlet.jstl.version}</version>
+            <version>${taglibs.standard.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/deposit/src/main/webapp/WEB-INF/fcrepo-clients-context.xml
+++ b/deposit/src/main/webapp/WEB-INF/fcrepo-clients-context.xml
@@ -16,13 +16,11 @@
     </bean>
 
     <bean id="serverAddress" class="java.lang.String">
-        <constructor-arg
-            value="${fedora.protocol:https}://${fedora.host:localhost}:${fedora.port:443}/${fedora.context:fcrepo}/" />
+        <constructor-arg value="${fcrepo.baseUrl}" />
     </bean>
     
     <bean id="baseAddress" class="java.lang.String">
-        <constructor-arg
-            value="${fedora.protocol:https}://${fedora.host:localhost}:${fedora.port:443}/${fedora.context:fcrepo}/rest/" />
+        <constructor-arg value="${fcrepo.baseUrl}rest/" />
     </bean>
     
     <bean id="fcrepoClientFactory" class="edu.unc.lib.dl.fcrepo4.FcrepoClientFactory" factory-method="factory">

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/FcrepoClientFactory.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/FcrepoClientFactory.java
@@ -29,10 +29,17 @@ public class FcrepoClientFactory {
 
     private String baseUri;
 
+    private String hostHeader;
+
     private static FcrepoClientFactory instance;
 
     private FcrepoClientFactory(String base) {
         baseUri = base;
+    }
+
+    private FcrepoClientFactory(String base, String hostHeader) {
+        baseUri = base;
+        this.hostHeader = hostHeader;
     }
 
     /**
@@ -40,18 +47,31 @@ public class FcrepoClientFactory {
      * not been previously constructed, otherwise the existing factory will be
      * returned.
      *
-     * @param baseUri
-     *            base uri for the repository. Required.
+     * @param baseUri base uri for the repository. Required.
      * @return a new FcrepoClientFactory with the given baseUri or the
      *         previously constructed factory.
      */
     public static FcrepoClientFactory factory(String baseUri) {
+        return factory(baseUri, null);
+    }
+
+    /**
+     * Returns a FcrepoClientFactory if the factory has not been previously
+     * constructed, otherwise the existing factory will be returned.
+     *
+     * @param baseUri base uri for the repository. Required.
+     * @param hostHeader value to provide as Host header on all requests to
+     *            fedora. Optional.
+     * @return a new FcrepoClientFactory with the given baseUri or the
+     *         previously constructed factory.
+     */
+    public static FcrepoClientFactory factory(String baseUri, String hostHeader) {
         if (baseUri == null) {
             throw new IllegalArgumentException("A base URI is required to construct a factory");
         }
 
         if (instance == null) {
-            instance = new FcrepoClientFactory(baseUri);
+            instance = new FcrepoClientFactory(baseUri, hostHeader);
         } else {
             log.warn("Requested to construct a factory when a previous instance has "
                     + "already been initialized (current base uri: {0}, requested {1}), ignoring.",
@@ -83,6 +103,7 @@ public class FcrepoClientFactory {
                 .credentials(user, password)
                 .authScope(host)
                 .throwExceptionOnFailure()
+                .hostHeader(hostHeader)
                 .build();
     }
 
@@ -92,6 +113,9 @@ public class FcrepoClientFactory {
      * @return
      */
     public FcrepoClient makeClient() {
-        return TransactionalFcrepoClient.client(baseUri).throwExceptionOnFailure().build();
+        return TransactionalFcrepoClient.client(baseUri)
+                .throwExceptionOnFailure()
+                .hostHeader(hostHeader)
+                .build();
     }
 }

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/TransactionalFcrepoClient.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/TransactionalFcrepoClient.java
@@ -69,8 +69,8 @@ public class TransactionalFcrepoClient extends FcrepoClient {
 
     protected TransactionalFcrepoClient(String username, String password, String host,
             Boolean throwExceptionOnFailure, String baseUri, String hostHeader) {
-    this(username, password, host, throwExceptionOnFailure, baseUri);
-    this.hostHeader = hostHeader;
+        this(username, password, host, throwExceptionOnFailure, baseUri);
+        this.hostHeader = hostHeader;
 }
 
     /**
@@ -147,11 +147,16 @@ public class TransactionalFcrepoClient extends FcrepoClient {
     private URI rewriteUri(URI rescUri) {
         URI txUri = FedoraTransaction.txUriThread.get();
         String rescId = rescUri.toString();
+        // locate the rest component of the path, everything after is the
+        // relative path to the resource
         int txIdIndex = rescId.indexOf(REST);
+        // Get index where the relative path would begin
         int rescPathIndex = txIdIndex + REST.length();
         if (rescPathIndex == rescId.length()) {
+            // If there is no relative path (is root of the repository), return the transaction uri
             return txUri;
         }
+        // Insert transaction id before the relative path, construct rewritten uri
         rescId = rescId.substring(rescPathIndex);
         return URI.create(URIUtil.join(txUri, rescId));
     }

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/TransactionalFcrepoClientIT.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/TransactionalFcrepoClientIT.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.fcrepo4;
+
+import static edu.unc.lib.dl.util.RDFModelUtil.createModel;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.vocabulary.RDF;
+import org.fcrepo.client.FcrepoResponse;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import edu.unc.lib.dl.test.TestHelper;
+
+/**
+ * @author bbpennel
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration({"/spring-test/test-fedora-container.xml"})
+public class TransactionalFcrepoClientIT {
+
+    private static final String BASE_PATH = "http://localhost:48085/rest/";
+    private static final URI BASE_URI = URI.create(BASE_PATH);
+
+    private static final String HOST_HEADER = "boxy.example.com";
+
+    private TransactionalFcrepoClient fcrepoClient;
+
+    private TransactionManager txManager;
+
+    @Before
+    public void setup() {
+        TestHelper.setContentBase(BASE_PATH);
+
+        txManager = new TransactionManager();
+    }
+
+    @Test
+    public void testRequestWithTx() throws Exception {
+        fcrepoClient = TransactionalFcrepoClient.client(BASE_PATH)
+                .build();
+
+        txManager.setClient(fcrepoClient);
+
+        // Create object in transaction, should return transaction location
+        FedoraTransaction tx = txManager.startTransaction();
+        URI objUri;
+        try (FcrepoResponse response = fcrepoClient.post(BASE_URI).perform()) {
+            objUri = response.getLocation();
+        }
+
+        assertTrue("Location must be within transaction",
+                objUri.toString().startsWith(tx.getTxUri().toString()));
+
+        // Verify that the response triples have non-tx uris
+        try (FcrepoResponse response = fcrepoClient.get(objUri).perform()) {
+            // Remove tx from obj uri
+            String nonTxObjUri = objUri.toString().replaceFirst("/tx:[^/]+", "");
+
+            Model model = createModel(response.getBody());
+
+            Resource resc = model.getResource(nonTxObjUri);
+            assertTrue("Subject must be non-tx uri", resc.hasProperty(RDF.type));
+        }
+    }
+
+    @Test
+    public void testRequestWithHostParam() throws Exception {
+        fcrepoClient = TransactionalFcrepoClient.client(BASE_PATH)
+                .hostHeader(HOST_HEADER)
+                .build();
+
+        URI objUri;
+        try (FcrepoResponse response = fcrepoClient.post(BASE_URI).perform()) {
+            objUri = response.getLocation();
+        }
+
+        assertEquals("Response must use provided Host.",
+                HOST_HEADER, objUri.getHost());
+    }
+}

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/move/MoveObjectsService.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/move/MoveObjectsService.java
@@ -151,4 +151,11 @@ public class MoveObjectsService {
     public void setOperationMetrics(ActivityMetricsClient operationMetrics) {
         this.operationMetrics = operationMetrics;
     }
+
+    /**
+     * @param moveExecutor the moveExecutor to set
+     */
+    public void setMoveExecutor(ExecutorService moveExecutor) {
+        this.moveExecutor = moveExecutor;
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,8 @@
         <solr.version>6.5.1</solr.version>
         <javax.servlet.api.version>3.1.0</javax.servlet.api.version>
         <javax.servlet.jsp.version>2.3.1</javax.servlet.jsp.version>
-        <javax.servlet.jstl.version>1.1.2</javax.servlet.jstl.version>
+        <taglibs.standard.version>1.1.2</taglibs.standard.version>
+        <javax.servlet.jstl.version>1.2</javax.servlet.jstl.version>
     </properties>
 
     <distributionManagement>

--- a/services-camel/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel/src/main/webapp/WEB-INF/service-context.xml
@@ -27,6 +27,7 @@
     
     <bean id="fcrepoClientFactory" class="edu.unc.lib.dl.fcrepo4.FcrepoClientFactory" factory-method="factory">
         <constructor-arg value="${fcrepo.baseUrl}" />
+        <constructor-arg value="${fcrepo.client.host}" />
     </bean>
     
     <bean id="fcrepoClient" class="org.fcrepo.client.FcrepoClient"

--- a/services/src/main/resources/cdr-services.properties
+++ b/services/src/main/resources/cdr-services.properties
@@ -11,7 +11,7 @@ conductor.solr.recoverableDelay=30000
 catchup.pageSize=100
 catchup.catchUpCheckDelay=1000
 fedoraDataService.maxThreads=5
-cdr.version=${project.version}
+project.version=${project.version}
 
 # Access Control Retrieval Properties
 fuseki.baseUri=http://localhost:8080/fuseki/test

--- a/services/src/main/webapp/WEB-INF/access-fedora-context.xml
+++ b/services/src/main/webapp/WEB-INF/access-fedora-context.xml
@@ -11,22 +11,6 @@
     xsi:schemaLocation="
     http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd"
     xmlns="http://www.springframework.org/schema/beans">
-    <bean name="propertiesURI" class="java.lang.System"
-        factory-method="getProperty">
-        <constructor-arg index="0" value="server.properties.uri" />
-        <!-- property name for properties URI location -->
-        <constructor-arg index="1" value="classpath:server.properties" />
-        <!-- default location for testing -->
-    </bean>
-    <bean id="serverProperties"
-        class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
-        <property name="locations">
-            <list>
-                <ref bean="propertiesURI" />
-            </list>
-        </property>
-        <property name="ignoreResourceNotFound" value="false" />
-    </bean>
     
     <bean id="sparqlQueryService" class="edu.unc.lib.dl.sparql.FusekiSparqlQueryServiceImpl">
         <property name="fusekiQueryURL" value="${fuseki.baseUri}" />

--- a/services/src/main/webapp/WEB-INF/service-context.xml
+++ b/services/src/main/webapp/WEB-INF/service-context.xml
@@ -237,7 +237,6 @@
     </bean>
     
     <bean id="fedoraContentService" class="edu.unc.lib.dl.ui.service.FedoraContentService">
-        <property name="fedoraHost" value="${fedora.host:localhost}" />
     </bean>
     
     <bean id="addContainerService" class="edu.unc.lib.dl.cdr.services.processing.AddContainerService">

--- a/services/src/main/webapp/WEB-INF/service-context.xml
+++ b/services/src/main/webapp/WEB-INF/service-context.xml
@@ -35,7 +35,6 @@
         <property name="locations">
             <list>
                 <ref bean="propertiesURI"/>
-                <value>classpath:cdr-services.properties</value>
             </list>
         </property>
         <property name="ignoreResourceNotFound" value="false"/>
@@ -80,6 +79,20 @@
         scope="prototype">
         <constructor-arg ref="jesqueConfig" />
         <constructor-arg ref="jedisPool" />
+    </bean>
+    
+    <bean id="moveObjectsService"
+        class="edu.unc.lib.dl.persist.services.move.MoveObjectsService">
+        <property name="aclService" ref="aclService" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="transactionManager" ref="transactionManager" />
+        <property name="sparqlQueryService" ref="sparqlQueryService" />
+        <property name="fcrepoClient" ref="fcrepoClient" />
+        <property name="operationsMessageSender" ref="operationsMessageSender" />
+        <property name="objectPathFactory" ref="objectPathFactory" />
+        <property name="asynchronous" value="true" />
+        <property name="moveExecutor" ref="moveExecutor" />
+        <property name="operationMetrics" ref="activityMetricsClient" />
     </bean>
 
     <!-- <bean id="rollbackMoveJob" class="edu.unc.lib.dl.cdr.services.processing.MoveRollbackJob"></bean>
@@ -211,7 +224,7 @@
     
     <bean id="fedoraUtil" class="edu.unc.lib.dl.ui.util.FedoraUtil">
         <property name="fedoraUrl"
-            value="${fedora.protocol}://${fedora.host}${fedora.port}/${fedora.context}" />
+            value="${fcrepo.baseUrl}" />
     </bean>
     
     <bean id="gaTrackingID" class="java.lang.String">
@@ -224,7 +237,6 @@
     </bean>
     
     <bean id="fedoraContentService" class="edu.unc.lib.dl.ui.service.FedoraContentService">
-        <property name="fedoraUtil" ref="fedoraUtil" />
         <property name="fedoraHost" value="${fedora.host:localhost}" />
     </bean>
     
@@ -269,6 +281,13 @@
       <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
       <property name="operationsMessageSender" ref="operationsMessageSender" />
       <property name="modsValidator" ref="modsValidator" />
+  </bean>
+  
+  <bean id="accessControlRetrievalService" class="edu.unc.lib.dl.cdr.services.processing.AccessControlRetrievalService" >
+      <property name="aclService" ref="aclService" />
+      <property name="objectAclFactory" ref="objectAclFactory" />
+      <property name="inheritedAclFactory" ref="inheritedAclFactory" />
+      <property name="repoObjLoader" ref="repositoryObjectLoader" />
   </bean>
   
   <bean id="xmlExportService" class="edu.unc.lib.dl.cdr.services.processing.XMLExportService" >

--- a/services/src/main/webapp/WEB-INF/solr-search-context.xml
+++ b/services/src/main/webapp/WEB-INF/solr-search-context.xml
@@ -25,26 +25,8 @@
             http://www.springframework.org/schema/util/spring-util-3.0.xsd
             http://www.springframework.org/schema/context 
             http://www.springframework.org/schema/context/spring-context-3.0.xsd">
-            
-    <bean name="propertiesURI" class="java.lang.System"
-        factory-method="getProperty">
-        <constructor-arg index="0" value="server.properties.uri" />
-        <!-- property name for properties URI location -->
-        <constructor-arg index="1" value="classpath:server.properties" />
-        <!-- default location for testing -->
-    </bean>
-    <bean id="serverProperties"
-        class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
-        <property name="locations">
-            <list>
-                <ref bean="propertiesURI" />
-            </list>
-        </property>
-        <property name="ignoreResourceNotFound" value="false" />
-    </bean>    
     
     <bean id="accessGroupConstants" class="edu.unc.lib.dl.acl.util.AccessGroupConstants">
-        <property name="ADMIN_GROUP" value="${access.group.admin}"/>
     </bean>
     
     <util:properties id="searchProperties" location="classpath:search.properties" />
@@ -91,12 +73,12 @@
         <property name="searchSettings" ref="searchSettings" />
         <property name="searchStateFactory" ref="searchStateFactory" />
         <property name="facetFieldUtil" ref="facetFieldUtil" />
-        <property name="pathFactory" ref="pathFactory" />
+        <property name="pathFactory" ref="objectPathFactory" />
         <property name="disablePermissionFiltering" value="false" />
         <property name="globalPermissionEvaluator" ref="globalPermissionEvaluator" />
     </bean>
     
-    <bean id="pathFactory" class="edu.unc.lib.dl.search.solr.service.ObjectPathFactory">
+    <bean id="objectPathFactory" class="edu.unc.lib.dl.search.solr.service.ObjectPathFactory">
         <property name="search" ref="queryLayer" />
         <property name="cacheSize" value="1000" />
         <property name="timeToLiveMilli" value="10000" />
@@ -107,7 +89,7 @@
         <property name="staticMethod" value="edu.unc.lib.dl.search.solr.model.BriefObjectMetadataBean.setPathFactory"/>
         <property name="arguments">
             <list>
-                <ref bean="pathFactory"/>
+                <ref bean="objectPathFactory"/>
             </list>
         </property>
     </bean>

--- a/services/src/main/webapp/WEB-INF/sword-context.xml
+++ b/services/src/main/webapp/WEB-INF/sword-context.xml
@@ -26,24 +26,6 @@
         http://www.springframework.org/schema/context 
         http://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
-    <bean name="propertiesURI" class="java.lang.System"
-        factory-method="getProperty">
-        <constructor-arg index="0" value="server.properties.uri" />
-        <!-- property name for properties URI location -->
-        <constructor-arg index="1" value="classpath:server.properties" />
-        <!-- default location for testing -->
-    </bean>
-    <bean id="serverProperties"
-        class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
-        <property name="locations">
-            <list>
-                <ref bean="propertiesURI" />
-                <value>classpath:cdr-services.properties</value>
-            </list>
-        </property>
-        <property name="ignoreResourceNotFound" value="false" />
-    </bean>
-
     <bean id="swordPath" class="java.lang.String">
         <constructor-arg
             value="${repository.protocol}://${repository.host}${repository.port}/${services.context}/${sword.context}" />
@@ -102,7 +84,7 @@
         <property name="basePath" value="${repository.protocol}://${repository.host}${repository.port}/${repository.context}"/>
         <property name="tempDirectory" value="${initial.batch.ingest.dir}"/>
         <property name="swordVersion" value="${sword.version}"/>
-        <property name="generatorVersion" value="${cdr.version}"/>
+        <property name="generatorVersion" value="${project.version}"/>
         <property name="generator" value="${repository.protocol}://${repository.host}"/>
         <property name="depositorNamespace" value="${sword.depositorNamespace}"/>
         <property name="adminDepositor" value="${sword.username}"/>
@@ -162,7 +144,7 @@
     
     <bean id="mediaResourceManager" class="edu.unc.lib.dl.cdr.sword.server.managers.MediaResourceManagerImpl">
         <property name="fedoraHost" value="${fedora.host:localhost}" />
-        <property name="fedoraPath" value="${fedora.protocol}://${fedora.host}${fedora.port}/${fedora.context}"/>
+        <property name="fedoraPath" value="${fcrepo.baseUrl}"/>
         <property name="virtualDatastreamMap" ref="virtualDatastreamMap" />
     </bean>
     

--- a/services/src/main/webapp/WEB-INF/sword-context.xml
+++ b/services/src/main/webapp/WEB-INF/sword-context.xml
@@ -143,7 +143,6 @@
     </bean>
     
     <bean id="mediaResourceManager" class="edu.unc.lib.dl.cdr.sword.server.managers.MediaResourceManagerImpl">
-        <property name="fedoraHost" value="${fedora.host:localhost}" />
         <property name="fedoraPath" value="${fcrepo.baseUrl}"/>
         <property name="virtualDatastreamMap" ref="virtualDatastreamMap" />
     </bean>


### PR DESCRIPTION
Gets services webapp deployable on FES and deals with issues related to it being deployed in multi-server environment.

* Adds optional Host header to requests to Fedora to deal with cross domain requests (by default, fedora responds with URIs that match the URI it was addressed at.  So if one service addresses fedora at repo.example.com and another as localhost, they will get back different URIs and triples) that was impacting indexing to triple store.
* Adds missing initialization of move and acl retrieval services
* Adjusts property names to match deployed values