### PR TITLE
Bxc-2166/2161 - Navigation issues

### DIFF
--- a/access-common/src/main/java/edu/unc/lib/dl/ui/controller/AbstractSolrSearchController.java
+++ b/access-common/src/main/java/edu/unc/lib/dl/ui/controller/AbstractSolrSearchController.java
@@ -15,6 +15,8 @@
  */
 package edu.unc.lib.dl.ui.controller;
 
+import static edu.unc.lib.dl.acl.util.GroupsThreadStore.getAgentPrincipals;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -26,15 +28,14 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import edu.unc.lib.dl.acl.util.AccessGroupSet;
-import edu.unc.lib.dl.acl.util.GroupsThreadStore;
 import edu.unc.lib.dl.search.solr.exception.InvalidHierarchicalFacetException;
-import edu.unc.lib.dl.search.solr.model.SearchState;
+import edu.unc.lib.dl.search.solr.model.HierarchicalBrowseRequest;
 import edu.unc.lib.dl.search.solr.model.SearchRequest;
 import edu.unc.lib.dl.search.solr.model.SearchResultResponse;
+import edu.unc.lib.dl.search.solr.model.SearchState;
 import edu.unc.lib.dl.search.solr.service.SearchActionService;
 import edu.unc.lib.dl.search.solr.service.SearchStateFactory;
 import edu.unc.lib.dl.search.solr.util.SearchSettings;
-import edu.unc.lib.dl.search.solr.model.HierarchicalBrowseRequest;
 import edu.unc.lib.dl.ui.service.SolrQueryLayerService;
 
 /**
@@ -77,7 +78,7 @@ public abstract class AbstractSolrSearchController {
         //Get user access groups.  Fill this in later, for now just set to public
         HttpSession session = request.getSession();
         //Get the access group list
-        AccessGroupSet accessGroups = GroupsThreadStore.getGroups();
+        AccessGroupSet accessGroups = getAgentPrincipals().getPrincipals();
         searchRequest.setAccessGroups(accessGroups);
 
         //Retrieve the last search state

--- a/access-common/src/main/java/edu/unc/lib/dl/ui/controller/AbstractStructureResultsController.java
+++ b/access-common/src/main/java/edu/unc/lib/dl/ui/controller/AbstractStructureResultsController.java
@@ -66,8 +66,8 @@ public class AbstractStructureResultsController extends AbstractSolrSearchContro
         }
 
         // Request object for the search
-        HierarchicalBrowseRequest browseRequest = new HierarchicalBrowseRequest(depth);
-        browseRequest.setAccessGroups(getAgentPrincipals().getPrincipals());
+        HierarchicalBrowseRequest browseRequest = new HierarchicalBrowseRequest(depth,
+                getAgentPrincipals().getPrincipals());
         browseRequest.setRetrieveFacets(retrieveFacets);
         if (retrieveFacets) {
             browseRequest.setSearchState(this.searchStateFactory.createHierarchicalBrowseSearchState(request

--- a/access-common/src/main/java/edu/unc/lib/dl/ui/controller/StructureResultsController.java
+++ b/access-common/src/main/java/edu/unc/lib/dl/ui/controller/StructureResultsController.java
@@ -15,6 +15,7 @@
  */
 package edu.unc.lib.dl.ui.controller;
 
+import static edu.unc.lib.dl.acl.util.GroupsThreadStore.getAgentPrincipals;
 import static edu.unc.lib.dl.fcrepo4.RepositoryPaths.getContentRootPid;
 
 import javax.servlet.http.HttpServletRequest;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import edu.unc.lib.dl.acl.util.AccessGroupSet;
 import edu.unc.lib.dl.acl.util.GroupsThreadStore;
 import edu.unc.lib.dl.search.solr.model.BriefObjectMetadataBean;
 import edu.unc.lib.dl.search.solr.model.HierarchicalBrowseResultResponse;
@@ -48,7 +50,7 @@ public class StructureResultsController extends AbstractStructureResultsControll
         response.setContentType("application/json");
         HierarchicalBrowseResultResponse result = getStructureResult(getContentRootPid().getId(),
                 "true".equals(includeFiles), false, false, request);
