### PR TITLE
Bxc 2147 - Download of original file

### DIFF
--- a/access-common/pom.xml
+++ b/access-common/pom.xml
@@ -113,6 +113,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>edu.unc.lib.cdr</groupId>
+            <artifactId>fcrepo-clients</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.solr</groupId>
             <artifactId>solr-core</artifactId>
             <version>${solr.version}</version>

--- a/access-common/src/main/java/edu/unc/lib/dl/ui/util/AnalyticsTrackerUtil.java
+++ b/access-common/src/main/java/edu/unc/lib/dl/ui/util/AnalyticsTrackerUtil.java
@@ -124,6 +124,13 @@ public class AnalyticsTrackerUtil {
         trackerThread.start();
     }
 
+    /**
+     * @param solrSearchService the solrSearchService to set
+     */
+    public void setSolrSearchService(SolrSearchService solrSearchService) {
+        this.solrSearchService = solrSearchService;
+    }
+
     public static class AnalyticsUserData {
         public String uip;
         public String cid;

--- a/access-common/src/main/java/edu/unc/lib/dl/ui/util/AnalyticsTrackerUtil.java
+++ b/access-common/src/main/java/edu/unc/lib/dl/ui/util/AnalyticsTrackerUtil.java
@@ -96,16 +96,18 @@ public class AnalyticsTrackerUtil {
      * @param request request
      * @param action action for the event
      * @param pid pid identifying the object involved in the event
-     * @param principals
+     * @param principals authorization principals
      */
     public void trackEvent(HttpServletRequest request, String action, PID pid, AccessGroupSet principals) {
         try {
             AnalyticsUserData userData = new AnalyticsUserData(request);
 
             BriefObjectMetadata briefObject = solrSearchService.getObjectById(new SimpleIdRequest(pid, principals));
-            trackEvent(userData, briefObject.getParentCollection() == null ? "(no collection)"
-                  : briefObject.getParentCollectionName(),
-                  "download", briefObject.getTitle() + "|" + pid, null);
+            String parentCollection = briefObject.getParentCollection() == null ?
+                    "(no collection)"
+                    : briefObject.getParentCollectionName();
+            String viewedObjectLabel = briefObject.getTitle() + "|" + pid;
+            trackEvent(userData, parentCollection, "download", viewedObjectLabel, null);
         } catch (Exception e) {
             // Prevent analytics exceptions from impacting user
             log.warn("An exception occurred while recording {} event on {}", action, pid, e);
@@ -132,7 +134,9 @@ public class AnalyticsTrackerUtil {
     }
 
     public static class AnalyticsUserData {
+        // ip of client
         public String uip;
+        // client id
         public String cid;
         public String userAgent;
 
@@ -213,6 +217,7 @@ public class AnalyticsTrackerUtil {
                 return;
             }
 
+            // See https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters
             List<NameValuePair> params = new ArrayList<>();
             params.add(new BasicNameValuePair("v", "1"));
             params.add(new BasicNameValuePair("tid", gaTrackingID));

--- a/access-common/src/main/java/edu/unc/lib/dl/ui/util/AnalyticsTrackerUtil.java
+++ b/access-common/src/main/java/edu/unc/lib/dl/ui/util/AnalyticsTrackerUtil.java
@@ -37,6 +37,12 @@ import org.apache.http.message.BasicNameValuePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import edu.unc.lib.dl.acl.util.AccessGroupSet;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.search.solr.model.BriefObjectMetadata;
+import edu.unc.lib.dl.search.solr.model.SimpleIdRequest;
+import edu.unc.lib.dl.search.solr.service.SolrSearchService;
+
 /**
  * Utility for performing asynchronous analytics tracking events when unable to use the javascript api
  *
@@ -57,6 +63,8 @@ public class AnalyticsTrackerUtil {
 
     private final HttpClientConnectionManager httpManager;
     private final CloseableHttpClient httpClient;
+
+    private SolrSearchService solrSearchService;
 
     public AnalyticsTrackerUtil() {
 
@@ -80,6 +88,28 @@ public class AnalyticsTrackerUtil {
 
     public void setGaTrackingID(String trackingID) {
         this.gaTrackingID = trackingID;
+    }
+
+    /**
+     * Track an event with the specified action for object pid for the active user on the request.
+     *
+     * @param request request
+     * @param action action for the event
+     * @param pid pid identifying the object involved in the event
+     * @param principals
+     */
+    public void trackEvent(HttpServletRequest request, String action, PID pid, AccessGroupSet principals) {
+        try {
+            AnalyticsUserData userData = new AnalyticsUserData(request);
+
+            BriefObjectMetadata briefObject = solrSearchService.getObjectById(new SimpleIdRequest(pid, principals));
+            trackEvent(userData, briefObject.getParentCollection() == null ? "(no collection)"
+                  : briefObject.getParentCollectionName(),
+                  "download", briefObject.getTitle() + "|" + pid, null);
+        } catch (Exception e) {
+            // Prevent analytics exceptions from impacting user
+            log.warn("An exception occurred while recording {} event on {}", action, pid, e);
+        }
     }
 
     public void trackEvent(AnalyticsUserData userData, String category, String action, String label, Integer value) {
@@ -165,7 +195,7 @@ public class AnalyticsTrackerUtil {
         public void run() {
             if (log.isDebugEnabled()) {
                 log.debug("Tracking user {} with event {} in category {} with label {}",
-                        new String[] { userData.cid, action, category, label });
+                        userData.cid, action, category, label);
             }
 
             URIBuilder builder;
@@ -187,7 +217,7 @@ public class AnalyticsTrackerUtil {
             params.add(new BasicNameValuePair("de", "UTF-8"));
             params.add(new BasicNameValuePair("ul", "en-us"));
             log.debug("Tracking user {} with event {} in category {} with label {}",
-                    new String[] { userData.cid, action, category, label });
+                    userData.cid, action, category, label);
             log.debug("Tracking:{} {} {} {}", new Object[] { GA_URL, gaTrackingID, userData.cid, userData.uip});
 
             if (category != null) {

--- a/access-common/src/main/java/edu/unc/lib/dl/ui/util/DatastreamUtil.java
+++ b/access-common/src/main/java/edu/unc/lib/dl/ui/util/DatastreamUtil.java
@@ -67,7 +67,7 @@ public class DatastreamUtil {
         } else {
             url.append(preferredDS.getOwner());
         }
-        if (!ORIGINAL_FILE.equals(datastreamName)) {
+        if (!ORIGINAL_FILE.equals(preferredDS.getName())) {
             url.append("/").append(preferredDS.getName());
         }
         return url.toString();

--- a/access-common/src/main/resources/META-INF/cdrUI.tld
+++ b/access-common/src/main/resources/META-INF/cdrUI.tld
@@ -57,14 +57,21 @@
 	</function>
 	<function>
 		<name>getDatastreamUrl</name>
-		<function-class>edu.unc.lib.dl.ui.util.FedoraUtil</function-class>
+		<function-class>edu.unc.lib.dl.ui.util.DatastreamUtil</function-class>
 		<function-signature>
-			java.lang.String getDatastreamUrl(java.lang.Object, java.lang.String, edu.unc.lib.dl.ui.util.FedoraUtil)
+			java.lang.String getDatastreamUrl(edu.unc.lib.dl.search.solr.model.BriefObjectMetadata, java.lang.String)
+		</function-signature>
+	</function>
+	<function>
+		<name>getOriginalFileUrl</name>
+		<function-class>edu.unc.lib.dl.ui.util.DatastreamUtil</function-class>
+		<function-signature>
+			java.lang.String getOriginalFileUrl(edu.unc.lib.dl.search.solr.model.BriefObjectMetadata)
 		</function-signature>
 	</function>
 	<function>
 		<name>getPreferredDatastream</name>
-		<function-class>edu.unc.lib.dl.ui.util.FedoraUtil</function-class>
+		<function-class>edu.unc.lib.dl.ui.util.DatastreamUtil</function-class>
 		<function-signature>
 			edu.unc.lib.dl.search.solr.model.Datastream getPreferredDatastream(edu.unc.lib.dl.search.solr.model.BriefObjectMetadata, java.lang.String)
 		</function-signature>

--- a/access-common/src/test/java/edu/unc/lib/dl/ui/util/DatastreamUtilTest.java
+++ b/access-common/src/test/java/edu/unc/lib/dl/ui/util/DatastreamUtilTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.ui.util;
+
+import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.ORIGINAL_FILE;
+import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.TECHNICAL_METADATA;
+import static edu.unc.lib.dl.test.TestHelper.makePid;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.search.solr.model.BriefObjectMetadataBean;
+
+/**
+ *
+ * @author bbpennel
+ *
+ */
+public class DatastreamUtilTest {
+
+    private final static String ORIGINAL_DS = ORIGINAL_FILE + "|image/jpg|image|jpg|555||";
+    private final static String ORIGINAL_INDEXABLE = ORIGINAL_FILE + "|application/pdf|doc.pdf|pdf|5555||";
+    private final static String FITS_DS = TECHNICAL_METADATA + "|text/xml|fits.xml|xml|5555||";
+
+    @Test
+    public void testGetOriginalFileUrl() {
+        PID pid = makePid();
+        BriefObjectMetadataBean mdObj = new BriefObjectMetadataBean();
+        mdObj.setId(pid.getId());
+        mdObj.setDatastream(asList(ORIGINAL_DS));
+
+        String url = DatastreamUtil.getOriginalFileUrl(mdObj);
+        assertEquals("content/" + pid.getId(), url);
+    }
+
+    @Test
+    public void testGetOriginalFileIndexableUrl() {
+        PID pid = makePid();
+        BriefObjectMetadataBean mdObj = new BriefObjectMetadataBean();
+        mdObj.setId(pid.getId());
+        mdObj.setDatastream(asList(ORIGINAL_INDEXABLE));
+
+        String url = DatastreamUtil.getOriginalFileUrl(mdObj);
+        assertEquals("indexablecontent/" + pid.getId(), url);
+    }
+
+    @Test
+    public void testGetDatastreamUrl() {
+        PID pid = makePid();
+        BriefObjectMetadataBean mdObj = new BriefObjectMetadataBean();
+        mdObj.setId(pid.getId());
+        mdObj.setDatastream(asList(FITS_DS));
+
+        String url = DatastreamUtil.getDatastreamUrl(mdObj, TECHNICAL_METADATA);
+        assertEquals("indexablecontent/" + pid.getId() + "/techmd_fits", url);
+    }
+}

--- a/access-common/src/test/java/edu/unc/lib/dl/ui/util/SerializationUtilTest.java
+++ b/access-common/src/test/java/edu/unc/lib/dl/ui/util/SerializationUtilTest.java
@@ -46,7 +46,7 @@ import edu.unc.lib.dl.search.solr.util.SolrSettings;
 @RunWith(MockitoJUnitRunner.class)
 public class SerializationUtilTest extends Assert {
     private static final List<String> DATASTREAMS =
-            singletonList("datastream|image/jpeg|jpg|orig|582753|");
+            singletonList("datastream|image/jpeg|image.jpg|jpg|orig|582753|");
 
     private static final String API_PATH = "http://example.com/api/";
 

--- a/access/pom.xml
+++ b/access/pom.xml
@@ -94,6 +94,27 @@
                     </webResources>
                 </configuration>
             </plugin>
+            
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <!--Set reuseForks=false due to the need for different instances of the -->
+                    <!--Singleton ServletContainerAuthenticationProvider -->
+                    <reuseForks>false</reuseForks>
+                    <argLine>${jacoco.agent.it.arg}</argLine>
+                    <systemPropertyVariables>
+                        <project.build.outputDirectory>${project.build.outputDirectory}</project.build.outputDirectory>
+                    </systemPropertyVariables>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <dependencies>
@@ -225,6 +246,18 @@
             <version>${spring.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>edu.unc.lib.cdr</groupId>
+            <artifactId>metadata</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>edu.unc.lib.cdr</groupId>
+            <artifactId>fcrepo-clients</artifactId>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
 
         <!-- CDR -->
         <dependency>
@@ -251,6 +284,88 @@
             <groupId>edu.unc.lib.cdr</groupId>
             <artifactId>solr-search</artifactId>
             <version>${cdr.version}</version>
+        </dependency>
+        <!-- integration testing -->
+        <dependency>
+            <groupId>org.fcrepo</groupId>
+            <artifactId>fcrepo-http-commons</artifactId>
+            <version>${fcrepo4.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.fcrepo</groupId>
+            <artifactId>fcrepo-auth-common</artifactId>
+            <version>${fcrepo4.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.grizzly</groupId>
+            <artifactId>grizzly-http-servlet</artifactId>
+            <version>${grizzly.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
+            <version>${jersey.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.ext</groupId>
+            <artifactId>jersey-spring3</artifactId>
+            <version>${jersey.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.test-framework.providers</groupId>
+            <artifactId>jersey-test-framework-provider-grizzly2</artifactId>
+            <version>${jersey.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mock-server</groupId>
+            <artifactId>mockserver-client-java</artifactId>
+            <version>${mock.server.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mock-server</groupId>
+            <artifactId>mockserver-netty</artifactId>
+            <version>${mock.server.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.fcrepo</groupId>
+            <artifactId>fcrepo-kernel-modeshape</artifactId>
+            <version>${fcrepo4.version}</version>
+            <scope>test</scope>
+            <classifier>tests</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.fcrepo</groupId>
+            <artifactId>fcrepo-http-api</artifactId>
+            <version>${fcrepo4.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.fcrepo</groupId>
+            <artifactId>fcrepo-http-commons</artifactId>
+            <version>${fcrepo4.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
+            <groupId>org.fcrepo</groupId>
+            <artifactId>fcrepo-auth-common</artifactId>
+            <version>${fcrepo4.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/access/src/main/java/edu/unc/lib/dl/ui/controller/FedoraContentController.java
+++ b/access/src/main/java/edu/unc/lib/dl/ui/controller/FedoraContentController.java
@@ -60,42 +60,21 @@ public class FedoraContentController {
     @Autowired
     private AnalyticsTrackerUtil analyticsTracker;
 
-    @RequestMapping("/indexablecontent/{pid}")
-    public void getDefaultIndexableContent(@PathVariable("pid") String pid,
-            @RequestParam(value = "dl", defaultValue = "false") boolean download,
-            HttpServletRequest request, HttpServletResponse response) {
-        streamData(pid, ORIGINAL_FILE, download, request, response);
-    }
-
-    @RequestMapping("/indexablecontent/{pid}/{datastream}")
-    public void getIndexableContent(@PathVariable("pid") String pid, @PathVariable("datastream") String datastream,
-            @RequestParam(value = "dl", defaultValue = "false") boolean download,
-            HttpServletRequest request, HttpServletResponse response) {
-        streamData(pid, datastream, download, request, response);
-    }
-
-    @RequestMapping("/indexablecontent")
-    public void getIndexableContentByParameters(@RequestParam("id") String id, @RequestParam("ds") String datastream,
-            @RequestParam(value = "dl", defaultValue = "false") boolean download,
-            HttpServletRequest request, HttpServletResponse response) {
-        streamData(id, ORIGINAL_FILE, download, request, response);
-    }
-
-    @RequestMapping("/content/{pid}")
+    @RequestMapping(value = {"/content/{pid}", "/indexablecontent/{pid}"})
     public void getDefaultDatastream(@PathVariable("pid") String pid,
             @RequestParam(value = "dl", defaultValue = "false") boolean download,
             HttpServletRequest request, HttpServletResponse response) {
         streamData(pid, ORIGINAL_FILE, download, request, response);
     }
 
-    @RequestMapping("/content/{pid}/{datastream}")
+    @RequestMapping(value = {"/content/{pid}/{datastream}", "/indexablecontent/{pid}/{datastream}"})
     public void getDatastream(@PathVariable("pid") String pid, @PathVariable("datastream") String datastream,
             @RequestParam(value = "dl", defaultValue = "false") boolean download,
             HttpServletRequest request, HttpServletResponse response) {
         streamData(pid, datastream, download, request, response);
     }
 
-    @RequestMapping("/content")
+    @RequestMapping(value = {"/indexablecontent", "/content"})
     public void getDatastreamByParameters(@RequestParam("id") String id, @RequestParam("ds") String datastream,
             @RequestParam(value = "dl", defaultValue = "false") boolean download,
             HttpServletRequest request, HttpServletResponse response) {

--- a/access/src/main/java/edu/unc/lib/dl/ui/controller/FedoraContentController.java
+++ b/access/src/main/java/edu/unc/lib/dl/ui/controller/FedoraContentController.java
@@ -15,9 +15,18 @@
  */
 package edu.unc.lib.dl.ui.controller;
 
+import static edu.unc.lib.dl.acl.util.GroupsThreadStore.getAgentPrincipals;
+import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.ORIGINAL_FILE;
+
+import java.io.IOException;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -26,8 +35,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-import edu.unc.lib.dl.ui.exception.InvalidRecordRequestException;
+import edu.unc.lib.dl.acl.exception.AccessRestrictionException;
+import edu.unc.lib.dl.acl.util.AccessGroupSet;
+import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fedora.NotFoundException;
+import edu.unc.lib.dl.fedora.ObjectTypeMismatchException;
+import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.ui.exception.ResourceNotFoundException;
+import edu.unc.lib.dl.ui.service.FedoraContentService;
+import edu.unc.lib.dl.ui.util.AnalyticsTrackerUtil;
 
 /**
  * Controller which handles requests for specific content datastreams from Fedora and streams the results back as the
@@ -37,63 +53,93 @@ import edu.unc.lib.dl.ui.exception.ResourceNotFoundException;
  */
 @Controller
 public class FedoraContentController {
-//    @Autowired
-//    private FedoraContentService fedoraContentService;
+    private static final Logger log = LoggerFactory.getLogger(FedoraContentController.class);
+
+    @Autowired
+    private FedoraContentService fedoraContentService;
+    @Autowired
+    private AnalyticsTrackerUtil analyticsTracker;
 
     @RequestMapping("/indexablecontent/{pid}")
     public void getDefaultIndexableContent(@PathVariable("pid") String pid,
             @RequestParam(value = "dl", defaultValue = "false") boolean download,
             HttpServletRequest request, HttpServletResponse response) {
-//        fedoraContentService.streamData(pid, ContentModelHelper.Datastream.DATA_FILE.getName(), download,
-//                new AnalyticsUserData(request), response);
+        streamData(pid, ORIGINAL_FILE, download, request, response);
     }
 
     @RequestMapping("/indexablecontent/{pid}/{datastream}")
     public void getIndexableContent(@PathVariable("pid") String pid, @PathVariable("datastream") String datastream,
             @RequestParam(value = "dl", defaultValue = "false") boolean download,
             HttpServletRequest request, HttpServletResponse response) {
-//        fedoraContentService.streamData(pid, datastream, download, new AnalyticsUserData(request), response);
+        streamData(pid, datastream, download, request, response);
     }
 
     @RequestMapping("/indexablecontent")
     public void getIndexableContentByParameters(@RequestParam("id") String id, @RequestParam("ds") String datastream,
             @RequestParam(value = "dl", defaultValue = "false") boolean download,
             HttpServletRequest request, HttpServletResponse response) {
-//        fedoraContentService.streamData(id, datastream, download, new AnalyticsUserData(request), response);
+        streamData(id, ORIGINAL_FILE, download, request, response);
     }
 
     @RequestMapping("/content/{pid}")
     public void getDefaultDatastream(@PathVariable("pid") String pid,
             @RequestParam(value = "dl", defaultValue = "false") boolean download,
             HttpServletRequest request, HttpServletResponse response) {
-//        fedoraContentService.streamData(pid, ContentModelHelper.Datastream.DATA_FILE.getName(), download,
-//                new AnalyticsUserData(request), response);
+        streamData(pid, ORIGINAL_FILE, download, request, response);
     }
 
     @RequestMapping("/content/{pid}/{datastream}")
     public void getDatastream(@PathVariable("pid") String pid, @PathVariable("datastream") String datastream,
             @RequestParam(value = "dl", defaultValue = "false") boolean download,
             HttpServletRequest request, HttpServletResponse response) {
-//        fedoraContentService.streamData(pid, datastream, download, new AnalyticsUserData(request), response);
+        streamData(pid, datastream, download, request, response);
     }
 
     @RequestMapping("/content")
     public void getDatastreamByParameters(@RequestParam("id") String id, @RequestParam("ds") String datastream,
             @RequestParam(value = "dl", defaultValue = "false") boolean download,
             HttpServletRequest request, HttpServletResponse response) {
-//        fedoraContentService.streamData(id, datastream, download, new AnalyticsUserData(request), response);
+        streamData(id, ORIGINAL_FILE, download, request, response);
+    }
+
+    private void streamData(String pidString, String datastream, boolean asAttachment, HttpServletRequest request,
+            HttpServletResponse response) {
+        PID pid = PIDs.get(pidString);
+        AccessGroupSet principals = getAgentPrincipals().getPrincipals();
+
+        try {
+            fedoraContentService.streamData(pid, datastream, principals, asAttachment, response);
+            recordDownloadEvent(pid, datastream, principals, request);
+        } catch (IOException e) {
+            log.error("Problem retrieving {} for {}", pid.toString(), datastream, e);
+        }
+    }
+
+    private void recordDownloadEvent(PID pid, String datastream, AccessGroupSet principals,
+            HttpServletRequest request) {
+        if (!(StringUtils.isBlank(datastream) || ORIGINAL_FILE.equals(datastream))) {
+            return;
+        }
+        analyticsTracker.trackEvent(request, "download", pid, principals);
     }
 
     @ResponseStatus(value = HttpStatus.NOT_FOUND)
-    @ExceptionHandler(ResourceNotFoundException.class)
+    @ExceptionHandler({ResourceNotFoundException.class, NotFoundException.class})
     public String handleResourceNotFound(HttpServletRequest request) {
         request.setAttribute("pageSubtitle", "Invalid content");
         return "error/invalidRecord";
     }
 
     @ResponseStatus(value = HttpStatus.FORBIDDEN)
-    @ExceptionHandler(InvalidRecordRequestException.class)
+    @ExceptionHandler(AccessRestrictionException.class)
     public String handleInvalidRecordRequest(HttpServletRequest request) {
+        request.setAttribute("pageSubtitle", "Invalid content");
+        return "error/invalidRecord";
+    }
+
+    @ResponseStatus(value = HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(ObjectTypeMismatchException.class)
+    public String handleObjectTypeMismatchException(HttpServletRequest request) {
         request.setAttribute("pageSubtitle", "Invalid content");
         return "error/invalidRecord";
     }

--- a/access/src/main/webapp/WEB-INF/access-fedora-context.xml
+++ b/access/src/main/webapp/WEB-INF/access-fedora-context.xml
@@ -29,11 +29,6 @@
         <property name="ignoreResourceNotFound" value="false" />
     </bean>
     
-    <bean id="fedoraUtil" class="edu.unc.lib.dl.ui.util.FedoraUtil">
-        <property name="fedoraUrl"
-            value="${fcrepo.baseUrl}" />
-    </bean>
-    
     <bean id="analyticsTracker" class="edu.unc.lib.dl.ui.util.AnalyticsTrackerUtil">
         <property name="gaTrackingID" ref="gaTrackingID" />
     </bean>

--- a/access/src/main/webapp/WEB-INF/access-fedora-context.xml
+++ b/access/src/main/webapp/WEB-INF/access-fedora-context.xml
@@ -140,4 +140,9 @@
         <property name="cacheMaxSize" value="50" />
         <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
     </bean>
+    
+    <bean id="fedoraContentService" class="edu.unc.lib.dl.ui.service.FedoraContentService">
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="accessControlService" ref="aclService" />
+    </bean>
 </beans>

--- a/access/src/main/webapp/WEB-INF/access-fedora-context.xml
+++ b/access/src/main/webapp/WEB-INF/access-fedora-context.xml
@@ -31,6 +31,7 @@
     
     <bean id="analyticsTracker" class="edu.unc.lib.dl.ui.util.AnalyticsTrackerUtil">
         <property name="gaTrackingID" ref="gaTrackingID" />
+        <property name="solrSearchService" ref="unrestrictedSolrSearchService" />
     </bean>
 
     <bean id="applicationPathSettings" class="edu.unc.lib.dl.ui.util.ApplicationPathSettings">

--- a/access/src/main/webapp/WEB-INF/jsp/common/thumbnail.jsp
+++ b/access/src/main/webapp/WEB-INF/jsp/common/thumbnail.jsp
@@ -37,7 +37,7 @@
 <c:set var="href">
 	<c:choose>
 		<c:when test="${param.target == 'file' && permsHelper.hasOriginalAccess(requestScope.accessGroupSet, thumbnailObject)}">
-			<c:out value="${cdr:getDatastreamUrl(thumbnailObject, 'DATA_FILE', fedoraUtil)}" />
+			<c:out value="${cdr:getOriginalFileUrl(thumbnailObject)}" />
 		</c:when>
 		<c:when test="${param.target == 'record'}">
 			<c:out value="record/${thumbnailObject.id}" />
@@ -68,10 +68,10 @@
 <c:set var="src">
 	<c:choose>
 		<c:when test="${param.size == 'large' && permsHelper.hasThumbnailAccess(requestScope.accessGroupSet, thumbnailObject)}">
-			<c:out value="${cdr:getDatastreamUrl(thumbnailObject, 'THUMB_LARGE', fedoraUtil)}" />
+			<c:out value="${cdr:getDatastreamUrl(thumbnailObject, 'THUMB_LARGE')}" />
 		</c:when>
 		<c:when test="${param.size == 'small' && permsHelper.hasThumbnailAccess(requestScope.accessGroupSet, thumbnailObject)}">
-			<c:out value="${cdr:getDatastreamUrl(thumbnailObject, 'THUMB_SMALL', fedoraUtil)}" />
+			<c:out value="${cdr:getDatastreamUrl(thumbnailObject, 'THUMB_SMALL')}" />
 		</c:when>
 	</c:choose>
 </c:set>

--- a/access/src/main/webapp/WEB-INF/jsp/fullRecord/aggregateRecord.jsp
+++ b/access/src/main/webapp/WEB-INF/jsp/fullRecord/aggregateRecord.jsp
@@ -31,7 +31,7 @@
 	</c:otherwise>
 </c:choose>
 
-<c:set var="dataFileUrl">${cdr:getDatastreamUrl(briefObject, 'original_file', fedoraUtil)}</c:set>
+<c:set var="dataFileUrl">${cdr:getOriginalFileUrl(briefObject)}</c:set>
 
 <div class="onecol full_record_top">
 	<div class="contentarea">

--- a/access/src/main/webapp/WEB-INF/jsp/fullRecord/fileRecord.jsp
+++ b/access/src/main/webapp/WEB-INF/jsp/fullRecord/fileRecord.jsp
@@ -66,11 +66,11 @@
 			<c:choose>
 				<c:when test="${permsHelper.hasOriginalAccess(requestScope.accessGroupSet, briefObject)}">
 					<div class="actionlink left download">
-						<a href="${cdr:getDatastreamUrl(briefObject, 'original_file', fedoraUtil)}?dl=true">Download</a>
+						<a href="${cdr:getOriginalFileUrl(briefObject)}?dl=true">Download</a>
 					</div>
 					<c:if test="${briefObject.contentTypeFacet[0].displayValue == 'mp4'}">
 						<div class="actionlink left">
-							<a href="${cdr:getDatastreamUrl(briefObject, 'original_file', fedoraUtil)}">View</a>
+							<a href="${cdr:getOriginalFileUrl(briefObject)}">View</a>
 						</div>
 					</c:if>
 				</c:when>
@@ -91,12 +91,12 @@
 					<c:choose>
 						<c:when test="${briefObject.contentTypeFacet[0].searchKey == 'pdf'}">
 							<div class="actionlink left">
-								<a href="${cdr:getDatastreamUrl(briefObject, 'original_file', fedoraUtil)}">View</a>
+								<a href="${cdr:getOriginalFileUrl(briefObject)}">View</a>
 							</div>
 						</c:when>
 						<c:when test="${briefObject.contentTypeFacet[0].displayValue == 'mp3'}">
 							<div class="clear_space"></div>
-							<audio class="audio_player inline_viewer" src="${cdr:getDatastreamUrl(briefObject, 'original_file', fedoraUtil)}">
+							<audio class="audio_player inline_viewer" src="${cdr:getOriginalFileUrl(briefObject)}">
 							</audio>
 						</c:when>
 					</c:choose>

--- a/access/src/main/webapp/WEB-INF/jsp/searchResults/searchResultEntry.jsp
+++ b/access/src/main/webapp/WEB-INF/jsp/searchResults/searchResultEntry.jsp
@@ -181,7 +181,7 @@
 					<c:choose>
 						<c:when test="${permsHelper.hasOriginalAccess(requestScope.accessGroupSet, metadata)}">
 							<div class="actionlink right download">
-								<a href="${cdr:getDatastreamUrl(metadata, 'original_file', fedoraUtil)}?dl=true">Download</a>
+								<a href="${cdr:getOriginalFileUrl(metadata)}?dl=true">Download</a>
 							</div>
 						</c:when>
 						<c:when test="${not empty embargoDate}">

--- a/access/src/main/webapp/WEB-INF/jsp/searchResults/selectedContainerEntry.jsp
+++ b/access/src/main/webapp/WEB-INF/jsp/searchResults/selectedContainerEntry.jsp
@@ -87,7 +87,7 @@
 					<c:choose>
 						<c:when test="${permsHelper.hasOriginalAccess(requestScope.accessGroupSet, metadata)}">
 							<div class="actionlink right download">
-								<a href="${cdr:getDatastreamUrl(metadata, 'DATA_FILE', fedoraUtil)}?dl=true">Download</a>
+								<a href="${cdr:getOriginalFileUrl(metadata)}?dl=true">Download</a>
 							</div>
 						</c:when>
 						<c:otherwise>

--- a/access/src/main/webapp/WEB-INF/service-context.xml
+++ b/access/src/main/webapp/WEB-INF/service-context.xml
@@ -111,7 +111,6 @@
                 <value>searchSettings</value>
                 <value>externalContentSettings</value>
                 <value>permsHelper</value>
-                <value>fedoraUtil</value>
                 <value>gaTrackingID</value>
                 <value>accessBaseUrl</value>
                 <value>adminBaseUrl</value>

--- a/access/src/main/webapp/WEB-INF/solr-search-context.xml
+++ b/access/src/main/webapp/WEB-INF/solr-search-context.xml
@@ -122,6 +122,19 @@
         <property name="accessRestrictionUtil" ref="solrAccessRestrictionUtil" />
     </bean>
     
+    <bean id="unrestrictedSolrAccessRestrictionUtil" class="edu.unc.lib.dl.search.solr.util.AccessRestrictionUtil">
+        <property name="searchSettings" ref="searchSettings" />
+        <property name="disablePermissionFiltering" value="true" />
+    </bean>
+    
+    <bean id="unrestrictedSolrSearchService" class="edu.unc.lib.dl.search.solr.service.SolrSearchService"
+        init-method="initializeSolrServer">
+        <property name="solrSettings" ref="solrSettings" />
+        <property name="searchSettings" ref="searchSettings" />
+        <property name="facetFieldUtil" ref="facetFieldUtil" />
+        <property name="accessRestrictionUtil" ref="unrestrictedSolrAccessRestrictionUtil" />
+    </bean>
+    
      <bean id="pathFactory" class="edu.unc.lib.dl.search.solr.service.ObjectPathFactory">
         <property name="search" ref="queryLayer" />
         <property name="cacheSize" value="2000" />

--- a/access/src/test/java/edu/unc/lib/dl/ui/controller/FedoraContentControllerIT.java
+++ b/access/src/test/java/edu/unc/lib/dl/ui/controller/FedoraContentControllerIT.java
@@ -1,0 +1,261 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.ui.controller;
+
+import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.TECHNICAL_METADATA;
+import static edu.unc.lib.dl.test.TestHelper.makePid;
+import static edu.unc.lib.dl.ui.service.FedoraContentService.CONTENT_DISPOSITION;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.fusesource.hawtbuf.ByteArrayInputStream;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import edu.unc.lib.dl.acl.exception.AccessRestrictionException;
+import edu.unc.lib.dl.acl.service.AccessControlService;
+import edu.unc.lib.dl.acl.util.AccessGroupSet;
+import edu.unc.lib.dl.acl.util.GroupsThreadStore;
+import edu.unc.lib.dl.acl.util.Permission;
+import edu.unc.lib.dl.fcrepo4.FileObject;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.test.TestHelper;
+
+/**
+ *
+ * @author bbpennel
+ *
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextHierarchy({
+    @ContextConfiguration("/spring-test/test-fedora-container.xml"),
+    @ContextConfiguration("/spring-test/cdr-client-container.xml"),
+    @ContextConfiguration("/fedora-content-it-servlet.xml")
+})
+public class FedoraContentControllerIT {
+
+    private static final String BINARY_CONTENT = "binary content";
+
+    @Autowired
+    private RepositoryObjectFactory repositoryObjectFactory;
+    @Autowired
+    private AccessControlService accessControlService;
+
+    protected MockMvc mvc;
+    @Autowired
+    protected WebApplicationContext context;
+
+    @Before
+    public void init() {
+
+        mvc = MockMvcBuilders
+                .webAppContextSetup(context)
+                .build();
+
+        TestHelper.setContentBase("http://localhost:48085/rest");
+
+        GroupsThreadStore.storeUsername("test_user");
+        GroupsThreadStore.storeGroups(new AccessGroupSet("adminGroup"));
+
+    }
+
+    @Test
+    public void testGetDatastream() throws Exception {
+        PID filePid = makePid();
+
+        FileObject fileObj = repositoryObjectFactory.createFileObject(filePid, null);
+        fileObj.addOriginalFile(new ByteArrayInputStream(BINARY_CONTENT.getBytes()), "file.txt", "text/plain", null, null);
+
+        MvcResult result = mvc.perform(get("/content/" + filePid.getId()))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+
+        // Verify content was retrieved
+        MockHttpServletResponse response = result.getResponse();
+        assertEquals(BINARY_CONTENT, response.getContentAsString());
+
+        assertEquals(BINARY_CONTENT.length(), response.getContentLength());
+        assertEquals("text/plain", response.getContentType());
+        assertEquals("inline; filename=\"file.txt\"", response.getHeader(CONTENT_DISPOSITION));
+    }
+
+    @Test
+    public void testGetDatastreamDownload() throws Exception {
+        PID filePid = makePid();
+
+        FileObject fileObj = repositoryObjectFactory.createFileObject(filePid, null);
+        fileObj.addOriginalFile(new ByteArrayInputStream(BINARY_CONTENT.getBytes()), "file.txt", "text/plain", null, null);
+
+        MvcResult result = mvc.perform(get("/content/" + filePid.getId())
+                .param("dl", "true"))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+
+        // Verify content was retrieved
+        MockHttpServletResponse response = result.getResponse();
+        assertEquals(BINARY_CONTENT, response.getContentAsString());
+
+        assertEquals(BINARY_CONTENT.length(), response.getContentLength());
+        assertEquals("text/plain", response.getContentType());
+        assertEquals("attachment; filename=\"file.txt\"", response.getHeader(CONTENT_DISPOSITION));
+    }
+
+    @Test
+    public void testGetDatastreamNoFilename() throws Exception {
+        PID filePid = makePid();
+
+        FileObject fileObj = repositoryObjectFactory.createFileObject(filePid, null);
+        fileObj.addOriginalFile(new ByteArrayInputStream(BINARY_CONTENT.getBytes()), null, "text/plain", null, null);
+
+        MvcResult result = mvc.perform(get("/content/" + filePid.getId())
+                .param("dl", "true"))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+
+        // Verify content was retrieved
+        MockHttpServletResponse response = result.getResponse();
+        assertEquals(BINARY_CONTENT, response.getContentAsString());
+
+        assertEquals(BINARY_CONTENT.length(), response.getContentLength());
+        assertEquals("text/plain", response.getContentType());
+        assertEquals("attachment; filename=\"" + filePid.getId() + "\"", response.getHeader(CONTENT_DISPOSITION));
+    }
+
+    @Test
+    public void testGetDatastreamInsufficientPermissions() throws Exception {
+        PID filePid = makePid();
+
+        FileObject fileObj = repositoryObjectFactory.createFileObject(filePid, null);
+        fileObj.addOriginalFile(new ByteArrayInputStream(BINARY_CONTENT.getBytes()), null, "text/plain", null, null);
+
+        doThrow(new AccessRestrictionException()).when(accessControlService)
+                .assertHasAccess(anyString(), eq(filePid), any(AccessGroupSet.class), eq(Permission.viewOriginal));
+
+        MvcResult result = mvc.perform(get("/content/" + filePid.getId()))
+                .andExpect(status().isForbidden())
+                .andReturn();
+
+        MockHttpServletResponse response = result.getResponse();
+        assertEquals("Must not return file content", "", response.getContentAsString());
+    }
+
+    @Test
+    public void testGetMultipleDatastreams() throws Exception {
+        testGetMultipleDatastreams("/content/");
+    }
+
+    @Test
+    public void testGetMultipleIndexableDatastreams() throws Exception {
+        testGetMultipleDatastreams("/indexablecontent/");
+    }
+
+    public void testGetMultipleDatastreams(String requestPath) throws Exception {
+        PID filePid = makePid();
+
+        String content = "<fits>content</fits>";
+
+        FileObject fileObj = repositoryObjectFactory.createFileObject(filePid, null);
+        fileObj.addOriginalFile(new ByteArrayInputStream(BINARY_CONTENT.getBytes()), null, "text/plain", null, null);
+        fileObj.addBinary(TECHNICAL_METADATA, new ByteArrayInputStream(content.getBytes()),
+                "fits.xml", "application/xml", null, null, null);
+
+        // Verify original file content retrievable
+        MvcResult result1 = mvc.perform(get(requestPath + filePid.getId()))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+
+        assertEquals(BINARY_CONTENT, result1.getResponse().getContentAsString());
+
+        // Verify administrative datastream retrievable
+        MvcResult result2 = mvc.perform(get(requestPath + filePid.getId() + "/" + TECHNICAL_METADATA))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+
+        MockHttpServletResponse response = result2.getResponse();
+        assertEquals(content, response.getContentAsString());
+
+        assertEquals(content.length(), response.getContentLength());
+        assertEquals("application/xml", response.getContentType());
+        assertEquals("inline; filename=\"fits.xml\"", response.getHeader(CONTENT_DISPOSITION));
+    }
+
+    @Test
+    public void testGetAdministrativeDatastreamNoPermissions() throws Exception {
+        PID filePid = makePid();
+
+        String content = "<fits>content</fits>";
+
+        FileObject fileObj = repositoryObjectFactory.createFileObject(filePid, null);
+        fileObj.addBinary(TECHNICAL_METADATA, new ByteArrayInputStream(content.getBytes()),
+                "fits.xml", "application/xml", null, null, null);
+
+        // Requires viewHidden permission
+        doThrow(new AccessRestrictionException()).when(accessControlService)
+                .assertHasAccess(anyString(), eq(filePid), any(AccessGroupSet.class), eq(Permission.viewHidden));
+
+        // Verify administrative datastream retrievable
+        MvcResult result = mvc.perform(get("/content/" + filePid.getId() + "/" + TECHNICAL_METADATA))
+                .andExpect(status().isForbidden())
+                .andReturn();
+
+        MockHttpServletResponse response = result.getResponse();
+        assertEquals("Must not return file content", "", response.getContentAsString());
+    }
+
+    @Test
+    public void testInvalidDatastream() throws Exception {
+        PID filePid = makePid();
+
+        repositoryObjectFactory.createFileObject(filePid, null);
+
+        // Verify administrative datastream retrievable
+        MvcResult result = mvc.perform(get("/content/" + filePid.getId() + "/some_ds"))
+                .andExpect(status().isNotFound())
+                .andReturn();
+
+        MockHttpServletResponse response = result.getResponse();
+        assertEquals("Must not return file content", "", response.getContentAsString());
+    }
+
+    @Test
+    public void testGetContentNonFile() throws Exception {
+        PID objPid = makePid();
+
+        repositoryObjectFactory.createWorkObject(objPid, null);
+
+        mvc.perform(get("/content/" + objPid.getId()))
+                .andExpect(status().isBadRequest())
+                .andReturn();
+    }
+}

--- a/access/src/test/java/edu/unc/lib/dl/ui/controller/FedoraContentControllerIT.java
+++ b/access/src/test/java/edu/unc/lib/dl/ui/controller/FedoraContentControllerIT.java
@@ -180,7 +180,7 @@ public class FedoraContentControllerIT {
         testGetMultipleDatastreams("/indexablecontent/");
     }
 
-    public void testGetMultipleDatastreams(String requestPath) throws Exception {
+    private void testGetMultipleDatastreams(String requestPath) throws Exception {
         PID filePid = makePid();
 
         String content = "<fits>content</fits>";

--- a/access/src/test/resources/fedora-content-it-servlet.xml
+++ b/access/src/test/resources/fedora-content-it-servlet.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2008 The University of North Carolina at Chapel Hill
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:mvc="http://www.springframework.org/schema/mvc"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context 
+        http://www.springframework.org/schema/context/spring-context-3.0.xsd
+        http://www.springframework.org/schema/mvc
+        http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd">
+        
+    <mvc:annotation-driven/>
+
+    <context:component-scan resource-pattern="**/FedoraContentController*" base-package="edu.unc.lib.dl.ui.controller"/>
+    
+    <bean id="fedoraContentService" class="edu.unc.lib.dl.ui.service.FedoraContentService">
+        <property name="accessControlService" ref="aclService" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+    </bean>
+</beans>

--- a/access/src/test/resources/spring-test/cdr-client-container.xml
+++ b/access/src/test/resources/spring-test/cdr-client-container.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+
+    <context:property-placeholder />
+    
+    <bean id="baseAddress" class="java.lang.String">
+        <constructor-arg
+            value="http://localhost:48085/rest/" />
+    </bean>
+    
+    <bean id="fcrepoClientFactory" class="edu.unc.lib.dl.fcrepo4.FcrepoClientFactory" factory-method="factory">
+        <constructor-arg ref="baseAddress" />
+    </bean>
+    
+    <bean id="fcrepoClient" class="org.fcrepo.client.FcrepoClient"
+            factory-bean="fcrepoClientFactory" factory-method="makeClient">
+    </bean>
+    
+    <bean id="ldpContainerFactory" class="edu.unc.lib.dl.fcrepo4.LdpContainerFactory">
+        <property name="client" ref="fcrepoClient" />
+    </bean>
+    
+    <bean id="repositoryPIDMinter" class="edu.unc.lib.dl.fcrepo4.RepositoryPIDMinter"></bean>
+    
+    <bean id="fedoraSparqlUpdateService" class="edu.unc.lib.dl.sparql.FedoraSparqlUpdateService">
+        <property name="fcrepoClient" ref="fcrepoClient" />
+    </bean>
+
+    <bean id="repositoryObjectFactory" class="edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory">
+        <property name="client" ref="fcrepoClient" />
+        <property name="ldpFactory" ref="ldpContainerFactory" />
+        <property name="pidMinter" ref="repositoryPIDMinter" />
+        <property name="repositoryObjectDriver" ref="repositoryObjectDriver" />
+        <property name="sparqlUpdateService" ref="fedoraSparqlUpdateService" />
+    </bean>
+    
+    <bean id="cacheTimeToLive" class="java.lang.Long">
+        <constructor-arg value="100" />
+    </bean>
+    
+    <bean id="cacheMaxSize" class="java.lang.Long">
+        <constructor-arg value="5" />
+    </bean>
+    
+    <bean id="repositoryObjectLoader" class="edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader" init-method="init">
+        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
+        <property name="cacheTimeToLive" ref="cacheTimeToLive" />
+        <property name="cacheMaxSize" ref="cacheMaxSize" />
+    </bean>
+    
+    <bean id="repositoryObjectDriver" class="edu.unc.lib.dl.fcrepo4.RepositoryObjectDriver">
+        <property name="client" ref="fcrepoClient" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
+        <property name="sparqlQueryService" ref="sparqlQueryService" />
+        <property name="pidMinter" ref="repositoryPIDMinter" />
+    </bean>
+
+    <bean id="queryModel" class="org.apache.jena.rdf.model.ModelFactory" factory-method="createDefaultModel">
+    </bean>
+    
+    <bean id="sparqlQueryService" class="edu.unc.lib.dl.sparql.JenaSparqlQueryServiceImpl">
+        <constructor-arg ref="queryModel" />
+    </bean>
+    
+    <bean id="repositoryObjectCacheLoader" class="edu.unc.lib.dl.fcrepo4.RepositoryObjectCacheLoader">
+        <property name="client" ref="fcrepoClient" />
+        <property name="repositoryObjectDriver" ref="repositoryObjectDriver" />
+        <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
+    </bean>
+    
+    <bean id="transactionManager" class="edu.unc.lib.dl.fcrepo4.TransactionManager">
+        <property name="client" ref="fcrepoClient" />
+    </bean>
+    
+    <bean id="sparqlUpdateService" class="edu.unc.lib.dl.sparql.FedoraSparqlUpdateService">
+        <property name="fcrepoClient" ref="fcrepoClient" />
+    </bean>
+    
+    <bean id="analyticsTracker" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.ui.util.AnalyticsTrackerUtil" />
+    </bean>
+    
+    <bean id="aclService" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.acl.fcrepo4.AccessControlServiceImpl" />
+    </bean>
+</beans>

--- a/access/src/test/resources/spring-test/master.xml
+++ b/access/src/test/resources/spring-test/master.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:context="http://www.springframework.org/schema/context"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+
+  <context:property-placeholder location="classpath:application.properties"/>
+
+  <!-- Master context for fcrepo4. -->
+
+  <import resource="${fcrepo.spring.repo.configuration:classpath:/spring-test/repo.xml}"/>
+  <import resource="${fcrepo.spring.rest.configuration:classpath:/spring-test/rest.xml}"/>
+
+</beans>

--- a/access/src/test/resources/spring-test/repo.xml
+++ b/access/src/test/resources/spring-test/repo.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
+    xmlns:p="http://www.springframework.org/schema/p"
+    xsi:schemaLocation="
+    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+
+    <!-- Context that supports the actual ModeShape JCR itself -->
+
+    <context:annotation-config />
+
+    <bean name="modeshapeRepofactory"
+        class="org.fcrepo.kernel.modeshape.spring.ModeShapeRepositoryFactoryBean"
+        p:repositoryConfiguration="${fcrepo.modeshape.configuration:repository-test.json}" />
+
+    <bean class="org.modeshape.jcr.ModeShapeEngine" init-method="start" />
+
+    <bean id="connectionManager"
+        class="org.apache.http.impl.conn.PoolingHttpClientConnectionManager" />
+
+</beans>
+

--- a/access/src/test/resources/spring-test/rest.xml
+++ b/access/src/test/resources/spring-test/rest.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
+    xmlns:util="http://www.springframework.org/schema/util"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+    http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+
+    <context:property-placeholder />
+
+    <!-- Context that houses JAX-RS Resources that compose the API as well as 
+        some utility gear. -->
+
+    <context:annotation-config />
+
+    <bean class="org.fcrepo.http.commons.session.SessionFactory" />
+
+    <!-- Identifier translation chain -->
+    <util:list id="translationChain"
+        value-type="org.fcrepo.kernel.api.identifiers.InternalIdentifierConverter">
+        <bean class="org.fcrepo.kernel.modeshape.identifiers.HashConverter" />
+        <bean class="org.fcrepo.kernel.modeshape.identifiers.NamespaceConverter" />
+    </util:list>
+
+    <context:component-scan base-package="org.fcrepo" />
+
+</beans>

--- a/access/src/test/resources/spring-test/test-fedora-container.xml
+++ b/access/src/test/resources/spring-test/test-fedora-container.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+
+    <context:property-placeholder />
+
+    <!-- show stack traces for easier debugging -->
+    <bean id="wildcardExceptionmapper"
+        class="org.fcrepo.http.commons.exceptionhandlers.WildcardExceptionMapper">
+        <property name="showStackTrace" value="true" />
+    </bean>
+
+    <bean id="containerWrapper" class="org.fcrepo.http.commons.test.util.ContainerWrapper"
+        init-method="start" destroy-method="stop">
+        <property name="port" value="48085" />
+        <property name="configLocation" value="classpath:spring-test/web.xml" />
+    </bean>
+
+</beans>

--- a/access/src/test/resources/spring-test/web.xml
+++ b/access/src/test/resources/spring-test/web.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+         version="3.0" metadata-complete="false">
+
+  <display-name>Fedora-on-ModeShape</display-name>
+
+  <context-param>
+    <param-name>contextConfigLocation</param-name>
+    <param-value>classpath:spring-test/master.xml</param-value>
+  </context-param>
+
+  <listener>
+    <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
+  </listener>
+
+  <servlet>
+    <servlet-name>jersey-servlet</servlet-name>
+    <servlet-class>org.glassfish.jersey.servlet.ServletContainer</servlet-class>
+
+    <init-param>
+      <param-name>javax.ws.rs.Application</param-name>
+      <param-value>org.fcrepo.http.commons.FedoraApplication</param-value>
+    </init-param>
+
+    <load-on-startup>1</load-on-startup>
+  </servlet>
+
+  <servlet-mapping>
+    <servlet-name>jersey-servlet</servlet-name>
+    <url-pattern>/rest/*</url-pattern>
+  </servlet-mapping>
+</web-app>

--- a/admin/src/main/webapp/WEB-INF/jsp/edit/description.jsp
+++ b/admin/src/main/webapp/WEB-INF/jsp/edit/description.jsp
@@ -26,7 +26,7 @@
 		config: {
 			'editDescription' : {
 				'recordUrl' : '${accessBaseUrl}/record/${resultObject.id}',
-				'originalUrl' : '${accessBaseUrl}/${cdr:getDatastreamUrl(resultObject, "DATA_FILE", fedoraUtil)}'
+				'originalUrl' : '${accessBaseUrl}/${cdr:getOriginalFileUrl(resultObject)}'
 			}
 		}
 	};

--- a/admin/src/main/webapp/WEB-INF/service-context.xml
+++ b/admin/src/main/webapp/WEB-INF/service-context.xml
@@ -80,7 +80,6 @@
             <list>
                 <value>searchSettings</value>
                 <value>externalContentSettings</value>
-                <value>fedoraUtil</value>
                 <value>accessGroupConstants</value>
                 <value>accessBaseUrl</value>
                 <value>adminBaseUrl</value>

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/FileObject.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/FileObject.java
@@ -187,10 +187,12 @@ public class FileObject extends ContentObject {
      * Retrieve binary object by name from the set of binaries contained by this
      * FileObject.
      *
-     * @param name
-     * @return
+     * @param name name of the binary object to retrieve
+     * @return BinaryObject identified by name
+     * @throws NotFoundException thrown if no datastream with the given name is
+     *             present in this FileObject.
      */
-    public BinaryObject getBinaryObject(String name) {
+    public BinaryObject getBinaryObject(String name) throws NotFoundException {
         Resource resc = getResource();
 
         StmtIterator it = resc.listProperties(PcdmModels.hasFile);

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/FileObject.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/FileObject.java
@@ -32,6 +32,7 @@ import org.apache.jena.rdf.model.StmtIterator;
 import org.apache.jena.vocabulary.RDF;
 
 import edu.unc.lib.dl.fedora.FedoraException;
+import edu.unc.lib.dl.fedora.NotFoundException;
 import edu.unc.lib.dl.fedora.ObjectTypeMismatchException;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.rdf.Cdr;
@@ -180,5 +181,31 @@ public class FileObject extends ContentObject {
         }
 
         return binaries;
+    }
+
+    /**
+     * Retrieve binary object by name from the set of binaries contained by this
+     * FileObject.
+     *
+     * @param name
+     * @return
+     */
+    public BinaryObject getBinaryObject(String name) {
+        Resource resc = getResource();
+
+        StmtIterator it = resc.listProperties(PcdmModels.hasFile);
+        try {
+            for (; it.hasNext(); ) {
+                PID binaryPid = PIDs.get(it.nextStatement().getResource().getURI());
+
+                if (binaryPid.getComponentPath().endsWith("/" + name)) {
+                    return driver.getRepositoryObject(binaryPid, BinaryObject.class);
+                }
+            }
+        } finally {
+            it.close();
+        }
+
+        throw new NotFoundException("No such binary " + name + " contained by " + pid);
     }
 }

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectLoader.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectLoader.java
@@ -65,7 +65,7 @@ public class RepositoryObjectLoader {
     public AdminUnit getAdminUnit(PID pid) {
         RepositoryObject repoObj = getRepositoryObject(pid);
         if (!(repoObj instanceof AdminUnit)) {
-            throw new FedoraException("Object with pid " + pid + "is not an admin unit");
+            throw new ObjectTypeMismatchException("Object with pid " + pid + " is not an admin unit");
         }
         return (AdminUnit) repoObj;
     }
@@ -73,7 +73,7 @@ public class RepositoryObjectLoader {
     public CollectionObject getCollectionObject(PID pid) {
         RepositoryObject repoObj = getRepositoryObject(pid);
         if (!(repoObj instanceof CollectionObject)) {
-            throw new FedoraException("Object with pid " + pid + "is not a collection");
+            throw new ObjectTypeMismatchException("Object with pid " + pid + " is not a collection");
         }
         return (CollectionObject) repoObj;
     }
@@ -81,7 +81,7 @@ public class RepositoryObjectLoader {
     public ContentRootObject getContentRootObject(PID pid) {
         RepositoryObject repoObj = getRepositoryObject(pid);
         if (!(repoObj instanceof ContentRootObject)) {
-            throw new FedoraException("Object with pid " + pid + "is not the content root");
+            throw new ObjectTypeMismatchException("Object with pid " + pid + " is not the content root");
         }
         return (ContentRootObject) repoObj;
     }
@@ -89,7 +89,7 @@ public class RepositoryObjectLoader {
     public FolderObject getFolderObject(PID pid) {
         RepositoryObject repoObj = getRepositoryObject(pid);
         if (!(repoObj instanceof FolderObject)) {
-            throw new FedoraException("Object with pid " + pid + "is not a folder");
+            throw new ObjectTypeMismatchException("Object with pid " + pid + " is not a folder");
         }
         return (FolderObject) repoObj;
     }
@@ -97,7 +97,7 @@ public class RepositoryObjectLoader {
     public WorkObject getWorkObject(PID pid) {
         RepositoryObject repoObj = getRepositoryObject(pid);
         if (!(repoObj instanceof WorkObject)) {
-            throw new FedoraException("Object with pid " + pid + "is not a work");
+            throw new ObjectTypeMismatchException("Object with pid " + pid + " is not a work");
         }
         return (WorkObject) repoObj;
     }
@@ -105,7 +105,7 @@ public class RepositoryObjectLoader {
     public FileObject getFileObject(PID pid) {
         RepositoryObject repoObj = getRepositoryObject(pid);
         if (!(repoObj instanceof FileObject)) {
-            throw new FedoraException("Object with pid " + pid + "is not a file");
+            throw new ObjectTypeMismatchException("Object with pid " + pid + " is not a file");
         }
         return (FileObject) repoObj;
     }
@@ -113,7 +113,7 @@ public class RepositoryObjectLoader {
     public BinaryObject getBinaryObject(PID pid) {
         RepositoryObject repoObj = getRepositoryObject(pid);
         if (!(repoObj instanceof BinaryObject)) {
-            throw new FedoraException("Object with pid " + pid + "is not a binary");
+            throw new ObjectTypeMismatchException("Object with pid " + pid + " is not a binary");
         }
         return (BinaryObject) repoObj;
     }
@@ -121,7 +121,7 @@ public class RepositoryObjectLoader {
     public PremisEventObject getPremisEventObject(PID pid) {
         RepositoryObject repoObj = getRepositoryObject(pid);
         if (!(repoObj instanceof PremisEventObject)) {
-            throw new FedoraException("Object with pid " + pid + " is not a premis event");
+            throw new ObjectTypeMismatchException("Object with pid " + pid + " is not a premis event");
         }
         return (PremisEventObject) repoObj;
     }
@@ -129,7 +129,7 @@ public class RepositoryObjectLoader {
     public DepositRecord getDepositRecord(PID pid) {
         RepositoryObject repoObj = getRepositoryObject(pid);
         if (!(repoObj instanceof DepositRecord)) {
-            throw new ObjectTypeMismatchException("Object with pid " + pid + "is not a deposit record");
+            throw new ObjectTypeMismatchException("Object with pid " + pid + " is not a deposit record");
         }
         return (DepositRecord) repoObj;
     }

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/FileObjectIT.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/FileObjectIT.java
@@ -122,6 +122,17 @@ public class FileObjectIT extends AbstractFedoraIT {
         verifyOriginalFile(rObj3);
     }
 
+    @Test
+    public void testGetBinaryByName() throws Exception {
+        FileObject fileObj = repoObjFactory.createFileObject(null);
+
+        InputStream contentStream = new ByteArrayInputStream(origBodyString.getBytes());
+        fileObj.addBinary("some_binary", contentStream, origFilename, origMimetype, null, null, null);
+
+        BinaryObject binObj = fileObj.getBinaryObject("some_binary");
+        verifyFile(binObj, origFilename, origMimetype, origBodyString);
+    }
+
     @Test(expected = ObjectTypeMismatchException.class)
     public void getNonFileObject() throws Exception {
         PID objPid = PIDs.get("uuid:" + UUID.randomUUID().toString());

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/test/TestHelper.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/test/TestHelper.java
@@ -17,8 +17,11 @@ package edu.unc.lib.dl.test;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.UUID;
 
+import edu.unc.lib.dl.fcrepo4.PIDs;
 import edu.unc.lib.dl.fcrepo4.RepositoryPaths;
+import edu.unc.lib.dl.fedora.PID;
 
 /**
  *  Helper method for IT tests
@@ -42,4 +45,7 @@ public class TestHelper {
         }
     }
 
+    public static PID makePid() {
+        return PIDs.get(UUID.randomUUID().toString());
+    }
 }

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/DatastreamRestController.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/DatastreamRestController.java
@@ -40,6 +40,8 @@ import edu.unc.lib.dl.ui.util.AnalyticsTrackerUtil;
 
 /**
  *
+ * Controller which provides access to datastreams of objects held in the repository.
+ *
  * @author bbpennel
  *
  */

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/DatastreamRestController.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/DatastreamRestController.java
@@ -15,57 +15,88 @@
  */
 package edu.unc.lib.dl.cdr.services.rest;
 
+import static edu.unc.lib.dl.acl.util.GroupsThreadStore.getAgentPrincipals;
+import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.ORIGINAL_FILE;
+
+import java.io.IOException;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import edu.unc.lib.dl.acl.util.AccessGroupSet;
+import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.ui.service.FedoraContentService;
-import edu.unc.lib.dl.ui.util.AnalyticsTrackerUtil.AnalyticsUserData;
-import edu.unc.lib.dl.util.ContentModelHelper;
+import edu.unc.lib.dl.ui.util.AnalyticsTrackerUtil;
 
 /**
- * 
+ *
  * @author bbpennel
  *
  */
 @Controller
 public class DatastreamRestController {
+    private static final Logger log = LoggerFactory.getLogger(DatastreamRestController.class);
+
     @Autowired
     private FedoraContentService fedoraContentService;
+    @Autowired
+    private AnalyticsTrackerUtil analyticsTracker;
 
     @RequestMapping("/file/{pid}")
-    public void getDatastream(@PathVariable("pid") String pid,
+    public void getDatastream(@PathVariable("pid") String pidString,
             @RequestParam(value = "dl", defaultValue = "false") boolean download,
-            HttpServletRequest request, HttpServletResponse response) {
-        fedoraContentService.streamData(pid, null, download, new AnalyticsUserData(request), response);
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        getDatastream(pidString, null, download, request, response);
     }
 
     @RequestMapping("/file/{pid}/{datastream}")
-    public void getDatastream(@PathVariable("pid") String pid, @PathVariable("datastream") String datastream,
+    public void getDatastream(@PathVariable("pid") String pidString,
+            @PathVariable("datastream") String datastream,
             @RequestParam(value = "dl", defaultValue = "false") boolean download,
-            HttpServletRequest request, HttpServletResponse response) {
-        fedoraContentService.streamData(pid, datastream, download, new AnalyticsUserData(request), response);
+            HttpServletRequest request,
+            HttpServletResponse response) {
+
+        PID pid = PIDs.get(pidString);
+        AccessGroupSet principals = getAgentPrincipals().getPrincipals();
+
+        try {
+            fedoraContentService.streamData(pid, datastream, principals, download, response);
+            recordDownloadEvent(pid, datastream, principals, request);
+        } catch (IOException e) {
+            log.error("Problem retrieving {} for {}", pid.toString(), datastream, e);
+        }
+    }
+
+    private void recordDownloadEvent(PID pid, String datastream, AccessGroupSet principals,
+            HttpServletRequest request) {
+        if (!(StringUtils.isBlank(datastream) || ORIGINAL_FILE.equals(datastream))) {
+            return;
+        }
+        analyticsTracker.trackEvent(request, "download", pid, principals);
     }
 
     @RequestMapping("/thumb/{pid}")
     public void getThumbnailSmall(@PathVariable("pid") String pid,
             @RequestParam(value = "size", defaultValue = "small") String size, HttpServletRequest request,
             HttpServletResponse response) {
-        fedoraContentService.streamData(pid, ContentModelHelper.Datastream.THUMB_SMALL.getName(),
-                false, null, response);
+        // TODO implement retrieval of derivatives
     }
 
     @RequestMapping("/thumb/{pid}/{size}")
     public void getThumbnail(@PathVariable("pid") String pid,
             @PathVariable("size") String size, HttpServletRequest request,
             HttpServletResponse response) {
-        String datastream = ("large".equals(size)) ? ContentModelHelper.Datastream.THUMB_LARGE.getName()
-                : ContentModelHelper.Datastream.THUMB_SMALL.getName();
-        fedoraContentService.streamData(pid, datastream, false, null, response);
+        // TODO implement retrieval of derivatives
     }
 }

--- a/services/src/main/webapp/WEB-INF/service-context.xml
+++ b/services/src/main/webapp/WEB-INF/service-context.xml
@@ -222,11 +222,6 @@
         <property name="apiRecordPath" value="${repository.protocol}://${repository.host}/record/" />
     </bean>
     
-    <bean id="fedoraUtil" class="edu.unc.lib.dl.ui.util.FedoraUtil">
-        <property name="fedoraUrl"
-            value="${fcrepo.baseUrl}" />
-    </bean>
-    
     <bean id="gaTrackingID" class="java.lang.String">
         <constructor-arg
             value="${google.trackingId}" />

--- a/services/src/main/webapp/WEB-INF/service-context.xml
+++ b/services/src/main/webapp/WEB-INF/service-context.xml
@@ -233,6 +233,8 @@
     </bean>
     
     <bean id="fedoraContentService" class="edu.unc.lib.dl.ui.service.FedoraContentService">
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="accessControlService" ref="aclService" />
     </bean>
     
     <bean id="addContainerService" class="edu.unc.lib.dl.cdr.services.processing.AddContainerService">

--- a/services/src/main/webapp/WEB-INF/service-context.xml
+++ b/services/src/main/webapp/WEB-INF/service-context.xml
@@ -229,6 +229,7 @@
     
     <bean id="analyticsTracker" class="edu.unc.lib.dl.ui.util.AnalyticsTrackerUtil">
         <property name="gaTrackingID" ref="gaTrackingID" />
+        <property name="solrSearchService" ref="unrestrictedSolrSearchService" />
     </bean>
     
     <bean id="fedoraContentService" class="edu.unc.lib.dl.ui.service.FedoraContentService">

--- a/services/src/main/webapp/WEB-INF/solr-search-context.xml
+++ b/services/src/main/webapp/WEB-INF/solr-search-context.xml
@@ -73,6 +73,19 @@
         <property name="globalPermissionEvaluator" ref="globalPermissionEvaluator" />
     </bean>
     
+    <bean id="unrestrictedSolrAccessRestrictionUtil" class="edu.unc.lib.dl.search.solr.util.AccessRestrictionUtil">
+        <property name="searchSettings" ref="searchSettings" />
+        <property name="disablePermissionFiltering" value="true" />
+    </bean>
+    
+    <bean id="unrestrictedSolrSearchService" class="edu.unc.lib.dl.search.solr.service.SolrSearchService"
+        init-method="initializeSolrServer">
+        <property name="solrSettings" ref="solrSettings" />
+        <property name="searchSettings" ref="searchSettings" />
+        <property name="facetFieldUtil" ref="facetFieldUtil" />
+        <property name="accessRestrictionUtil" ref="unrestrictedSolrAccessRestrictionUtil" />
+    </bean>
+    
     <bean id="childrenCountService" class="edu.unc.lib.dl.search.solr.service.ChildrenCountService"
         init-method="initializeSolrServer">
         <property name="searchSettings" ref="searchSettings" />

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/DatastreamRestControllerIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/DatastreamRestControllerIT.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.cdr.services.rest;
+
+import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.TECHNICAL_METADATA;
+import static edu.unc.lib.dl.ui.service.FedoraContentService.CONTENT_DISPOSITION;
+import static org.junit.Assert.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.fusesource.hawtbuf.ByteArrayInputStream;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.unc.lib.dl.cdr.services.rest.modify.AbstractAPIIT;
+import edu.unc.lib.dl.fcrepo4.FileObject;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
+import edu.unc.lib.dl.fedora.PID;
+
+/**
+ *
+ * @author bbpennel
+ *
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextHierarchy({
+    @ContextConfiguration("/spring-test/test-fedora-container.xml"),
+    @ContextConfiguration("/spring-test/cdr-client-container.xml"),
+    @ContextConfiguration("/datastream-content-it-servlet.xml")
+})
+public class DatastreamRestControllerIT extends AbstractAPIIT {
+
+    private static final String BINARY_CONTENT = "binary content";
+
+    @Autowired
+    private RepositoryObjectFactory repositoryObjectFactory;
+
+    @Test
+    public void testGetFile() throws Exception {
+        PID filePid = makePid();
+
+        FileObject fileObj = repositoryObjectFactory.createFileObject(filePid, null);
+        fileObj.addOriginalFile(new ByteArrayInputStream(BINARY_CONTENT.getBytes()), "file.txt", "text/plain", null, null);
+
+        MvcResult result = mvc.perform(get("/file/" + filePid.getId()))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+
+        // Verify content was retrieved
+        MockHttpServletResponse response = result.getResponse();
+        assertEquals(BINARY_CONTENT, response.getContentAsString());
+
+        assertEquals(BINARY_CONTENT.length(), response.getContentLength());
+        assertEquals("text/plain", response.getContentType());
+        assertEquals("inline; filename=\"file.txt\"", response.getHeader(CONTENT_DISPOSITION));
+    }
+
+    @Test
+    public void testGetMultipleDatastreams() throws Exception {
+        PID filePid = makePid();
+
+        String content = "<fits>content</fits>";
+
+        FileObject fileObj = repositoryObjectFactory.createFileObject(filePid, null);
+        fileObj.addOriginalFile(new ByteArrayInputStream(BINARY_CONTENT.getBytes()), null, "text/plain", null, null);
+        fileObj.addBinary(TECHNICAL_METADATA, new ByteArrayInputStream(content.getBytes()),
+                "fits.xml", "application/xml", null, null, null);
+
+        // Verify original file content retrievable
+        MvcResult result1 = mvc.perform(get("/file/" + filePid.getId()))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+
+        assertEquals(BINARY_CONTENT, result1.getResponse().getContentAsString());
+
+        // Verify administrative datastream retrievable
+        MvcResult result2 = mvc.perform(get("/file/" + filePid.getId() + "/" + TECHNICAL_METADATA))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+
+        MockHttpServletResponse response = result2.getResponse();
+        assertEquals(content, response.getContentAsString());
+
+        assertEquals(content.length(), response.getContentLength());
+        assertEquals("application/xml", response.getContentType());
+        assertEquals("inline; filename=\"fits.xml\"", response.getHeader(CONTENT_DISPOSITION));
+    }
+}

--- a/services/src/test/resources/datastream-content-it-servlet.xml
+++ b/services/src/test/resources/datastream-content-it-servlet.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2008 The University of North Carolina at Chapel Hill
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:mvc="http://www.springframework.org/schema/mvc"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context 
+        http://www.springframework.org/schema/context/spring-context-3.0.xsd
+        http://www.springframework.org/schema/mvc
+        http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd">
+        
+    <mvc:annotation-driven/>
+
+    <context:component-scan resource-pattern="**/DatastreamRestController*" base-package="edu.unc.lib.dl.cdr.services.rest"/>
+    
+    <bean id="fedoraContentService" class="edu.unc.lib.dl.ui.service.FedoraContentService">
+        <property name="accessControlService" ref="aclService" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+    </bean>
+    
+    <bean id="aclService" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.acl.fcrepo4.AccessControlServiceImpl" />
+    </bean>
+    
+    <bean id="analyticsTracker" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.ui.util.AnalyticsTrackerUtil" />
+    </bean>
+</beans>

--- a/solr-search/src/main/java/edu/unc/lib/dl/search/solr/model/Datastream.java
+++ b/solr-search/src/main/java/edu/unc/lib/dl/search/solr/model/Datastream.java
@@ -57,14 +57,16 @@ public class Datastream {
 
         this.name = dsParts[0];
         this.mimetype = dsParts[1];
-        this.extension = dsParts[2];
+        this.filename = dsParts[2];
+        this.extension = dsParts[3];
+
         try {
-            this.filesize = new Long(dsParts[3]);
+            this.filesize = new Long(dsParts[4]);
         } catch (NumberFormatException e) {
             this.filesize = null;
         }
-        this.checksum = dsParts[4];
-        this.owner = dsParts[5];
+        this.checksum = dsParts[5];
+        this.owner = dsParts[6];
     }
 
     @Override

--- a/solr-search/src/test/java/edu/unc/lib/dl/search/solr/model/DatastreamTest.java
+++ b/solr-search/src/test/java/edu/unc/lib/dl/search/solr/model/DatastreamTest.java
@@ -27,37 +27,57 @@ import org.junit.Test;
  *
  */
 public class DatastreamTest {
+    private static final String CHECKSUM = "urn:sha1:2c9e902133d6809b445942dca5a93a9b3e766c15";
 
     @Test
-    public void datastreamParsing() {
-        Datastream ds = new Datastream("DATA_FILE|image/jpeg|jpg|30459|dc93eff50ca7dbd688971716e55e0084|");
+    public void testToString() {
+        Datastream ds = new Datastream(null, "original", 555l, "text/plain", "file.txt", "txt", CHECKSUM);
 
-        assertEquals("DATA_FILE", ds.getName());
+        assertEquals("original", ds.getName());
+        assertEquals("text/plain", ds.getMimetype());
+        assertEquals("file.txt", ds.getFilename());
+        assertEquals("txt", ds.getExtension());
+        assertEquals(555, ds.getFilesize().longValue());
+        assertEquals(CHECKSUM, ds.getChecksum());
+        assertEmpty(ds.getOwner());
+
+        assertEquals("original|text/plain|file.txt|txt|555|" + CHECKSUM + "|", ds.toString());
+    }
+
+    @Test
+    public void testDatastreamParsing() {
+        Datastream ds = new Datastream("original_file|image/jpeg|file.jpg|jpg"
+                + "|30459|" + CHECKSUM + "|");
+
+        assertEquals("original_file", ds.getName());
         assertEquals("image/jpeg", ds.getMimetype());
+        assertEquals("file.jpg", ds.getFilename());
         assertEquals("jpg", ds.getExtension());
         assertEquals(30459, ds.getFilesize().longValue());
-        assertEquals("dc93eff50ca7dbd688971716e55e0084", ds.getChecksum());
+        assertEquals(CHECKSUM, ds.getChecksum());
         assertEmpty(ds.getOwner());
     }
 
     @Test
-    public void datastreamSurrogateParsing() {
-        Datastream ds = new Datastream("DATA_FILE|image/jpeg|jpg|30459|dc93eff50ca7dbd688971716e55e0084|uuid:73247248-e351-49dc-9b27-fe44df3884e7");
+    public void testDatastreamSurrogateParsing() {
+        Datastream ds = new Datastream("DATA_FILE|image/jpeg|file.jpg|jpg|30459|" + CHECKSUM + "|uuid:73247248-e351-49dc-9b27-fe44df3884e7");
 
         assertEquals("DATA_FILE", ds.getName());
         assertEquals("image/jpeg", ds.getMimetype());
+        assertEquals("file.jpg", ds.getFilename());
         assertEquals("jpg", ds.getExtension());
         assertEquals(30459, ds.getFilesize().longValue());
-        assertEquals("dc93eff50ca7dbd688971716e55e0084", ds.getChecksum());
+        assertEquals(CHECKSUM, ds.getChecksum());
         assertEquals("uuid:73247248-e351-49dc-9b27-fe44df3884e7", ds.getOwner());
     }
 
     @Test
-    public void datastreamNoChecksum() {
-        Datastream ds = new Datastream("AUDIT|text/xml|xml|30459||");
+    public void testDatastreamNoChecksum() {
+        Datastream ds = new Datastream("AUDIT|text/xml|audit|xml|30459||");
 
         assertEquals("AUDIT", ds.getName());
         assertEquals("text/xml", ds.getMimetype());
+        assertEquals("audit", ds.getFilename());
         assertEquals("xml", ds.getExtension());
         assertEquals(30459, ds.getFilesize().longValue());
         assertEmpty(ds.getChecksum());
@@ -65,11 +85,12 @@ public class DatastreamTest {
     }
 
     @Test
-    public void datastreamNoChecksumFromSurrogate() {
-        Datastream ds = new Datastream("AUDIT|text/xml|xml|30459||uuid:73247248-e351-49dc-9b27-fe44df3884e7");
+    public void testDatastreamNoChecksumFromSurrogate() {
+        Datastream ds = new Datastream("AUDIT|text/xml|audit|xml|30459||uuid:73247248-e351-49dc-9b27-fe44df3884e7");
 
         assertEquals("AUDIT", ds.getName());
         assertEquals("text/xml", ds.getMimetype());
+        assertEquals("audit", ds.getFilename());
         assertEquals("xml", ds.getExtension());
         assertEquals(30459, ds.getFilesize().longValue());
         assertEmpty(ds.getChecksum());
@@ -79,7 +100,7 @@ public class DatastreamTest {
     @Test
     public void testDatastreamEqualsString() {
         String dsName = "data_stream";
-        Datastream ds = new Datastream("data_stream|image/jpeg|jpg|0||");
+        Datastream ds = new Datastream("data_stream|image/jpeg|ds.jpg|jpg|0||");
 
         assertTrue(ds.equals(dsName));
     }
@@ -87,39 +108,39 @@ public class DatastreamTest {
     @Test
     public void testDatastreamNotEqualsString() {
         String dsName = "other_ds";
-        Datastream ds = new Datastream("data_stream|image/jpeg|jpg|0||");
+        Datastream ds = new Datastream("data_stream|image/jpeg|ds.jpg|jpg|0||");
 
         assertFalse(ds.equals(dsName));
     }
 
     @Test
     public void testDatastreamEqualsFullDSString() {
-        String dsName = "data_stream|image/jpeg|jpg|0||";
-        Datastream ds = new Datastream("data_stream|image/jpeg|jpg|0||");
+        String dsName = "data_stream|image/jpeg|ds.jpg|jpg|0||";
+        Datastream ds = new Datastream("data_stream|image/jpeg|ds.jpg|jpg|0||");
 
         assertTrue(ds.equals(dsName));
     }
 
     @Test
     public void testDatastreamEqualsDatastream() {
-        Datastream ds1 = new Datastream("data_stream|image/jpeg|jpg|0||");
-        Datastream ds2 = new Datastream("data_stream|image/jpeg|jpg|0||");
+        Datastream ds1 = new Datastream("data_stream|image/jpeg|ds.jpg|jpg|0||");
+        Datastream ds2 = new Datastream("data_stream|image/jpeg|ds.jpg|jpg|0||");
 
         assertTrue(ds1.equals(ds2));
     }
 
     @Test
     public void testDatastreamEqualsDatastreamByNameAndOwner() {
-        Datastream ds1 = new Datastream("data_stream|image/jpeg|jpg|0||owner_id");
-        Datastream ds2 = new Datastream("data_stream|||||owner_id");
+        Datastream ds1 = new Datastream("data_stream|image/jpeg|ds.jpg|jpg|0||owner_id");
+        Datastream ds2 = new Datastream("data_stream||||||owner_id");
 
         assertTrue(ds1.equals(ds2));
     }
 
     @Test
     public void testDatastreamNotEqualsDatastreamByOwner() {
-        Datastream ds1 = new Datastream("data_stream|image/jpeg|jpg|0||owner_2");
-        Datastream ds2 = new Datastream("data_stream|image/jpeg|jpg|0||owner_1");
+        Datastream ds1 = new Datastream("data_stream|image/jpeg|ds.jpg|jpg|0||owner_2");
+        Datastream ds2 = new Datastream("data_stream|image/jpeg|ds.jpg|jpg|0||owner_1");
 
         assertFalse(ds1.equals(ds2));
     }


### PR DESCRIPTION
* Fixes URLs for download links
* Updates controllers and service involved in stream binaries from fedora
* Adds FileObject.getBinary(name) for retrieval of a single binary by name
* Adds integration tests for binary retrieval controllers
* Updates AnalyticsUtil to be more self contained to make for easier mocking.
* Switched to getOriginalFileUrl helper method for views versus passing in datastream name.