-        return SerializationUtil.structureToJSON(result, GroupsThreadStore.getGroups());
+        return SerializationUtil.structureToJSON(result, getAgentPrincipals().getPrincipals());
     }
 
     @RequestMapping("/structure/{pid}/json")
@@ -59,7 +61,7 @@ public class StructureResultsController extends AbstractStructureResultsControll
         response.setContentType("application/json");
         HierarchicalBrowseResultResponse result = getStructureResult(pid, "true".equals(includeFiles), false, false,
                 request);
-        return SerializationUtil.structureToJSON(result, GroupsThreadStore.getGroups());
+        return SerializationUtil.structureToJSON(result, getAgentPrincipals().getPrincipals());
     }
 
     @RequestMapping("/structure/path")
@@ -69,7 +71,7 @@ public class StructureResultsController extends AbstractStructureResultsControll
         response.setContentType("application/json");
         HierarchicalBrowseResultResponse result = getStructureResult(getContentRootPid().getId(),
                 "true".equals(includeFiles), true, false, request);
-        return SerializationUtil.structureToJSON(result, GroupsThreadStore.getGroups());
+        return SerializationUtil.structureToJSON(result, getAgentPrincipals().getPrincipals());
     }
 
     /**
@@ -83,7 +85,7 @@ public class StructureResultsController extends AbstractStructureResultsControll
         response.setContentType("application/json");
         HierarchicalBrowseResultResponse result = getStructureResult(pid, "true".equals(includeFiles), true, false,
                 request);
-        return SerializationUtil.structureToJSON(result, GroupsThreadStore.getGroups());
+        return SerializationUtil.structureToJSON(result, getAgentPrincipals().getPrincipals());
     }
 
     /**
@@ -93,9 +95,11 @@ public class StructureResultsController extends AbstractStructureResultsControll
     public @ResponseBody String getParentChildren(@PathVariable("pid") String pid,
             @RequestParam(value = "files", required = false) String includeFiles,
             Model model, HttpServletRequest request, HttpServletResponse response) {
+
+        AccessGroupSet principals = getAgentPrincipals().getPrincipals();
         // Get the parent pid for the selected object and get its structure view
-        BriefObjectMetadataBean selectedContainer = queryLayer.getObjectById(new SimpleIdRequest(pid,
-                tierResultFieldsList));
+        BriefObjectMetadataBean selectedContainer = queryLayer.getObjectById(
+                new SimpleIdRequest(pid, tierResultFieldsList, principals));
         if (selectedContainer == null) {
             throw new ResourceNotFoundException("Object " + pid + " was not found.");
         }

--- a/access-common/src/main/java/edu/unc/lib/dl/ui/service/SolrQueryLayerService.java
+++ b/access-common/src/main/java/edu/unc/lib/dl/ui/service/SolrQueryLayerService.java
@@ -102,7 +102,7 @@ public class SolrQueryLayerService extends SolrSearchService {
 
         if (has_pid) {
             selectedContainer = addSelectedContainer(searchRequest.getRootPid(), searchState,
-                    false);
+                    false, accessGroups);
         }
 
         SearchResultResponse results = getSearchResults(searchRequest);
@@ -136,7 +136,7 @@ public class SolrQueryLayerService extends SolrSearchService {
         BriefObjectMetadata selectedContainer = null;
         if (searchRequest.getRootPid() != null) {
             selectedContainer = addSelectedContainer(searchRequest.getRootPid(), searchState,
-                    searchRequest.isApplyCutoffs());
+                    searchRequest.isApplyCutoffs(), searchRequest.getAccessGroups());
         } else {
             CutoffFacet ancestorPath;
             if (!searchState.getFacets().containsKey(SearchFieldKeys.ANCESTOR_PATH.name())) {
@@ -379,7 +379,7 @@ public class SolrQueryLayerService extends SolrSearchService {
         // Get the record for the currently selected container if one is selected.
         if (searchRequest.getRootPid() != null) {
             selectedContainer = addSelectedContainer(searchRequest.getRootPid(), searchState,
-                    searchRequest.isApplyCutoffs());
+                    searchRequest.isApplyCutoffs(), searchRequest.getAccessGroups());
         } else if (rollup == null) {
             LOG.debug("No container and no rollup, defaulting rollup to true");
             searchState.setRollup(true);
@@ -456,7 +456,7 @@ public class SolrQueryLayerService extends SolrSearchService {
 
         if (searchRequest.getRootPid() != null) {
             addSelectedContainer(searchRequest.getRootPid(), searchRequest.getSearchState(),
-                    searchRequest.isApplyCutoffs());
+                    searchRequest.isApplyCutoffs(), searchRequest.getAccessGroups());
         }
 
         SolrQuery query = generateSearch(searchRequest);

--- a/access/src/main/java/edu/unc/lib/dl/ui/controller/SearchActionController.java
+++ b/access/src/main/java/edu/unc/lib/dl/ui/controller/SearchActionController.java
@@ -27,6 +27,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 
+import edu.unc.lib.dl.acl.util.AccessGroupSet;
 import edu.unc.lib.dl.fcrepo4.RepositoryPaths;
 import edu.unc.lib.dl.search.solr.model.CutoffFacet;
 import edu.unc.lib.dl.search.solr.model.SearchRequest;
@@ -144,15 +145,16 @@ public class SearchActionController extends AbstractSolrSearchController {
 
         // Request object for the search
         SearchState searchState = searchRequest.getSearchState();
+        AccessGroupSet principals = searchRequest.getAccessGroups();
 
         SearchResultResponse resultResponse = queryLayer.performSearch(searchRequest);
 
         if (resultResponse != null) {
             childrenCountService.addChildrenCounts(resultResponse.getResultList(),
-                    searchRequest.getAccessGroups());
+                    principals);
 
             if (searchRequest.isRetrieveFacets()) {
-                SearchRequest facetRequest = new SearchRequest(searchState, true);
+                SearchRequest facetRequest = new SearchRequest(searchState, principals, true);
                 facetRequest.setApplyCutoffs(false);
                 if (resultResponse.getSelectedContainer() != null) {
                     SearchState facetState = (SearchState) searchState.clone();
@@ -171,7 +173,7 @@ public class SearchActionController extends AbstractSolrSearchController {
 
         model.addAttribute("searchStateUrl", SearchStateUtil.generateStateParameterString(searchState));
         model.addAttribute("searchQueryUrl", SearchStateUtil.generateSearchParameterString(searchState));
-        model.addAttribute("userAccessGroups", searchRequest.getAccessGroups());
+        model.addAttribute("userAccessGroups", principals);
         model.addAttribute("resultResponse", resultResponse);
 
         return resultResponse;

--- a/admin/src/main/java/edu/unc/lib/dl/admin/controller/DashboardController.java
+++ b/admin/src/main/java/edu/unc/lib/dl/admin/controller/DashboardController.java
@@ -15,6 +15,8 @@
  */
 package edu.unc.lib.dl.admin.controller;
 
+import static edu.unc.lib.dl.acl.util.GroupsThreadStore.getAgentPrincipals;
+
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.solr.client.solrj.SolrQuery;
@@ -59,10 +61,8 @@ public class DashboardController extends AbstractSolrSearchController {
         depthFacet.setCutoff(FACET_CUTOFF);
         collectionsState.getFacets().put(SearchFieldKeys.ANCESTOR_PATH.name(), depthFacet);
 
-        AccessGroupSet accessGroups = GroupsThreadStore.getGroups();
-        SearchRequest searchRequest = new SearchRequest();
-        searchRequest.setAccessGroups(accessGroups);
-        searchRequest.setSearchState(collectionsState);
+        AccessGroupSet accessGroups = getAgentPrincipals().getPrincipals();
+        SearchRequest searchRequest = new SearchRequest(collectionsState, accessGroups);
 
         SearchResultResponse resultResponse = queryLayer.getSearchResults(searchRequest);
         // Get children counts

--- a/admin/src/main/java/edu/unc/lib/dl/admin/controller/ExportController.java
+++ b/admin/src/main/java/edu/unc/lib/dl/admin/controller/ExportController.java
@@ -82,7 +82,8 @@ public class ExportController extends AbstractSolrSearchController {
         searchState.setSortType("export");
         searchState.setRowsPerPage(searchSettings.maxPerPage);
 
-        BriefObjectMetadata container = queryLayer.addSelectedContainer(pid, searchState, false);
+        BriefObjectMetadata container = queryLayer.addSelectedContainer(pid, searchState, false,
+                searchRequest.getAccessGroups());
         SearchResultResponse resultResponse = queryLayer.getSearchResults(searchRequest);
 
         List<BriefObjectMetadata> objects = resultResponse.getResultList();

--- a/admin/src/main/java/edu/unc/lib/dl/admin/controller/ExportController.java
+++ b/admin/src/main/java/edu/unc/lib/dl/admin/controller/ExportController.java
@@ -37,6 +37,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
+import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.search.solr.model.BriefObjectMetadata;
 import edu.unc.lib.dl.search.solr.model.Datastream;
 import edu.unc.lib.dl.search.solr.model.SearchRequest;
@@ -64,9 +66,10 @@ public class ExportController extends AbstractSolrSearchController {
     protected SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd kk:mm:ss");
 
     @RequestMapping(value = "{pid}", method = RequestMethod.GET)
-    public void export(@PathVariable("pid") String pid, HttpServletRequest request,
+    public void export(@PathVariable("pid") String pidString, HttpServletRequest request,
             HttpServletResponse response) throws IOException {
-        String filename = pid.replace(":", "_") + ".csv";
+        PID pid = PIDs.get(pidString);
+        String filename = pid.getId().replace(":", "_") + ".csv";
         response.addHeader("Content-Disposition", "attachment; filename=\"" + filename + "\"");
         response.addHeader("Content-Type", "text/csv");
 

--- a/admin/src/main/java/edu/unc/lib/dl/admin/controller/VocabularyController.java
+++ b/admin/src/main/java/edu/unc/lib/dl/admin/controller/VocabularyController.java
@@ -82,12 +82,12 @@ public class VocabularyController extends AbstractSearchController {
     }
 
     public Map<String, Object> getInvalidVocab(SearchRequest searchRequest) {
-        AccessGroupSet groups = GroupsThreadStore.getGroups();
+        AccessGroupSet groups = GroupsThreadStore.getAgentPrincipals().getPrincipals();
 
-        BriefObjectMetadata selectedContainer =
-                queryLayer.addSelectedContainer(searchRequest.getRootPid(), searchRequest.getSearchState(), false);
+        BriefObjectMetadata selectedContainer = queryLayer.addSelectedContainer(searchRequest.getRootPid(),
+                searchRequest.getSearchState(), false, groups);
 
-        Map<String, Object> results = new LinkedHashMap<String, Object>();
+        Map<String, Object> results = new LinkedHashMap<>();
 
         Map<String, Object> vocabResults = new HashMap<>();
 

--- a/etc/server.properties
+++ b/etc/server.properties
@@ -22,8 +22,6 @@ fedora.host=localhost
 fedora.context=fedora
 fedora.activemq.data=
 
-fcrepo.baseUrl=http://localhost:8080/fedora
-
 fedora.admin.username=fedoraAdmin
 fedora.admin.password=fedoraAdmin
 fedora.appUser.username=fedoraAdmin

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/SearchRestController.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/SearchRestController.java
@@ -15,6 +15,8 @@
  */
 package edu.unc.lib.dl.cdr.services.rest;
 
+import static edu.unc.lib.dl.acl.util.GroupsThreadStore.getAgentPrincipals;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -151,7 +153,7 @@ public class SearchRestController extends AbstractSolrSearchController {
             HttpServletRequest request, HttpServletResponse response) {
         List<String> resultFields = this.getResultFields(request);
 
-        SimpleIdRequest idRequest = new SimpleIdRequest(id, resultFields);
+        SimpleIdRequest idRequest = new SimpleIdRequest(id, resultFields, getAgentPrincipals().getPrincipals());
         BriefObjectMetadataBean briefObject = queryLayer.getObjectById(idRequest);
         if (briefObject == null) {
             response.setStatus(404);

--- a/solr-search/src/main/java/edu/unc/lib/dl/search/solr/model/HierarchicalBrowseRequest.java
+++ b/solr-search/src/main/java/edu/unc/lib/dl/search/solr/model/HierarchicalBrowseRequest.java
@@ -18,7 +18,7 @@ package edu.unc.lib.dl.search.solr.model;
 import edu.unc.lib.dl.acl.util.AccessGroupSet;
 
 /**
- * 
+ *
  * @author bbpennel
  *
  */
@@ -27,8 +27,8 @@ public class HierarchicalBrowseRequest extends SearchRequest {
     private int retrievalDepth;
     private boolean includeFiles;
 
-    public HierarchicalBrowseRequest(int retrievalDepth) {
-        this.retrievalDepth = retrievalDepth;
+    public HierarchicalBrowseRequest(int retrievalDepth, AccessGroupSet accessGroups) {
+        this(null, retrievalDepth, accessGroups);
     }
 
     public HierarchicalBrowseRequest(SearchState searchState, int retrievalDepth, AccessGroupSet accessGroups) {

--- a/solr-search/src/main/java/edu/unc/lib/dl/search/solr/model/IdListRequest.java
+++ b/solr-search/src/main/java/edu/unc/lib/dl/search/solr/model/IdListRequest.java
@@ -18,6 +18,7 @@ package edu.unc.lib.dl.search.solr.model;
 import java.util.List;
 
 import edu.unc.lib.dl.acl.util.AccessGroupSet;
+import edu.unc.lib.dl.fedora.PID;
 
 /**
  * 
@@ -28,7 +29,7 @@ public class IdListRequest extends SimpleIdRequest {
     private List<String> ids;
 
     public IdListRequest(List<String> ids, List<String> resultFields, AccessGroupSet accessGroups) {
-        super(resultFields, accessGroups);
+        super((PID) null, resultFields, accessGroups);
         this.ids = ids;
     }
 

--- a/solr-search/src/main/java/edu/unc/lib/dl/search/solr/model/SearchRequest.java
+++ b/solr-search/src/main/java/edu/unc/lib/dl/search/solr/model/SearchRequest.java
@@ -18,10 +18,12 @@ package edu.unc.lib.dl.search.solr.model;
 import java.io.Serializable;
 
 import edu.unc.lib.dl.acl.util.AccessGroupSet;
+import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fedora.PID;
 
 /**
  * Request bean for a brief record search. Handles basic searches and advanced searches.
- * 
+ *
  * @author bbpennel
  */
 public class SearchRequest implements Serializable {
@@ -31,42 +33,31 @@ public class SearchRequest implements Serializable {
     private boolean retrieveFacets;
     private boolean applyCutoffs;
     protected AccessGroupSet accessGroups;
-    protected String rootPid;
+    protected String rootId;
+    protected PID rootPid;
 
     public SearchRequest() {
-        searchState = null;
-        accessGroups = null;
-        applyCutoffs = true;
-        retrieveFacets = false;
-        rootPid = null;
+        this((PID) null, null, null, false);
     }
 
     public SearchRequest(SearchState searchState, AccessGroupSet accessGroups) {
-        setSearchState(searchState);
-        setAccessGroups(accessGroups);
-        applyCutoffs = true;
-        retrieveFacets = false;
+        this((PID) null, searchState, accessGroups, false);
     }
 
     public SearchRequest(String rootPid, SearchState searchState, AccessGroupSet accessGroups) {
-        setSearchState(searchState);
-        setAccessGroups(accessGroups);
-        applyCutoffs = true;
-        retrieveFacets = false;
-        this.rootPid = rootPid;
-    }
-
-    public SearchRequest(SearchState searchState, boolean retrieveFacets) {
-        this();
-        setSearchState(searchState);
-        this.retrieveFacets = retrieveFacets;
+        this(PIDs.get(rootPid), searchState, accessGroups, false);
     }
 
     public SearchRequest(SearchState searchState, AccessGroupSet accessGroups, boolean retrieveFacets) {
+        this((PID) null, searchState, accessGroups, retrieveFacets);
+    }
+
+    public SearchRequest(PID rootPid, SearchState searchState, AccessGroupSet accessGroups, boolean retrieveFacets) {
         setSearchState(searchState);
         setAccessGroups(accessGroups);
         applyCutoffs = true;
         this.retrieveFacets = retrieveFacets;
+        this.rootPid = rootPid;
     }
 
     public SearchState getSearchState() {
@@ -93,12 +84,22 @@ public class SearchRequest implements Serializable {
         this.applyCutoffs = applyCutoffs;
     }
 
-    public String getRootPid() {
+    /**
+     * @return the rootPid
+     */
+    public PID getRootPid() {
         return rootPid;
     }
 
-    public void setRootPid(String rootPid) {
+    /**
+     * @param rootPid the rootPid to set
+     */
+    public void setRootPid(PID rootPid) {
         this.rootPid = rootPid;
+    }
+
+    public void setRootPid(String rootId) {
+        this.rootPid = PIDs.get(rootId);
     }
 
     public boolean isRetrieveFacets() {

--- a/solr-search/src/main/java/edu/unc/lib/dl/search/solr/model/SimpleIdRequest.java
+++ b/solr-search/src/main/java/edu/unc/lib/dl/search/solr/model/SimpleIdRequest.java
@@ -18,54 +18,53 @@ package edu.unc.lib.dl.search.solr.model;
 import java.util.List;
 
 import edu.unc.lib.dl.acl.util.AccessGroupSet;
+import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fedora.PID;
 
 /**
  * Request object for a single ID along with access restrictions and requested result data.
  * @author bbpennel
  */
 public class SimpleIdRequest {
-    protected String id;
+    protected final PID pid;
     protected List<String> resultFields;
-    protected AccessGroupSet accessGroups;
-
-    public SimpleIdRequest(String id) {
-        this.id = id;
-    }
-
-    public SimpleIdRequest(List<String> resultFields, AccessGroupSet accessGroups) {
-        this.accessGroups = accessGroups;
-        this.resultFields = resultFields;
-    }
-
-    public SimpleIdRequest(String id, List<String> resultFields) {
-        this.id = id;
-        this.resultFields = resultFields;
-    }
-
-    public SimpleIdRequest(String id, List<String> resultFields, AccessGroupSet accessGroups) {
-        this.id = id;
-        this.accessGroups = accessGroups;
-        this.resultFields = resultFields;
-    }
+    protected final AccessGroupSet accessGroups;
 
     public SimpleIdRequest(String id, AccessGroupSet accessGroups) {
         this(id, null, accessGroups);
     }
 
-    public String getId() {
-        return id;
+    public SimpleIdRequest(PID pid, AccessGroupSet accessGroups) {
+        this(pid, null, accessGroups);
     }
 
-    public void setId(String id) {
-        this.id = id;
+    protected SimpleIdRequest(List<String> resultFields, AccessGroupSet accessGroups) {
+        this((PID) null, resultFields, accessGroups);
+    }
+
+    public SimpleIdRequest(String id, List<String> resultFields, AccessGroupSet accessGroups) {
+        this(PIDs.get(id), resultFields, accessGroups);
+    }
+
+    public SimpleIdRequest(PID pid, List<String> resultFields, AccessGroupSet accessGroups) {
+        this.pid = pid;
+        this.accessGroups = accessGroups;
+        this.resultFields = resultFields;
+    }
+
+    /**
+     * @return the pid
+     */
+    public PID getPid() {
+        return pid;
+    }
+
+    public String getId() {
+        return pid.getId();
     }
 
     public AccessGroupSet getAccessGroups() {
         return accessGroups;
-    }
-
-    public void setAccessGroups(AccessGroupSet accessGroups) {
-        this.accessGroups = accessGroups;
     }
 
     public List<String> getResultFields() {

--- a/solr-search/src/main/java/edu/unc/lib/dl/search/solr/model/SimpleIdRequest.java
+++ b/solr-search/src/main/java/edu/unc/lib/dl/search/solr/model/SimpleIdRequest.java
@@ -38,10 +38,6 @@ public class SimpleIdRequest {
         this(pid, null, accessGroups);
     }
 
-    protected SimpleIdRequest(List<String> resultFields, AccessGroupSet accessGroups) {
-        this((PID) null, resultFields, accessGroups);
-    }
-
     public SimpleIdRequest(String id, List<String> resultFields, AccessGroupSet accessGroups) {
         this(PIDs.get(id), resultFields, accessGroups);
     }

--- a/solr-search/src/main/java/edu/unc/lib/dl/search/solr/service/ObjectPathFactory.java
+++ b/solr-search/src/main/java/edu/unc/lib/dl/search/solr/service/ObjectPathFactory.java
@@ -97,7 +97,7 @@ public class ObjectPathFactory {
      * @return path
      */
     public ObjectPath getPath(PID pid) {
-        SimpleIdRequest idRequest = new SimpleIdRequest(pid.getId(), startObjectFields);
+        SimpleIdRequest idRequest = new SimpleIdRequest(pid, startObjectFields, null);
         BriefObjectMetadata bom = search.getObjectById(idRequest);
         return getPath(bom);
     }

--- a/solr-search/src/main/java/edu/unc/lib/dl/search/solr/service/SolrSearchService.java
+++ b/solr-search/src/main/java/edu/unc/lib/dl/search/solr/service/SolrSearchService.java
@@ -277,8 +277,8 @@ public class SolrSearchService extends AbstractQueryService {
     }
 
     public BriefObjectMetadata addSelectedContainer(String containerPid, SearchState searchState,
-            boolean applyCutoffs) {
-        BriefObjectMetadata selectedContainer = getObjectById(new SimpleIdRequest(containerPid));
+            boolean applyCutoffs, AccessGroupSet principals) {
+        BriefObjectMetadata selectedContainer = getObjectById(new SimpleIdRequest(containerPid, principals));
         if (selectedContainer == null) {
             return null;
         }

--- a/solr-search/src/main/java/edu/unc/lib/dl/search/solr/service/SolrSearchService.java
+++ b/solr-search/src/main/java/edu/unc/lib/dl/search/solr/service/SolrSearchService.java
@@ -42,6 +42,7 @@ import edu.unc.lib.dl.acl.exception.AccessRestrictionException;
 import edu.unc.lib.dl.acl.util.AccessGroupSet;
 import edu.unc.lib.dl.acl.util.Permission;
 import edu.unc.lib.dl.acl.util.UserRole;
+import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.search.solr.model.BriefObjectMetadata;
 import edu.unc.lib.dl.search.solr.model.BriefObjectMetadataBean;
 import edu.unc.lib.dl.search.solr.model.CutoffFacet;
@@ -276,7 +277,7 @@ public class SolrSearchService extends AbstractQueryService {
         return rootNode.getAncestorPathFacet();
     }
 
-    public BriefObjectMetadata addSelectedContainer(String containerPid, SearchState searchState,
+    public BriefObjectMetadata addSelectedContainer(PID containerPid, SearchState searchState,
             boolean applyCutoffs, AccessGroupSet principals) {
         BriefObjectMetadata selectedContainer = getObjectById(new SimpleIdRequest(containerPid, principals));
         if (selectedContainer == null) {

--- a/solr-search/src/main/java/edu/unc/lib/dl/search/solr/service/StructureQueryService.java
+++ b/solr-search/src/main/java/edu/unc/lib/dl/search/solr/service/StructureQueryService.java
@@ -37,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import edu.unc.lib.dl.acl.util.AccessGroupSet;
+import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.search.solr.exception.SolrRuntimeException;
 import edu.unc.lib.dl.search.solr.model.BriefObjectMetadata;
 import edu.unc.lib.dl.search.solr.model.BriefObjectMetadataBean;
@@ -152,10 +153,10 @@ public class StructureQueryService extends AbstractQueryService {
      * Gets metadata for the requested root object. Defaults to the root of the
      * content tree if no rootId is provided.
      */
-    private BriefObjectMetadata getRootMetadata(String rootId, AccessGroupSet principals) {
+    private BriefObjectMetadata getRootMetadata(PID rootPid, AccessGroupSet principals) {
         BriefObjectMetadata rootNode = null;
-        if (rootId != null) {
-            rootNode = searchService.getObjectById(new SimpleIdRequest(rootId, principals));
+        if (rootPid != null) {
+            rootNode = searchService.getObjectById(new SimpleIdRequest(rootPid, principals));
         }
         // Default the root to the collections object so we always have a root
         if (rootNode == null) {
@@ -284,7 +285,7 @@ public class StructureQueryService extends AbstractQueryService {
             SearchState browseState = browseRequest.getSearchState();
             browseResults.setMatchingContainerPids(getDirectContainerMatches(browseState,
                     browseRequest.getAccessGroups()));
-            browseResults.getMatchingContainerPids().add(browseRequest.getRootPid());
+            browseResults.getMatchingContainerPids().add(browseRequest.getRootPid().getId());
             // Remove all containers that are not direct matches for the user's query and have 0 children
             browseResults.removeContainersWithoutContents();
         } catch (SolrServerException e) {
@@ -306,6 +307,7 @@ public class StructureQueryService extends AbstractQueryService {
         SearchRequest directMatchRequest = new SearchRequest(directMatchState, accessGroups, false);
         SolrQuery directMatchQuery = searchService.generateSearch(directMatchRequest);
         QueryResponse directMatchResponse = this.executeQuery(directMatchQuery);
+
         String idField = solrField(SearchFieldKeys.ID);
         Set<String> directMatchIds = new HashSet<>(directMatchResponse.getResults().size());
         for (SolrDocument document : directMatchResponse.getResults()) {
@@ -317,7 +319,7 @@ public class StructureQueryService extends AbstractQueryService {
     /*
      * Returns the path facet of the object identified by pid.
      */
-    private CutoffFacet getObjectPath(String pid, AccessGroupSet accessGroups) {
+    private CutoffFacet getObjectPath(PID pid, AccessGroupSet accessGroups) {
         List<String> resultFields = asList(SearchFieldKeys.ID.name(), ANCESTOR_PATH.name());
         SimpleIdRequest idRequest = new SimpleIdRequest(pid, resultFields, accessGroups);
 

--- a/solr-search/src/test/java/edu/unc/lib/dl/search/solr/service/ObjectPathFactoryIT.java
+++ b/solr-search/src/test/java/edu/unc/lib/dl/search/solr/service/ObjectPathFactoryIT.java
@@ -112,7 +112,7 @@ public class ObjectPathFactoryIT extends BaseEmbeddedSolrTest {
 
     @Test
     public void testGetPathByMetadata() throws Exception {
-        BriefObjectMetadata bom = solrSearchService.getObjectById(new SimpleIdRequest(testCorpus.coll1Pid.getId()));
+        BriefObjectMetadata bom = solrSearchService.getObjectById(new SimpleIdRequest(testCorpus.coll1Pid, null));
 
         ObjectPath path = objPathFactory.getPath(bom);
 

--- a/solr-search/src/test/java/edu/unc/lib/dl/search/solr/service/StructureQueryServiceIT.java
+++ b/solr-search/src/test/java/edu/unc/lib/dl/search/solr/service/StructureQueryServiceIT.java
@@ -324,10 +324,9 @@ public class StructureQueryServiceIT extends BaseEmbeddedSolrTest {
     }
 
     private HierarchicalBrowseRequest makeRequest(PID rootPid) {
-        HierarchicalBrowseRequest browseRequest = new HierarchicalBrowseRequest(1);
-        browseRequest.setAccessGroups(principals);
+        HierarchicalBrowseRequest browseRequest = new HierarchicalBrowseRequest(1, principals);
         browseRequest.setSearchState(new SearchState());
-        browseRequest.setRootPid(rootPid.getId());
+        browseRequest.setRootPid(rootPid);
 
         return browseRequest;
     }


### PR DESCRIPTION
* Fixes permission issue that was preventing filtering to specific containers from working
* Solr queries depending on search requests to provide access groups consistently
* Using PID class in solr search requests for better control over formatting of ids.
* Removed duplicate fcrepo.baseUri to fix issue retrieving info from fedora in access interface