### PR TITLE
Fcrepo 2154 - Thumbnails and Derivatives

### DIFF
--- a/access-common/src/main/java/edu/unc/lib/dl/ui/controller/LorisContentController.java
+++ b/access-common/src/main/java/edu/unc/lib/dl/ui/controller/LorisContentController.java
@@ -15,6 +15,8 @@
  */
 package edu.unc.lib.dl.ui.controller;
 
+import static edu.unc.lib.dl.model.DatastreamType.JP2_ACCESS_COPY;
+
 import javax.servlet.http.HttpServletResponse;
 
 import org.slf4j.Logger;
@@ -31,7 +33,6 @@ import edu.unc.lib.dl.acl.util.AgentPrincipals;
 import edu.unc.lib.dl.acl.util.GroupsThreadStore;
 import edu.unc.lib.dl.acl.util.Permission;
 import edu.unc.lib.dl.fcrepo4.PIDs;
-import edu.unc.lib.dl.fcrepo4.RepositoryPathConstants;
 import edu.unc.lib.dl.fedora.PID;
 
 /**
@@ -51,18 +52,16 @@ public class LorisContentController extends AbstractSolrSearchController {
     private AccessControlService accessControlService;
 
     /**
-     * Determines if the user is allowed to access a specific datastream on the selected object. If so, then the result
-     * is cached for future use.
+     * Determines if the user is allowed to access a specific datastream on the selected object.
      *
-     * @param id
+     * @param pid
      * @param datastream
-     * @param request
      * @return
      */
     private boolean hasAccess(PID pid, String datastream) {
         // Defaults to jp2 surrogate if no datastream specified
         if (datastream == null) {
-            datastream = RepositoryPathConstants.JPEG_2000;
+            datastream = JP2_ACCESS_COPY.getId();
         }
 
         Permission permission = DatastreamPermissionUtil.getPermissionForDatastream(datastream);

--- a/access-common/src/main/java/edu/unc/lib/dl/ui/service/DerivativeContentService.java
+++ b/access-common/src/main/java/edu/unc/lib/dl/ui/service/DerivativeContentService.java
@@ -18,6 +18,7 @@ package edu.unc.lib.dl.ui.service;
 import static edu.unc.lib.dl.acl.fcrepo4.DatastreamPermissionUtil.getPermissionForDatastream;
 import static edu.unc.lib.dl.model.DatastreamType.getByIdentifier;
 import static edu.unc.lib.dl.ui.service.FedoraContentService.CONTENT_DISPOSITION;
+import static edu.unc.lib.dl.util.DerivativeService.listDerivativeTypes;
 import static org.apache.http.HttpHeaders.CONTENT_LENGTH;
 import static org.apache.http.HttpHeaders.CONTENT_TYPE;
 
@@ -56,22 +57,25 @@ public class DerivativeContentService {
     }
 
     /**
-     * Set content headers and stream the content of the specified derivative from the object identified by pid.
+     * Set content headers and stream the content of the specified derivative
+     * from the object identified by pid.
      *
      * @param pid pid of object containing the derivative
-     * @param dsName name of derivative being requested.
+     * @param dsName name of derivative being requested. Must be a derivative
+     *            type, otherwise an IllegalArgumentException will be thrown.
      * @param principals principals of requesting client
      * @param asAttachment if true, then content-disposition header will specify
      *            as "attachment" instead of "inline"
      * @param response response content and headers will be added to.
      * @throws IOException if unable to stream content to the response.
-     * @throws ResourceNotFoundException if an invalid derivative type is requested.
+     * @throws ResourceNotFoundException if an invalid derivative type is
+     *             requested.
      */
     public void streamData(PID pid, String dsName, AccessGroupSet principals, boolean asAttachment,
             HttpServletResponse response) throws IOException, ResourceNotFoundException {
 
         DatastreamType derivType = getByIdentifier(dsName);
-        if (derivType == null || !derivativeService.listDerivativeTypes().contains(derivType)) {
+        if (derivType == null || !listDerivativeTypes().contains(derivType)) {
             throw new IllegalArgumentException(dsName + " is not a valid derivative type.");
         }
 

--- a/access-common/src/main/java/edu/unc/lib/dl/ui/service/DerivativeContentService.java
+++ b/access-common/src/main/java/edu/unc/lib/dl/ui/service/DerivativeContentService.java
@@ -1,0 +1,99 @@
+package edu.unc.lib.dl.ui.service;
+
+import static edu.unc.lib.dl.acl.fcrepo4.DatastreamPermissionUtil.getPermissionForDatastream;
+import static edu.unc.lib.dl.model.DatastreamType.getByIdentifier;
+import static edu.unc.lib.dl.ui.service.FedoraContentService.CONTENT_DISPOSITION;
+import static org.apache.http.HttpHeaders.CONTENT_LENGTH;
+import static org.apache.http.HttpHeaders.CONTENT_TYPE;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.io.IOUtils;
+
+import edu.unc.lib.dl.acl.service.AccessControlService;
+import edu.unc.lib.dl.acl.util.AccessGroupSet;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.model.DatastreamType;
+import edu.unc.lib.dl.ui.exception.ResourceNotFoundException;
+import edu.unc.lib.dl.util.DerivativeService;
+import edu.unc.lib.dl.util.DerivativeService.Derivative;
+
+/**
+ * Streams content for derivative files of repository objects.
+ *
+ * @author bbpennel
+ *
+ */
+public class DerivativeContentService {
+
+    private static final int BUFFER_SIZE = 4096;
+
+    private DerivativeService derivativeService;
+
+    private AccessControlService accessControlService;
+
+    public DerivativeContentService() {
+    }
+
+    /**
+     * Set content headers and stream the content of the specified derivative from the object identified by pid.
+     *
+     * @param pid pid of object containing the derivative
+     * @param dsName name of derivative being requested.
+     * @param principals principals of requesting client
+     * @param asAttachment if true, then content-disposition header will specify
+     *            as "attachment" instead of "inline"
+     * @param response response content and headers will be added to.
+     * @throws IOException if unable to stream content to the response.
+     * @throws ResourceNotFoundException if an invalid derivative type is requested.
+     */
+    public void streamData(PID pid, String dsName, AccessGroupSet principals, boolean asAttachment,
+            HttpServletResponse response) throws IOException, ResourceNotFoundException {
+
+        DatastreamType derivType = getByIdentifier(dsName);
+        if (derivType == null || !derivativeService.listDerivativeTypes().contains(derivType)) {
+            throw new IllegalArgumentException(dsName + " is not a valid derivative type.");
+        }
+
+        accessControlService.assertHasAccess("Insufficient permissions to access derivative "
+                + dsName + " for object " + pid,
+                pid, principals, getPermissionForDatastream(derivType));
+
+        Derivative deriv = derivativeService.getDerivative(pid, derivType);
+        if (deriv == null) {
+            throw new ResourceNotFoundException("Deriviatve " + dsName +" does not exist for object " + pid);
+        }
+
+        File derivFile = deriv.getFile();
+        response.setHeader(CONTENT_LENGTH, Long.toString(derivFile.length()));
+        response.setHeader(CONTENT_TYPE, derivType.getMimetype());
+        String filename = derivFile.getName();
+        if (asAttachment) {
+            response.setHeader(CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"");
+        } else {
+            response.setHeader(CONTENT_DISPOSITION, "inline; filename=\"" + filename + "\"");
+        }
+
+        OutputStream outStream = response.getOutputStream();
+        IOUtils.copy(new FileInputStream(derivFile), outStream, BUFFER_SIZE);
+    }
+
+    /**
+     * @param derivativeService the derivativeService to set
+     */
+    public void setDerivativeService(DerivativeService derivativeService) {
+        this.derivativeService = derivativeService;
+    }
+
+    /**
+     * @param accessControlService the accessControlService to set
+     */
+    public void setAccessControlService(AccessControlService accessControlService) {
+        this.accessControlService = accessControlService;
+    }
+}

--- a/access-common/src/main/java/edu/unc/lib/dl/ui/service/DerivativeContentService.java
+++ b/access-common/src/main/java/edu/unc/lib/dl/ui/service/DerivativeContentService.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package edu.unc.lib.dl.ui.service;
 
 import static edu.unc.lib.dl.acl.fcrepo4.DatastreamPermissionUtil.getPermissionForDatastream;
@@ -66,7 +81,7 @@ public class DerivativeContentService {
 
         Derivative deriv = derivativeService.getDerivative(pid, derivType);
         if (deriv == null) {
-            throw new ResourceNotFoundException("Deriviatve " + dsName +" does not exist for object " + pid);
+            throw new ResourceNotFoundException("Deriviatve " + dsName + " does not exist for object " + pid);
         }
 
         File derivFile = deriv.getFile();

--- a/access-common/src/main/java/edu/unc/lib/dl/ui/service/PermissionsHelper.java
+++ b/access-common/src/main/java/edu/unc/lib/dl/ui/service/PermissionsHelper.java
@@ -87,7 +87,7 @@ public class PermissionsHelper {
      * requested datastream, and the datastream is present.
      *
      * @param principals agent principals
-     * @param datastream datastream being requested
+     * @param datastream type of datastream being requested
      * @param metadata object
      * @return
      */

--- a/access-common/src/main/java/edu/unc/lib/dl/ui/service/PermissionsHelper.java
+++ b/access-common/src/main/java/edu/unc/lib/dl/ui/service/PermissionsHelper.java
@@ -19,15 +19,15 @@ import static edu.unc.lib.dl.acl.fcrepo4.DatastreamPermissionUtil.getPermissionF
 import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.PUBLIC_PRINC;
 import static edu.unc.lib.dl.acl.util.Permission.editDescription;
 import static edu.unc.lib.dl.acl.util.UserRole.canViewOriginals;
-import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.JPEG_2000;
-import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.ORIGINAL_FILE;
-import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.SMALL_THUMBNAIL;
-import static org.springframework.util.Assert.hasText;
+import static edu.unc.lib.dl.model.DatastreamType.JP2_ACCESS_COPY;
+import static edu.unc.lib.dl.model.DatastreamType.ORIGINAL_FILE;
+import static edu.unc.lib.dl.model.DatastreamType.THUMBNAIL_SMALL;
 import static org.springframework.util.Assert.notNull;
 
 import edu.unc.lib.dl.acl.service.AccessControlService;
 import edu.unc.lib.dl.acl.util.AccessGroupSet;
 import edu.unc.lib.dl.acl.util.Permission;
+import edu.unc.lib.dl.model.DatastreamType;
 import edu.unc.lib.dl.search.solr.model.BriefObjectMetadata;
 
 /**
@@ -67,7 +67,7 @@ public class PermissionsHelper {
      * @return
      */
     public boolean hasThumbnailAccess(AccessGroupSet principals, BriefObjectMetadata metadata) {
-        return hasDatastreamAccess(principals, SMALL_THUMBNAIL, metadata);
+        return hasDatastreamAccess(principals, THUMBNAIL_SMALL, metadata);
     }
 
     /**
@@ -79,7 +79,7 @@ public class PermissionsHelper {
      * @return
      */
     public boolean hasImagePreviewAccess(AccessGroupSet principals, BriefObjectMetadata metadata) {
-        return hasDatastreamAccess(principals, JPEG_2000, metadata);
+        return hasDatastreamAccess(principals, JP2_ACCESS_COPY, metadata);
     }
 
     /**
@@ -87,18 +87,19 @@ public class PermissionsHelper {
      * requested datastream, and the datastream is present.
      *
      * @param principals agent principals
-     * @param datastream name of datastream being requested
+     * @param datastream datastream being requested
      * @param metadata object
      * @return
      */
-    public boolean hasDatastreamAccess(AccessGroupSet principals, String datastream,
+    public boolean hasDatastreamAccess(AccessGroupSet principals, DatastreamType datastream,
             BriefObjectMetadata metadata) {
         notNull(principals, "Requires agent principals");
-        hasText(datastream, "Requires datastream name");
+        notNull(datastream, "Requires datastream type");
         notNull(metadata, "Requires metadata object");
 
+        String dsIdentifier = datastream.getId();
         if (metadata.getDatastreamObjects() == null
-                || !containsDatastream(metadata, datastream)) {
+                || !containsDatastream(metadata, dsIdentifier)) {
             return false;
         }
 

--- a/access-common/src/main/java/edu/unc/lib/dl/ui/util/DatastreamUtil.java
+++ b/access-common/src/main/java/edu/unc/lib/dl/ui/util/DatastreamUtil.java
@@ -32,12 +32,17 @@ import edu.unc.lib.dl.search.solr.model.Datastream;
  */
 public class DatastreamUtil {
 
+    private static String datastreamEndpoint;
+
     private static final List<String> INDEXABLE_EXTENSIONS = asList(
             "doc", "docx", "htm", "html", "pdf", "ppt", "pptx", "rtf", "txt", "xls", "xlsx", "xml");
 
     private DatastreamUtil() {
     }
 
+    public static void setDatastreamEndpoint(String uri) {
+        datastreamEndpoint = uri;
+    }
     /**
      * Returns a URL for retrieving a specific datastream of the provided object.
      *
@@ -114,4 +119,37 @@ public class DatastreamUtil {
         return preferredDS;
     }
 
+    /**
+     * Returns the url for accessing a thumbnail of the specified size for the provided object. If the object does not have a thumbnail of that size, an empty string is returned.
+     *
+     * @param metadata metadata record for object
+     * @param size name of thumbnail size being requested.
+     * @return url for thumbnail or empty string if the requested size thumbnail is not available.
+     */
+    public static String getThumbnailUrl(BriefObjectMetadata metadata, String size) {
+        String selectedSize = size == null ? "small" : size;
+        selectedSize = selectedSize.toLowerCase().trim();
+        String derivativeName = selectedSize + "_thumbnail";
+
+        // Prefer the matching derivative from this object
+        Datastream preferredDS = getPreferredDatastream(metadata, derivativeName);
+
+        // Ensure that this item has the appropriate thumbnail
+        if (preferredDS == null) {
+            return "";
+        }
+
+        StringBuilder url = new StringBuilder(datastreamEndpoint);
+
+        url.append("thumb/");
+        if (isBlank(preferredDS.getOwner())) {
+            url.append(metadata.getId());
+        } else {
+            url.append(preferredDS.getOwner());
+        }
+
+        url.append("/").append(selectedSize);
+
+        return url.toString();
+    }
 }

--- a/access-common/src/main/java/edu/unc/lib/dl/ui/util/DatastreamUtil.java
+++ b/access-common/src/main/java/edu/unc/lib/dl/ui/util/DatastreamUtil.java
@@ -120,11 +120,14 @@ public class DatastreamUtil {
     }
 
     /**
-     * Returns the url for accessing a thumbnail of the specified size for the provided object. If the object does not have a thumbnail of that size, an empty string is returned.
+     * Returns the url for accessing a thumbnail of the specified size for the
+     * provided object. If the object does not have a thumbnail of that size, an
+     * empty string is returned.
      *
      * @param metadata metadata record for object
      * @param size name of thumbnail size being requested.
-     * @return url for thumbnail or empty string if the requested size thumbnail is not available.
+     * @return url for thumbnail or empty string if the requested size thumbnail
+     *         is not available.
      */
     public static String getThumbnailUrl(BriefObjectMetadata metadata, String size) {
         String selectedSize = size == null ? "small" : size;

--- a/access-common/src/main/java/edu/unc/lib/dl/ui/util/DatastreamUtil.java
+++ b/access-common/src/main/java/edu/unc/lib/dl/ui/util/DatastreamUtil.java
@@ -129,7 +129,7 @@ public class DatastreamUtil {
     public static String getThumbnailUrl(BriefObjectMetadata metadata, String size) {
         String selectedSize = size == null ? "small" : size;
         selectedSize = selectedSize.toLowerCase().trim();
-        String derivativeName = selectedSize + "_thumbnail";
+        String derivativeName = "thumbnail_" + selectedSize;
 
         // Prefer the matching derivative from this object
         Datastream preferredDS = getPreferredDatastream(metadata, derivativeName);

--- a/access-common/src/main/resources/META-INF/cdrUI.tld
+++ b/access-common/src/main/resources/META-INF/cdrUI.tld
@@ -77,6 +77,13 @@
 		</function-signature>
 	</function>
 	<function>
+		<name>getThumbnailUrl</name>
+		<function-class>edu.unc.lib.dl.ui.util.DatastreamUtil</function-class>
+		<function-signature>
+			java.lang.String getThumbnailUrl(edu.unc.lib.dl.search.solr.model.BriefObjectMetadata, java.lang.String)
+		</function-signature>
+	</function>
+	<function>
 		<name>formatFilesize</name>
 		<function-class>edu.unc.lib.dl.ui.util.StringFormatUtil</function-class>
 		<function-signature>

--- a/access-common/src/test/java/edu/unc/lib/dl/ui/service/PermissionsHelperTest.java
+++ b/access-common/src/test/java/edu/unc/lib/dl/ui/service/PermissionsHelperTest.java
@@ -18,6 +18,8 @@ package edu.unc.lib.dl.ui.service;
 import static edu.unc.lib.dl.acl.util.Permission.editDescription;
 import static edu.unc.lib.dl.acl.util.Permission.viewAccessCopies;
 import static edu.unc.lib.dl.acl.util.Permission.viewOriginal;
+import static edu.unc.lib.dl.model.DatastreamType.JP2_ACCESS_COPY;
+import static edu.unc.lib.dl.model.DatastreamType.ORIGINAL_FILE;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
@@ -67,8 +69,8 @@ public class PermissionsHelperTest {
         mdObject.setId("uuid:test");
         mdObject.setRoleGroup(roleGroups);
         List<String> datastreams = Arrays.asList(
-                "original_file|application/pdf|file.pdf|pdf|766|urn:sha1:36a318bb36f5b2c9aa218bad6e43c952d0a0f413|",
-                "jp2_access_copy|application/jp2|file.jp2|jp2|884|urn:sha1:fc9ac8a1af222d4179934fe2815f2acf9cefaca3|");
+                ORIGINAL_FILE.getId() + "|application/pdf|file.pdf|pdf|766|urn:sha1:checksum|",
+                JP2_ACCESS_COPY.getId() + "|application/jp2|file.jp2|jp2|884||");
         mdObject.setDatastream(datastreams);
 
         principals = new AccessGroupSet("group");
@@ -105,21 +107,21 @@ public class PermissionsHelperTest {
     public void testPermitOriginalAccess() {
         assignPermission(viewOriginal, true);
 
-        assertTrue(helper.hasDatastreamAccess(principals, "original_file", mdObject));
+        assertTrue(helper.hasDatastreamAccess(principals, ORIGINAL_FILE, mdObject));
     }
 
     @Test
     public void testPermitDerivativeAccess() {
         assignPermission(viewAccessCopies, true);
 
-        assertTrue(helper.hasDatastreamAccess(principals, "jp2_access_copy", mdObject));
+        assertTrue(helper.hasDatastreamAccess(principals, JP2_ACCESS_COPY, mdObject));
     }
 
     @Test
     public void testDenyOriginalAccess() {
         assignPermission(viewOriginal, false);
 
-        assertFalse(helper.hasDatastreamAccess(principals, "original_file", mdObject));
+        assertFalse(helper.hasDatastreamAccess(principals, ORIGINAL_FILE, mdObject));
     }
 
     @Test

--- a/access-common/src/test/java/edu/unc/lib/dl/ui/util/DatastreamUtilTest.java
+++ b/access-common/src/test/java/edu/unc/lib/dl/ui/util/DatastreamUtilTest.java
@@ -16,11 +16,13 @@
 package edu.unc.lib.dl.ui.util;
 
 import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.ORIGINAL_FILE;
+import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.SMALL_THUMBNAIL;
 import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.TECHNICAL_METADATA;
 import static edu.unc.lib.dl.test.TestHelper.makePid;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import edu.unc.lib.dl.fedora.PID;
@@ -33,9 +35,17 @@ import edu.unc.lib.dl.search.solr.model.BriefObjectMetadataBean;
  */
 public class DatastreamUtilTest {
 
+    private final static String ENDPOINT_URL = "services/api/";
+
     private final static String ORIGINAL_DS = ORIGINAL_FILE + "|image/jpg|image|jpg|555||";
     private final static String ORIGINAL_INDEXABLE = ORIGINAL_FILE + "|application/pdf|doc.pdf|pdf|5555||";
     private final static String FITS_DS = TECHNICAL_METADATA + "|text/xml|fits.xml|xml|5555||";
+    private final static String THUMB_SMALL_DS = SMALL_THUMBNAIL + "|image/png|small|png|3333||";
+
+    @Before
+    public void setup() {
+        DatastreamUtil.setDatastreamEndpoint(ENDPOINT_URL);
+    }
 
     @Test
     public void testGetOriginalFileUrl() {
@@ -68,5 +78,40 @@ public class DatastreamUtilTest {
 
         String url = DatastreamUtil.getDatastreamUrl(mdObj, TECHNICAL_METADATA);
         assertEquals("indexablecontent/" + pid.getId() + "/techmd_fits", url);
+    }
+
+    @Test
+    public void testGetThumbnailUrl() {
+        PID pid = makePid();
+        BriefObjectMetadataBean mdObj = new BriefObjectMetadataBean();
+        mdObj.setId(pid.getId());
+        mdObj.setDatastream(asList(ORIGINAL_DS, THUMB_SMALL_DS));
+
+        String url = DatastreamUtil.getThumbnailUrl(mdObj, "small");
+        assertEquals(ENDPOINT_URL + "thumb/" + pid.getId() + "/small", url);
+    }
+
+    @Test
+    public void testGetThumbnailUrlForPrimaryObject() {
+        PID primaryObjPid = makePid();
+
+        PID pid = makePid();
+        BriefObjectMetadataBean mdObj = new BriefObjectMetadataBean();
+        mdObj.setId(pid.getId());
+        mdObj.setDatastream(asList(ORIGINAL_DS, THUMB_SMALL_DS + primaryObjPid.getId()));
+
+        String url = DatastreamUtil.getThumbnailUrl(mdObj, "small");
+        assertEquals(ENDPOINT_URL + "thumb/" + primaryObjPid.getId() + "/small", url);
+    }
+
+    @Test
+    public void testGetThumbnailUrlNoThumbs() {
+        PID pid = makePid();
+        BriefObjectMetadataBean mdObj = new BriefObjectMetadataBean();
+        mdObj.setId(pid.getId());
+        mdObj.setDatastream(asList(ORIGINAL_DS));
+
+        String url = DatastreamUtil.getThumbnailUrl(mdObj, "small");
+        assertEquals("", url);
     }
 }

--- a/access-common/src/test/java/edu/unc/lib/dl/ui/util/DatastreamUtilTest.java
+++ b/access-common/src/test/java/edu/unc/lib/dl/ui/util/DatastreamUtilTest.java
@@ -15,9 +15,9 @@
  */
 package edu.unc.lib.dl.ui.util;
 
-import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.ORIGINAL_FILE;
-import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.SMALL_THUMBNAIL;
-import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.TECHNICAL_METADATA;
+import static edu.unc.lib.dl.model.DatastreamType.ORIGINAL_FILE;
+import static edu.unc.lib.dl.model.DatastreamType.TECHNICAL_METADATA;
+import static edu.unc.lib.dl.model.DatastreamType.THUMBNAIL_SMALL;
 import static edu.unc.lib.dl.test.TestHelper.makePid;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
@@ -37,10 +37,10 @@ public class DatastreamUtilTest {
 
     private final static String ENDPOINT_URL = "services/api/";
 
-    private final static String ORIGINAL_DS = ORIGINAL_FILE + "|image/jpg|image|jpg|555||";
-    private final static String ORIGINAL_INDEXABLE = ORIGINAL_FILE + "|application/pdf|doc.pdf|pdf|5555||";
-    private final static String FITS_DS = TECHNICAL_METADATA + "|text/xml|fits.xml|xml|5555||";
-    private final static String THUMB_SMALL_DS = SMALL_THUMBNAIL + "|image/png|small|png|3333||";
+    private final static String ORIGINAL_DS = ORIGINAL_FILE.getId() + "|image/jpg|image|jpg|555||";
+    private final static String ORIGINAL_INDEXABLE = ORIGINAL_FILE.getId() + "|application/pdf|doc.pdf|pdf|5555||";
+    private final static String FITS_DS = TECHNICAL_METADATA.getId() + "|text/xml|fits.xml|xml|5555||";
+    private final static String THUMB_SMALL_DS = THUMBNAIL_SMALL.getId() + "|image/png|small|png|3333||";
 
     @Before
     public void setup() {
@@ -76,7 +76,7 @@ public class DatastreamUtilTest {
         mdObj.setId(pid.getId());
         mdObj.setDatastream(asList(FITS_DS));
 
-        String url = DatastreamUtil.getDatastreamUrl(mdObj, TECHNICAL_METADATA);
+        String url = DatastreamUtil.getDatastreamUrl(mdObj, TECHNICAL_METADATA.getId());
         assertEquals("indexablecontent/" + pid.getId() + "/techmd_fits", url);
     }
 

--- a/access/src/main/webapp/WEB-INF/access-fedora-context.xml
+++ b/access/src/main/webapp/WEB-INF/access-fedora-context.xml
@@ -44,7 +44,7 @@
         <property name="externalContentPath" value="${external.base.url}" />
     </bean>
     
-      <bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+    <bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
         <property name="staticMethod"
             value="edu.unc.lib.dl.ui.util.SerializationUtil.injectSettings" />
         <property name="arguments">
@@ -52,6 +52,16 @@
                 <ref bean="applicationPathSettings" />
                 <ref bean="searchSettings" />
                 <ref bean="solrSettings" />
+            </list>
+        </property>
+    </bean>
+    
+    <bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+        <property name="staticMethod"
+            value="edu.unc.lib.dl.ui.util.DatastreamUtil.setDatastreamEndpoint" />
+        <property name="arguments">
+            <list>
+                <value>${services.api.url}</value>
             </list>
         </property>
     </bean>

--- a/access/src/main/webapp/WEB-INF/jsp/common/thumbnail.jsp
+++ b/access/src/main/webapp/WEB-INF/jsp/common/thumbnail.jsp
@@ -68,10 +68,10 @@
 <c:set var="src">
 	<c:choose>
 		<c:when test="${param.size == 'large' && permsHelper.hasThumbnailAccess(requestScope.accessGroupSet, thumbnailObject)}">
-			<c:out value="${cdr:getDatastreamUrl(thumbnailObject, 'THUMB_LARGE')}" />
+			<c:out value="${cdr:getThumbnailUrl(thumbnailObject, 'large')}" />
 		</c:when>
 		<c:when test="${param.size == 'small' && permsHelper.hasThumbnailAccess(requestScope.accessGroupSet, thumbnailObject)}">
-			<c:out value="${cdr:getDatastreamUrl(thumbnailObject, 'THUMB_SMALL')}" />
+			<c:out value="${cdr:getThumbnailUrl(thumbnailObject, 'small')}" />
 		</c:when>
 	</c:choose>
 </c:set>

--- a/access/src/test/java/edu/unc/lib/dl/ui/controller/FedoraContentControllerIT.java
+++ b/access/src/test/java/edu/unc/lib/dl/ui/controller/FedoraContentControllerIT.java
@@ -15,7 +15,7 @@
  */
 package edu.unc.lib.dl.ui.controller;
 
-import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.TECHNICAL_METADATA;
+import static edu.unc.lib.dl.model.DatastreamType.TECHNICAL_METADATA;
 import static edu.unc.lib.dl.test.TestHelper.makePid;
 import static edu.unc.lib.dl.ui.service.FedoraContentService.CONTENT_DISPOSITION;
 import static org.junit.Assert.assertEquals;
@@ -187,7 +187,7 @@ public class FedoraContentControllerIT {
 
         FileObject fileObj = repositoryObjectFactory.createFileObject(filePid, null);
         fileObj.addOriginalFile(new ByteArrayInputStream(BINARY_CONTENT.getBytes()), null, "text/plain", null, null);
-        fileObj.addBinary(TECHNICAL_METADATA, new ByteArrayInputStream(content.getBytes()),
+        fileObj.addBinary(TECHNICAL_METADATA.getId(), new ByteArrayInputStream(content.getBytes()),
                 "fits.xml", "application/xml", null, null, null);
 
         // Verify original file content retrievable
@@ -198,7 +198,7 @@ public class FedoraContentControllerIT {
         assertEquals(BINARY_CONTENT, result1.getResponse().getContentAsString());
 
         // Verify administrative datastream retrievable
-        MvcResult result2 = mvc.perform(get(requestPath + filePid.getId() + "/" + TECHNICAL_METADATA))
+        MvcResult result2 = mvc.perform(get(requestPath + filePid.getId() + "/" + TECHNICAL_METADATA.getId()))
                 .andExpect(status().is2xxSuccessful())
                 .andReturn();
 
@@ -217,7 +217,7 @@ public class FedoraContentControllerIT {
         String content = "<fits>content</fits>";
 
         FileObject fileObj = repositoryObjectFactory.createFileObject(filePid, null);
-        fileObj.addBinary(TECHNICAL_METADATA, new ByteArrayInputStream(content.getBytes()),
+        fileObj.addBinary(TECHNICAL_METADATA.getId(), new ByteArrayInputStream(content.getBytes()),
                 "fits.xml", "application/xml", null, null, null);
 
         // Requires viewHidden permission
@@ -225,7 +225,7 @@ public class FedoraContentControllerIT {
                 .assertHasAccess(anyString(), eq(filePid), any(AccessGroupSet.class), eq(Permission.viewHidden));
 
         // Verify administrative datastream retrievable
-        MvcResult result = mvc.perform(get("/content/" + filePid.getId() + "/" + TECHNICAL_METADATA))
+        MvcResult result = mvc.perform(get("/content/" + filePid.getId() + "/" + TECHNICAL_METADATA.getId()))
                 .andExpect(status().isForbidden())
                 .andReturn();
 

--- a/deposit/src/main/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJob.java
@@ -15,7 +15,7 @@
  */
 package edu.unc.lib.deposit.fcrepo4;
 
-import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.TECHNICAL_METADATA;
+import static edu.unc.lib.dl.model.DatastreamType.TECHNICAL_METADATA;
 import static edu.unc.lib.dl.xml.NamespaceConstants.FITS_URI;
 import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 
@@ -368,7 +368,7 @@ public class IngestContentObjectsJob extends AbstractDepositJob {
     private void addFitsReport(FileObject fileObj) throws DepositException {
         File fitsFile = new File(getTechMdDirectory(), fileObj.getPid().getUUID() + ".xml");
         try (InputStream fitsStream = new FileInputStream(fitsFile)) {
-            fileObj.addBinary(TECHNICAL_METADATA, fitsStream, fitsFile.getName(), "text/xml",
+            fileObj.addBinary(TECHNICAL_METADATA.getId(), fitsStream, fitsFile.getName(), "text/xml",
                     IanaRelation.derivedfrom, DCTerms.conformsTo, createResource(FITS_URI));
         } catch (IOException e) {
             throw new DepositException("Unable to ingest technical metadata for "

--- a/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJobTest.java
@@ -16,7 +16,7 @@
 package edu.unc.lib.deposit.fcrepo4;
 
 import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.AUTHENTICATED_PRINC;
-import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.TECHNICAL_METADATA;
+import static edu.unc.lib.dl.model.DatastreamType.TECHNICAL_METADATA;
 import static edu.unc.lib.dl.test.TestHelpers.setField;
 import static edu.unc.lib.dl.util.DepositConstants.TECHMD_DIR;
 import static org.junit.Assert.assertTrue;
@@ -291,7 +291,7 @@ public class IngestContentObjectsJobTest extends AbstractDepositJobTest {
 
         verify(jobStatusFactory, times(3)).incrCompletion(eq(jobUUID), eq(1));
 
-        verify(mockFileObj, times(2)).addBinary(eq(TECHNICAL_METADATA), any(InputStream.class),
+        verify(mockFileObj, times(2)).addBinary(eq(TECHNICAL_METADATA.getId()), any(InputStream.class),
                 anyString(), anyString(), any(Property.class), eq(DCTerms.conformsTo),
                 any(Resource.class));
     }

--- a/etc/server.properties
+++ b/etc/server.properties
@@ -79,6 +79,8 @@ access.base.url=http://localhost:8181/
 services.base.url=http://localhost:8182/services/
 services.api.url=http://localhost:8182/services/api/
 
+derivative.dir=${vagrant.cwd}/data/derivatives/
+
 # ingest service settings
 initial.batch.ingest.dir=${vagrant.cwd}/data/deposits/
 batch.ingest.dir=${vagrant.cwd}/data/deposits/

--- a/etc/server.properties
+++ b/etc/server.properties
@@ -77,6 +77,7 @@ admin.services.url=http://localhost:8182
 admin.base.url=http://localhost:8182/admin/
 access.base.url=http://localhost:8181/
 services.base.url=http://localhost:8182/services/
+services.api.url=http://localhost:8182/services/api/
 
 # ingest service settings
 initial.batch.ingest.dir=${vagrant.cwd}/data/deposits/

--- a/etc/services-camel.properties
+++ b/etc/services-camel.properties
@@ -8,11 +8,6 @@ fcrepo.authUsername=
 fcrepo.authPassword=
 fcrepo.authHost=
 
-cdr.enhancement.thumbnail.fileExtension=PNG
-cdr.enhancement.thumbnail.mimetype=image/png
-cdr.enhancement.fulltext.fileName=full_text.txt
-cdr.enhancement.jp2.fileExtension=JP2
-cdr.enhancement.jp2.mimetype=image/jp2
 # Delay specified in milliseconds
 cdr.enhancement.postIndexingDelay=5000
 cdr.enhancement.processingThreads=2

--- a/etc/services-camel.properties
+++ b/etc/services-camel.properties
@@ -8,6 +8,8 @@ fcrepo.authUsername=
 fcrepo.authPassword=
 fcrepo.authHost=
 
+derivative.dir=${vagrant.cwd}/data/derivatives/
+
 # Delay specified in milliseconds
 cdr.enhancement.postIndexingDelay=5000
 cdr.enhancement.processingThreads=2

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/acl/fcrepo4/DatastreamPermissionUtil.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/acl/fcrepo4/DatastreamPermissionUtil.java
@@ -15,18 +15,14 @@
  */
 package edu.unc.lib.dl.acl.fcrepo4;
 
-import static edu.unc.lib.dl.acl.util.Permission.viewAccessCopies;
 import static edu.unc.lib.dl.acl.util.Permission.viewHidden;
-import static edu.unc.lib.dl.acl.util.Permission.viewMetadata;
-import static edu.unc.lib.dl.acl.util.Permission.viewOriginal;
-import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.JPEG_2000;
-import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.LARGE_THUMBNAIL;
-import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.ORIGINAL_FILE;
-import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.SMALL_THUMBNAIL;
+import static edu.unc.lib.dl.model.DatastreamType.getByIdentifier;
 
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.util.Assert;
 
 import edu.unc.lib.dl.acl.util.Permission;
+import edu.unc.lib.dl.model.DatastreamType;
 
 /**
  * Helper methods for determining permissions of datastreams.
@@ -41,27 +37,32 @@ public class DatastreamPermissionUtil {
     /**
      * Determine the Permission which applies to accessing the specified datastream.
      *
-     * @param datastream name of the datastream.  Required.
+     * @param dsName name of the datastream.  Required.
      * @return permission
      */
-    public static Permission getPermissionForDatastream(String datastream) {
-        if (StringUtils.isBlank(datastream)) {
+    public static Permission getPermissionForDatastream(String dsName) {
+        if (StringUtils.isBlank(dsName)) {
             throw new IllegalArgumentException("A non-null datastream name must be provided");
         }
 
-        if (ORIGINAL_FILE.equals(datastream)) {
-            return viewOriginal;
+        DatastreamType datastream = getByIdentifier(dsName);
+        // If the requested datastream is not a known type, consider it to be administrative
+        if (datastream == null) {
+            return viewHidden;
         }
-        if (SMALL_THUMBNAIL.equals(datastream)) {
-            return viewMetadata;
-        }
-        if (LARGE_THUMBNAIL.equals(datastream)) {
-            return viewMetadata;
-        }
-        if (JPEG_2000.equals(datastream)) {
-            return viewAccessCopies;
-        }
-        // All other datastreams are considered administrative
-        return viewHidden;
+
+        return getPermissionForDatastream(datastream);
+    }
+
+    /**
+     * Determine the Permission which applies to accessing the specified datastream.
+     *
+     * @param datastream datastream type to check. Required.
+     * @return permission
+     */
+    public static Permission getPermissionForDatastream(DatastreamType datastream) {
+        Assert.notNull(datastream);
+
+        return datastream.getAccessPermission();
     }
 }

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryPathConstants.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryPathConstants.java
@@ -45,17 +45,7 @@ public abstract class RepositoryPathConstants {
 
     // Named objects
 
-    public static final String SMALL_THUMBNAIL = "small_thumbnail";
-
-    public static final String LARGE_THUMBNAIL = "large_thumbnail";
-
-    public static final String FULLTEXT_EXTRACTION = "fulltext_extraction";
-
-    public static final String JPEG_2000 = "jp2_access_copy";
-
     public static final String ORIGINAL_FILE = "original_file";
-
-    public static final String TECHNICAL_METADATA = "techmd_fits";
 
     public static final String CONTENT_ROOT_ID = "collections";
 

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/model/DatastreamType.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/model/DatastreamType.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.model;
+
+import static edu.unc.lib.dl.acl.util.Permission.viewAccessCopies;
+import static edu.unc.lib.dl.acl.util.Permission.viewHidden;
+import static edu.unc.lib.dl.acl.util.Permission.viewMetadata;
+import static edu.unc.lib.dl.acl.util.Permission.viewOriginal;
+import static edu.unc.lib.dl.model.StoragePolicy.EXTERNAL;
+import static edu.unc.lib.dl.model.StoragePolicy.INTERNAL;
+
+import edu.unc.lib.dl.acl.util.Permission;
+
+/**
+ * Predefined binary datastream types which may be associated with repository objects.
+ *
+ * @author bbpennel
+ *
+ */
+public enum DatastreamType {
+    FULLTEXT_EXTRACTION("fulltext", "text/plain", "txt", EXTERNAL, viewHidden),
+    JP2_ACCESS_COPY("jp2", "image/jp2", "jp2", EXTERNAL, viewAccessCopies),
+    ORIGINAL_FILE("original_file", null, null, INTERNAL, viewOriginal),
+    TECHNICAL_METADATA("techmd_fits", "text/xml", "xml", INTERNAL, viewHidden),
+    THUMBNAIL_SMALL("thumbnail_small", "image/png", "png", EXTERNAL, viewMetadata),
+    THUMBNAIL_LARGE("thumbnail_large", "image/png", "png", EXTERNAL, viewMetadata);
+
+    private final String id;
+    private final String mimetype;
+    private final String extension;
+    private final StoragePolicy storagePolicy;
+    private final Permission accessPermission;
+
+    private DatastreamType(String identifier, String mimetype, String extension, StoragePolicy storagePolicy,
+            Permission accessPermission) {
+        this.id = identifier;
+        this.mimetype = mimetype;
+        this.extension = extension;
+        this.storagePolicy = storagePolicy;
+        this.accessPermission = accessPermission;
+    }
+
+    /**
+     * @return name identifier for the datastream.
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * @return Mimetype for datastreams of this type
+     */
+    public String getMimetype() {
+        return mimetype;
+    }
+
+    /**
+     * @return File extension used with this datastream
+     */
+    public String getExtension() {
+        return extension;
+    }
+
+    /**
+     * @return Policy indicating how this datastream should be stored and accessed.
+     */
+    public StoragePolicy getStoragePolicy() {
+        return storagePolicy;
+    }
+
+    /**
+     * @return Permission required in order to access this datastream
+     */
+    public Permission getAccessPermission() {
+        return accessPermission;
+    }
+
+    /**
+     * Get the DatastreamType with the given identifier.
+     *
+     * @param id identifier of the datastream.
+     * @return datastream type for identifier, or null if there is no matching type.
+     */
+    public static DatastreamType getByIdentifier(String id) {
+        for (DatastreamType type : values()) {
+            if (type.getId().equals(id)) {
+                return type;
+            }
+        }
+        return null;
+    }
+}

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/model/StoragePolicy.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/model/StoragePolicy.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.model;
+
+/**
+ * Storage policy describing how a datastream should be stored and addressed.
+ *
+ * @author bbpennel
+ *
+ */
+public enum StoragePolicy {
+    INTERNAL("Stored within the repository's internally managed datastore."),
+    PROXIED("Managed and served via the repository from an external URI."),
+    EXTERNAL("Stored, addressed and managed outside of repository."),
+    REDIRECTED("Tracked by repository, requests are redirected to an external URI.");
+
+    private final String description;
+
+    private StoragePolicy(String description) {
+        this.description = description;
+    }
+
+    /**
+     * @return description of the storage policy
+     */
+    public String getDescription() {
+        return description;
+    }
+}

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/util/DerivativeService.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/util/DerivativeService.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.util;
+
+import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.HASHED_PATH_DEPTH;
+import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.HASHED_PATH_SIZE;
+import static edu.unc.lib.dl.fcrepo4.RepositoryPaths.idToPath;
+import static edu.unc.lib.dl.model.StoragePolicy.EXTERNAL;
+import static org.springframework.util.Assert.notNull;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.model.DatastreamType;
+
+/**
+ * Service which locates and returns file information about derivatives for
+ * repository objects.
+ *
+ * @author bbpennel
+ *
+ */
+public class DerivativeService {
+
+    private String derivativeDir;
+
+    private List<DatastreamType> derivativeTypes;
+
+    public DerivativeService() {
+    }
+
+    /**
+     * Gets the derivative of type dsType for the object identified by pid.
+     *
+     * @param pid pid of the object. Required.
+     * @param dsType type of the derivative to retrieve.
+     * @return Derivative of type dsType for object pid, or null if the
+     *         derivative does not exist.
+     */
+    public Derivative getDerivative(PID pid, DatastreamType dsType) {
+        notNull(pid);
+        notNull(dsType);
+
+        String id = pid.getId();
+        String hashedPath = idToPath(id, HASHED_PATH_DEPTH, HASHED_PATH_SIZE);
+
+        // Construct the full path of the derivative
+        Path derivPath = Paths.get(derivativeDir, dsType.getId(), hashedPath, id + dsType.getExtension());
+        File derivFile = derivPath.toFile();
+
+        // If the derivative file does not exist, then return no result
+        if (!derivFile.exists()) {
+            return null;
+        }
+
+        return new Derivative(dsType, derivFile);
+    }
+
+    /**
+     * Generates a list of all derivatives present for the object identified by
+     * pid.
+     *
+     * @param pid pid of the object. Required.
+     * @return list of derivatives for pid
+     */
+    public List<Derivative> getDerivatives(PID pid) {
+        notNull(pid);
+
+        return listDerivativeTypes().stream()
+            .map(derivType -> getDerivative(pid, derivType))
+            .filter(deriv -> deriv != null)
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * List all DatastreamTypes which are considered derivatives.
+     *
+     * @return
+     */
+    public List<DatastreamType> listDerivativeTypes() {
+        if (derivativeTypes == null) {
+            derivativeTypes = Arrays.stream(DatastreamType.values())
+                    .filter(dt -> EXTERNAL.equals(dt.getStoragePolicy()))
+                    .collect(Collectors.toList());
+        }
+
+        return derivativeTypes;
+    }
+
+    /**
+     * @param derivativeDir the derivativeDir to set
+     */
+    public void setDerivativeDir(String derivativeDir) {
+        this.derivativeDir = derivativeDir;
+    }
+
+    /**
+     * A derivative datastream.
+     *
+     * @author bbpennel
+     *
+     */
+    public static class Derivative {
+        private DatastreamType type;
+        private File file;
+
+        public Derivative(DatastreamType type, File file) {
+            this.type = type;
+            this.file = file;
+        }
+
+        /**
+         * @return the datastream type of this derivative
+         */
+        public DatastreamType getType() {
+            return type;
+        }
+
+        /**
+         * @return the derivative file
+         */
+        public File getFile() {
+            return file;
+        }
+
+    }
+}

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/util/DerivativeService.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/util/DerivativeService.java
@@ -63,7 +63,7 @@ public class DerivativeService {
         String hashedPath = idToPath(id, HASHED_PATH_DEPTH, HASHED_PATH_SIZE);
 
         // Construct the full path of the derivative
-        Path derivPath = Paths.get(derivativeDir, dsType.getId(), hashedPath, id + dsType.getExtension());
+        Path derivPath = Paths.get(derivativeDir, dsType.getId(), hashedPath, id + "." + dsType.getExtension());
         File derivFile = derivPath.toFile();
 
         // If the derivative file does not exist, then return no result

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/util/DerivativeService.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/util/DerivativeService.java
@@ -18,6 +18,7 @@ package edu.unc.lib.dl.util;
 import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.HASHED_PATH_DEPTH;
 import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.HASHED_PATH_SIZE;
 import static edu.unc.lib.dl.fcrepo4.RepositoryPaths.idToPath;
+import static edu.unc.lib.dl.model.DatastreamType.getByIdentifier;
 import static edu.unc.lib.dl.model.StoragePolicy.EXTERNAL;
 import static org.springframework.util.Assert.notNull;
 
@@ -42,7 +43,7 @@ public class DerivativeService {
 
     private String derivativeDir;
 
-    private List<DatastreamType> derivativeTypes;
+    private volatile static List<DatastreamType> derivativeTypes;
 
     public DerivativeService() {
     }
@@ -95,7 +96,7 @@ public class DerivativeService {
      *
      * @return
      */
-    public List<DatastreamType> listDerivativeTypes() {
+    public static List<DatastreamType> listDerivativeTypes() {
         if (derivativeTypes == null) {
             derivativeTypes = Arrays.stream(DatastreamType.values())
                     .filter(dt -> EXTERNAL.equals(dt.getStoragePolicy()))
@@ -103,6 +104,16 @@ public class DerivativeService {
         }
 
         return derivativeTypes;
+    }
+
+    /**
+     * Returns true if the datastream provided is a derivative type
+     *
+     * @param dsName
+     * @return
+     */
+    public static boolean isDerivative(String dsName) {
+        return listDerivativeTypes().contains(getByIdentifier(dsName));
     }
 
     /**

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/acl/fcrepo4/DatastreamPermissionUtilTest.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/acl/fcrepo4/DatastreamPermissionUtilTest.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.acl.fcrepo4;
+
+import static edu.unc.lib.dl.acl.fcrepo4.DatastreamPermissionUtil.getPermissionForDatastream;
+import static edu.unc.lib.dl.acl.util.Permission.viewAccessCopies;
+import static edu.unc.lib.dl.acl.util.Permission.viewHidden;
+import static edu.unc.lib.dl.acl.util.Permission.viewOriginal;
+import static edu.unc.lib.dl.model.DatastreamType.JP2_ACCESS_COPY;
+import static edu.unc.lib.dl.model.DatastreamType.ORIGINAL_FILE;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ *
+ * @author bbpennel
+ *
+ */
+public class DatastreamPermissionUtilTest {
+
+    @Test
+    public void testGetDatastreamPermissionByName() {
+        assertEquals(viewOriginal, getPermissionForDatastream(ORIGINAL_FILE.getId()));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetDatastreamPermissionNoName() {
+        getPermissionForDatastream("");
+    }
+
+    @Test
+    public void testGetDatastreamPermissionUnknownType() {
+        assertEquals(viewHidden, getPermissionForDatastream("unknown"));
+    }
+
+    @Test
+    public void testGetDatastreamPermissionByType() {
+        assertEquals(viewAccessCopies, getPermissionForDatastream(JP2_ACCESS_COPY));
+    }
+}

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/util/DerivativeServiceTest.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/util/DerivativeServiceTest.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.util;
+
+import static edu.unc.lib.dl.model.DatastreamType.JP2_ACCESS_COPY;
+import static edu.unc.lib.dl.model.DatastreamType.ORIGINAL_FILE;
+import static edu.unc.lib.dl.model.DatastreamType.THUMBNAIL_SMALL;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.model.DatastreamType;
+import edu.unc.lib.dl.util.DerivativeService.Derivative;
+
+/**
+ *
+ * @author bbpennel
+ *
+ */
+public class DerivativeServiceTest {
+
+    private static final String ID = "c9d57df5-f67c-4330-917e-b46c1d0bec26";
+    private static final String HASHED_ID = "c9/d5/7d/f5/c9d57df5-f67c-4330-917e-b46c1d0bec26";
+
+    @Rule
+    public TemporaryFolder tmpDir = new TemporaryFolder();
+
+    private File derivativeDir;
+    private String derivativePath;
+
+    private PID pid;
+
+    private DerivativeService derivativeService;
+
+    @Before
+    public void init() throws Exception {
+        derivativeDir = tmpDir.getRoot();
+        derivativePath = derivativeDir.getAbsolutePath();
+
+        derivativeService = new DerivativeService();
+        derivativeService.setDerivativeDir(derivativePath);
+
+        pid = PIDs.get(ID);
+    }
+
+    @Test
+    public void testGetDerivative() throws Exception {
+        File originalDerivFile = createDerivative(pid, THUMBNAIL_SMALL);
+
+        Derivative deriv = derivativeService.getDerivative(pid, THUMBNAIL_SMALL);
+
+        assertEquals(originalDerivFile, deriv.getFile());
+        assertEquals(THUMBNAIL_SMALL, deriv.getType());
+    }
+
+    @Test
+    public void testGetDerivativeNotExist() throws Exception {
+        Derivative deriv = derivativeService.getDerivative(pid, THUMBNAIL_SMALL);
+
+        assertNull(deriv);
+    }
+
+    @Test
+    public void testGetDerivatives() throws Exception {
+        File originalDerivFile1 = createDerivative(pid, THUMBNAIL_SMALL);
+        File originalDerivFil21 = createDerivative(pid, JP2_ACCESS_COPY);
+
+        List<Derivative> derivs = derivativeService.getDerivatives(pid);
+        assertEquals(2, derivs.size());
+
+        Derivative thumbDeriv = findDerivative(derivs, THUMBNAIL_SMALL);
+        Derivative jp2Deriv = findDerivative(derivs, JP2_ACCESS_COPY);
+
+        assertNotNull(thumbDeriv);
+        assertNotNull(jp2Deriv);
+
+        assertEquals(originalDerivFile1, thumbDeriv.getFile());
+        assertEquals(originalDerivFil21, jp2Deriv.getFile());
+    }
+
+    @Test
+    public void testGetDerivativesIgnoreNonDerivatives() throws Exception {
+        File originalDerivFile1 = createDerivative(pid, THUMBNAIL_SMALL);
+        createDerivative(pid, ORIGINAL_FILE);
+
+        List<Derivative> derivs = derivativeService.getDerivatives(pid);
+        assertEquals(1, derivs.size());
+
+        Derivative thumbDeriv = findDerivative(derivs, THUMBNAIL_SMALL);
+        assertEquals(originalDerivFile1, thumbDeriv.getFile());
+    }
+
+    private Derivative findDerivative(List<Derivative> derivs, DatastreamType dsType) {
+        return derivs.stream().filter(d -> dsType.equals(d.getType()))
+                .findFirst().get();
+    }
+
+    private File createDerivative(PID pid, DatastreamType dsType) throws Exception {
+        Path derivPath = Paths.get(derivativePath, dsType.getId(), HASHED_ID + dsType.getExtension());
+        File derivFile = derivPath.toFile();
+        derivFile.getParentFile().mkdirs();
+
+        FileUtils.write(derivFile, "content", "UTF-8");
+
+        return derivFile;
+    }
+}

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/util/DerivativeServiceTest.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/util/DerivativeServiceTest.java
@@ -122,7 +122,7 @@ public class DerivativeServiceTest {
     }
 
     private File createDerivative(PID pid, DatastreamType dsType) throws Exception {
-        Path derivPath = Paths.get(derivativePath, dsType.getId(), HASHED_ID + dsType.getExtension());
+        Path derivPath = Paths.get(derivativePath, dsType.getId(), HASHED_ID + "." + dsType.getExtension());
         File derivFile = derivPath.toFile();
         derivFile.getParentFile().mkdirs();
 

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/images/AddDerivativeProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/images/AddDerivativeProcessor.java
@@ -84,8 +84,8 @@ public class AddDerivativeProcessor implements Processor {
         File derivative = derivativeFinalPath.toFile();
         File parentDir = derivative.getParentFile();
 
-        if (parentDir != null && !parentDir.mkdirs()) {
-            throw new IOException("Failed to create parent directories for " + derivative);
+        if (parentDir != null) {
+            parentDir.mkdirs();
         }
 
         Files.move(Paths.get(derivativeTmpPath),

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/images/ImageEnhancementsRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/images/ImageEnhancementsRouter.java
@@ -62,7 +62,7 @@ public class ImageEnhancementsRouter extends RouteBuilder {
             .routeId("SmallThumbnail")
             .log(LoggingLevel.INFO, "Creating/Updating Small Thumbnail for ${headers[CdrBinaryPath]}")
             .recipientList(simple("exec:/bin/sh?args=${properties:cdr.enhancement.bin}/convertScaleStage.sh "
-                    + "${headers[CdrBinaryPath]} PNG 64 64 "
+                    + "${headers[CdrBinaryPath]} png 64 64 "
                     + "${properties:services.tempDirectory}/${headers[CdrCheckSum]}-small"))
             .bean(addSmallThumbnailProcessor);
 
@@ -70,7 +70,7 @@ public class ImageEnhancementsRouter extends RouteBuilder {
             .routeId("LargeThumbnail")
             .log(LoggingLevel.INFO, "Creating/Updating Large Thumbnail for ${headers[CdrBinaryPath]}")
             .recipientList(simple("exec:/bin/sh?args=${properties:cdr.enhancement.bin}/convertScaleStage.sh "
-                    + "${headers[CdrBinaryPath]} PNG 128 128 "
+                    + "${headers[CdrBinaryPath]} png 128 128 "
                     + "${properties:services.tempDirectory}/${headers[CdrCheckSum]}-large"))
             .bean(addLargeThumbProcessor);
 
@@ -78,7 +78,7 @@ public class ImageEnhancementsRouter extends RouteBuilder {
             .routeId("AccessCopy")
             .log(LoggingLevel.INFO, "Creating/Updating JP2 access copy for ${headers[CdrBinaryPath]}")
             .recipientList(simple("exec:/bin/sh?args=${properties:cdr.enhancement.bin}/convertJp2.sh "
-                    + "${headers[CdrBinaryPath]} JP2 "
+                    + "${headers[CdrBinaryPath]} jp2 "
                     + "${properties:services.tempDirectory}/${headers[CdrCheckSum]}-access"))
             .bean(addAccessCopyProcessor);
     }

--- a/services-camel/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel/src/main/webapp/WEB-INF/service-context.xml
@@ -148,17 +148,17 @@
     </bean>
 
     <bean id="addSmallThumbnailProcessor" class="edu.unc.lib.dl.services.camel.images.AddDerivativeProcessor">
-        <constructor-arg value="${cdr.enhancement.thumbnail.fileExtension}" />
+        <constructor-arg value="#{T(edu.unc.lib.dl.model.DatastreamType).THUMBNAIL_SMALL.getExtension()}" />
         <constructor-arg value="${cdr.enhancement.path.thumbnail.small}" />
     </bean>
     
     <bean id="addLargeThumbnailProcessor" class="edu.unc.lib.dl.services.camel.images.AddDerivativeProcessor">
-        <constructor-arg value="${cdr.enhancement.thumbnail.fileExtension}" />
+        <constructor-arg value="#{T(edu.unc.lib.dl.model.DatastreamType).THUMBNAIL_LARGE.getExtension()}" />
         <constructor-arg value="${cdr.enhancement.path.thumbnail.large}" />
     </bean>
     
     <bean id="addAccessCopyProcessor" class="edu.unc.lib.dl.services.camel.images.AddDerivativeProcessor">
-        <constructor-arg value="${cdr.enhancement.jp2.fileExtension}" />
+        <constructor-arg value="#{T(edu.unc.lib.dl.model.DatastreamType).JP2_ACCESS_COPY.getExtension()}" />
         <constructor-arg value="${cdr.enhancement.path.jp2}" />
     </bean>
     

--- a/services-camel/src/main/webapp/WEB-INF/solr-indexing-context.xml
+++ b/services-camel/src/main/webapp/WEB-INF/solr-indexing-context.xml
@@ -185,6 +185,10 @@
         <property name="accessRestrictionUtil" ref="solrAccessRestrictionUtil" />
     </bean>
     
+    <bean id="derivativeService" class="edu.unc.lib.dl.util.DerivativeService">
+        <property name="derivativeDir" value="${derivative.dir}" />
+    </bean>
+    
     <!-- Solr ingest filters -->
     <bean id="setAccessControlFilter"
         class="edu.unc.lib.dl.data.ingest.solr.filter.SetAccessControlFilter">
@@ -209,6 +213,7 @@
     
     <bean id="setDatastreamFilter"
         class="edu.unc.lib.dl.data.ingest.solr.filter.SetDatastreamFilter">
+        <property name="derivativeService" ref="derivativeService" />
     </bean>
     
     <bean id="setDescriptiveMetadataFilter"

--- a/services-camel/src/test/resources/solr-update-it-context.xml
+++ b/services-camel/src/test/resources/solr-update-it-context.xml
@@ -246,6 +246,10 @@
         <constructor-arg value="edu.unc.lib.dl.util.VocabularyHelperManager" />
     </bean>
     
+    <bean id="derivativeService" class="edu.unc.lib.dl.util.DerivativeService">
+        <property name="derivativeDir" value="target/" />
+    </bean>
+    
     <!-- Solr ingest filters -->
     <bean id="setAccessControlFilter"
         class="edu.unc.lib.dl.data.ingest.solr.filter.SetAccessControlFilter">
@@ -270,6 +274,7 @@
     
     <bean id="setDatastreamFilter"
         class="edu.unc.lib.dl.data.ingest.solr.filter.SetDatastreamFilter">
+        <property name="derivativeService" ref="derivativeService" />
     </bean>
     
     <bean id="setDescriptiveMetadataFilter"

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/DatastreamController.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/DatastreamController.java
@@ -56,8 +56,8 @@ import edu.unc.lib.dl.ui.util.AnalyticsTrackerUtil;
  *
  */
 @Controller
-public class DatastreamRestController {
-    private static final Logger log = LoggerFactory.getLogger(DatastreamRestController.class);
+public class DatastreamController {
+    private static final Logger log = LoggerFactory.getLogger(DatastreamController.class);
 
     @Autowired
     private FedoraContentService fedoraContentService;
@@ -136,6 +136,6 @@ public class DatastreamRestController {
 
     @ResponseStatus(value = HttpStatus.BAD_REQUEST)
     @ExceptionHandler({ObjectTypeMismatchException.class, IllegalArgumentException.class})
-    public void handleBadRequestException() {
+    public void handleBadRequest() {
     }
 }

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/DatastreamRestController.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/DatastreamRestController.java
@@ -17,6 +17,7 @@ package edu.unc.lib.dl.cdr.services.rest;
 
 import static edu.unc.lib.dl.acl.util.GroupsThreadStore.getAgentPrincipals;
 import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.ORIGINAL_FILE;
+import static edu.unc.lib.dl.util.DerivativeService.isDerivative;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -84,8 +85,12 @@ public class DatastreamRestController {
         AccessGroupSet principals = getAgentPrincipals().getPrincipals();
 
         try {
-            fedoraContentService.streamData(pid, datastream, principals, download, response);
-            recordDownloadEvent(pid, datastream, principals, request);
+            if (isDerivative(datastream)) {
+                derivativeContentService.streamData(pid, datastream, principals, false, response);
+            } else {
+                fedoraContentService.streamData(pid, datastream, principals, download, response);
+                recordDownloadEvent(pid, datastream, principals, request);
+            }
         } catch (IOException e) {
             log.error("Problem retrieving {} for {}", pid.toString(), datastream, e);
         }

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/DatastreamRestController.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/DatastreamRestController.java
@@ -18,6 +18,7 @@ package edu.unc.lib.dl.cdr.services.rest;
 import static edu.unc.lib.dl.acl.util.GroupsThreadStore.getAgentPrincipals;
 import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.ORIGINAL_FILE;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import javax.servlet.http.HttpServletRequest;
@@ -27,14 +28,22 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
+import edu.unc.lib.dl.acl.exception.AccessRestrictionException;
 import edu.unc.lib.dl.acl.util.AccessGroupSet;
 import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fedora.NotFoundException;
+import edu.unc.lib.dl.fedora.ObjectTypeMismatchException;
 import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.ui.exception.ResourceNotFoundException;
+import edu.unc.lib.dl.ui.service.DerivativeContentService;
 import edu.unc.lib.dl.ui.service.FedoraContentService;
 import edu.unc.lib.dl.ui.util.AnalyticsTrackerUtil;
 
@@ -53,6 +62,8 @@ public class DatastreamRestController {
     private FedoraContentService fedoraContentService;
     @Autowired
     private AnalyticsTrackerUtil analyticsTracker;
+    @Autowired
+    private DerivativeContentService derivativeContentService;
 
     @RequestMapping("/file/{pid}")
     public void getDatastream(@PathVariable("pid") String pidString,
@@ -91,14 +102,35 @@ public class DatastreamRestController {
     @RequestMapping("/thumb/{pid}")
     public void getThumbnailSmall(@PathVariable("pid") String pid,
             @RequestParam(value = "size", defaultValue = "small") String size, HttpServletRequest request,
-            HttpServletResponse response) {
-        // TODO implement retrieval of derivatives
+            HttpServletResponse response) throws IOException {
+
+        getThumbnail(pid, size, request, response);
     }
 
     @RequestMapping("/thumb/{pid}/{size}")
-    public void getThumbnail(@PathVariable("pid") String pid,
+    public void getThumbnail(@PathVariable("pid") String pidString,
             @PathVariable("size") String size, HttpServletRequest request,
-            HttpServletResponse response) {
-        // TODO implement retrieval of derivatives
+            HttpServletResponse response) throws IOException {
+
+        PID pid = PIDs.get(pidString);
+        AccessGroupSet principals = getAgentPrincipals().getPrincipals();
+        String thumbName = "thumbnail_" + size.toLowerCase().trim();
+
+        derivativeContentService.streamData(pid, thumbName, principals, false, response);
+    }
+
+    @ResponseStatus(value = HttpStatus.NOT_FOUND)
+    @ExceptionHandler({ResourceNotFoundException.class, NotFoundException.class, FileNotFoundException.class})
+    public void handleResourceNotFound() {
+    }
+
+    @ResponseStatus(value = HttpStatus.FORBIDDEN)
+    @ExceptionHandler(AccessRestrictionException.class)
+    public void handleInvalidRecordRequest() {
+    }
+
+    @ResponseStatus(value = HttpStatus.BAD_REQUEST)
+    @ExceptionHandler({ObjectTypeMismatchException.class, IllegalArgumentException.class})
+    public void handleBadRequestException() {
     }
 }

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/ItemInfoRestController.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/ItemInfoRestController.java
@@ -40,7 +40,7 @@ import edu.unc.lib.dl.search.solr.model.BriefObjectMetadata;
 import edu.unc.lib.dl.search.solr.model.BriefObjectMetadataBean;
 import edu.unc.lib.dl.search.solr.model.IdListRequest;
 import edu.unc.lib.dl.search.solr.model.SimpleIdRequest;
-import edu.unc.lib.dl.search.solr.service.SolrSearchService;
+import edu.unc.lib.dl.ui.service.SolrQueryLayerService;
 
 /**
  *
@@ -55,7 +55,7 @@ public class ItemInfoRestController implements ServletContextAware {
     protected ServletContext servletContext = null;
 
     @Resource
-    private SolrSearchService solrSearchService;
+    private SolrQueryLayerService solrSearchService;
 
     @Resource(name = "contextUrl")
     protected String contextUrl = null;
@@ -107,10 +107,6 @@ public class ItemInfoRestController implements ServletContextAware {
         }
 
         return results;
-    }
-
-    public void setSolrSearchService(SolrSearchService solrSearchService) {
-        this.solrSearchService = solrSearchService;
     }
 
     @Override

--- a/services/src/main/webapp/WEB-INF/service-context.xml
+++ b/services/src/main/webapp/WEB-INF/service-context.xml
@@ -352,6 +352,15 @@
       <property name="failedTemplate" ref="updateFailedTemplate" />
       <property name="fromAddress" ref="fromAddress" />
    </bean>
+   
+    <bean id="derivativeService" class="edu.unc.lib.dl.util.DerivativeService">
+        <property name="derivativeDir" value="${derivative.dir}" />
+    </bean>
+   
+    <bean id="derivativeContentService" class="edu.unc.lib.dl.ui.service.DerivativeContentService">
+        <property name="accessControlService" ref="aclService" />
+        <property name="derivativeService" ref="derivativeService" />
+    </bean>
     
     <bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
         <property name="staticMethod" value="edu.unc.lib.dl.ui.util.SerializationUtil.injectSettings"/>

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/DatastreamRestControllerIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/DatastreamRestControllerIT.java
@@ -15,7 +15,7 @@
  */
 package edu.unc.lib.dl.cdr.services.rest;
 
-import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.TECHNICAL_METADATA;
+import static edu.unc.lib.dl.model.DatastreamType.TECHNICAL_METADATA;
 import static edu.unc.lib.dl.ui.service.FedoraContentService.CONTENT_DISPOSITION;
 import static org.junit.Assert.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -84,7 +84,7 @@ public class DatastreamRestControllerIT extends AbstractAPIIT {
 
         FileObject fileObj = repositoryObjectFactory.createFileObject(filePid, null);
         fileObj.addOriginalFile(new ByteArrayInputStream(BINARY_CONTENT.getBytes()), null, "text/plain", null, null);
-        fileObj.addBinary(TECHNICAL_METADATA, new ByteArrayInputStream(content.getBytes()),
+        fileObj.addBinary(TECHNICAL_METADATA.getId(), new ByteArrayInputStream(content.getBytes()),
                 "fits.xml", "application/xml", null, null, null);
 
         // Verify original file content retrievable
@@ -95,7 +95,7 @@ public class DatastreamRestControllerIT extends AbstractAPIIT {
         assertEquals(BINARY_CONTENT, result1.getResponse().getContentAsString());
 
         // Verify administrative datastream retrievable
-        MvcResult result2 = mvc.perform(get("/file/" + filePid.getId() + "/" + TECHNICAL_METADATA))
+        MvcResult result2 = mvc.perform(get("/file/" + filePid.getId() + "/" + TECHNICAL_METADATA.getId()))
                 .andExpect(status().is2xxSuccessful())
                 .andReturn();
 

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/DatastreamRestControllerIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/DatastreamRestControllerIT.java
@@ -198,6 +198,25 @@ public class DatastreamRestControllerIT extends AbstractAPIIT {
     }
 
     @Test
+    public void testGetFileDerivative() throws Exception {
+        PID filePid = makePid();
+        String id = filePid.getId();
+        createDerivative(id, THUMBNAIL_SMALL, BINARY_CONTENT.getBytes());
+
+        MvcResult result = mvc.perform(get("/file/" + filePid.getId() + "/" + THUMBNAIL_SMALL.getId()))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+
+        // Verify content was retrieved
+        MockHttpServletResponse response = result.getResponse();
+        assertEquals(BINARY_CONTENT, response.getContentAsString());
+        assertEquals(BINARY_CONTENT.length(), response.getContentLength());
+        assertEquals("image/png", response.getContentType());
+        assertEquals("inline; filename=\"" + id + "." + THUMBNAIL_SMALL.getExtension() + "\"",
+                response.getHeader(CONTENT_DISPOSITION));
+    }
+
+    @Test
     public void testGetThumbnailNotPresent() throws Exception {
         PID filePid = makePid();
 

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/DatastreamRestControllerIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/DatastreamRestControllerIT.java
@@ -15,14 +15,31 @@
  */
 package edu.unc.lib.dl.cdr.services.rest;
 
+import static edu.unc.lib.dl.acl.util.Permission.viewMetadata;
+import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.HASHED_PATH_DEPTH;
+import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.HASHED_PATH_SIZE;
+import static edu.unc.lib.dl.fcrepo4.RepositoryPaths.idToPath;
 import static edu.unc.lib.dl.model.DatastreamType.TECHNICAL_METADATA;
+import static edu.unc.lib.dl.model.DatastreamType.THUMBNAIL_SMALL;
 import static edu.unc.lib.dl.ui.service.FedoraContentService.CONTENT_DISPOSITION;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.apache.commons.io.FileUtils;
 import org.fusesource.hawtbuf.ByteArrayInputStream;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -32,10 +49,16 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MvcResult;
 
+import edu.unc.lib.dl.acl.exception.AccessRestrictionException;
+import edu.unc.lib.dl.acl.service.AccessControlService;
+import edu.unc.lib.dl.acl.util.AccessGroupSet;
 import edu.unc.lib.dl.cdr.services.rest.modify.AbstractAPIIT;
 import edu.unc.lib.dl.fcrepo4.FileObject;
 import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
 import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.model.DatastreamType;
+import edu.unc.lib.dl.ui.service.DerivativeContentService;
+import edu.unc.lib.dl.util.DerivativeService;
 
 /**
  *
@@ -54,7 +77,27 @@ public class DatastreamRestControllerIT extends AbstractAPIIT {
     private static final String BINARY_CONTENT = "binary content";
 
     @Autowired
+    private AccessControlService accessControlService;
+
+    @Autowired
     private RepositoryObjectFactory repositoryObjectFactory;
+
+    @Autowired
+    private DerivativeContentService derivativeContentService;
+
+    @Rule
+    public TemporaryFolder derivDir = new TemporaryFolder();
+    private String derivDirPath;
+
+    @Before
+    public void setup() {
+        derivDirPath = derivDir.getRoot().getAbsolutePath();
+
+        DerivativeService derivService = new DerivativeService();
+        derivService.setDerivativeDir(derivDirPath);
+
+        derivativeContentService.setDerivativeService(derivService);
+    }
 
     @Test
     public void testGetFile() throws Exception {
@@ -105,5 +148,73 @@ public class DatastreamRestControllerIT extends AbstractAPIIT {
         assertEquals(content.length(), response.getContentLength());
         assertEquals("application/xml", response.getContentType());
         assertEquals("inline; filename=\"fits.xml\"", response.getHeader(CONTENT_DISPOSITION));
+    }
+
+    @Test
+    public void testGetThumbnail() throws Exception {
+        PID filePid = makePid();
+        String id = filePid.getId();
+        createDerivative(id, THUMBNAIL_SMALL, BINARY_CONTENT.getBytes());
+
+        MvcResult result = mvc.perform(get("/thumb/" + filePid.getId()))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+
+        // Verify content was retrieved
+        MockHttpServletResponse response = result.getResponse();
+        assertEquals(BINARY_CONTENT, response.getContentAsString());
+        assertEquals(BINARY_CONTENT.length(), response.getContentLength());
+        assertEquals("image/png", response.getContentType());
+        assertEquals("inline; filename=\"" + id + "." + THUMBNAIL_SMALL.getExtension() + "\"",
+                response.getHeader(CONTENT_DISPOSITION));
+    }
+
+    @Test
+    public void testGetInvalidThumbnailSize() throws Exception {
+        PID filePid = makePid();
+        String id = filePid.getId();
+        createDerivative(id, THUMBNAIL_SMALL, BINARY_CONTENT.getBytes());
+
+        mvc.perform(get("/thumb/" + filePid.getId() + "/megasize"))
+                .andExpect(status().isBadRequest())
+                .andReturn();
+    }
+
+    @Test
+    public void testGetThumbnailNoPermission() throws Exception {
+        PID filePid = makePid();
+        String id = filePid.getId();
+        createDerivative(id, THUMBNAIL_SMALL, BINARY_CONTENT.getBytes());
+
+        doThrow(new AccessRestrictionException()).when(accessControlService)
+                .assertHasAccess(anyString(), eq(filePid), any(AccessGroupSet.class), eq(viewMetadata));
+
+        MvcResult result = mvc.perform(get("/thumb/" + filePid.getId()))
+                .andExpect(status().isForbidden())
+                .andReturn();
+
+        MockHttpServletResponse response = result.getResponse();
+        assertEquals("Content must not be returned", "", response.getContentAsString());
+    }
+
+    @Test
+    public void testGetThumbnailNotPresent() throws Exception {
+        PID filePid = makePid();
+
+        mvc.perform(get("/thumb/" + filePid.getId()))
+                .andExpect(status().isNotFound())
+                .andReturn();
+    }
+
+    private File createDerivative(String id, DatastreamType dsType, byte[] content) throws Exception {
+        String hashedPath = idToPath(id, HASHED_PATH_DEPTH, HASHED_PATH_SIZE);
+        Path derivPath = Paths.get(derivDirPath, dsType.getId(), hashedPath,
+                id + "." + dsType.getExtension());
+
+        File derivFile = derivPath.toFile();
+        derivFile.getParentFile().mkdirs();
+        FileUtils.writeByteArrayToFile(derivFile, content);
+
+        return derivFile;
     }
 }

--- a/services/src/test/resources/datastream-content-it-servlet.xml
+++ b/services/src/test/resources/datastream-content-it-servlet.xml
@@ -37,6 +37,10 @@
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
     </bean>
     
+    <bean id="derivativeContentService" class="edu.unc.lib.dl.ui.service.DerivativeContentService">
+        <property name="accessControlService" ref="aclService" />
+    </bean>
+    
     <bean id="aclService" class="org.mockito.Mockito" factory-method="mock">
         <constructor-arg value="edu.unc.lib.dl.acl.fcrepo4.AccessControlServiceImpl" />
     </bean>

--- a/services/src/test/resources/datastream-content-it-servlet.xml
+++ b/services/src/test/resources/datastream-content-it-servlet.xml
@@ -30,7 +30,7 @@
         
     <mvc:annotation-driven/>
 
-    <context:component-scan resource-pattern="**/DatastreamRestController*" base-package="edu.unc.lib.dl.cdr.services.rest"/>
+    <context:component-scan resource-pattern="**/DatastreamController*" base-package="edu.unc.lib.dl.cdr.services.rest"/>
     
     <bean id="fedoraContentService" class="edu.unc.lib.dl.ui.service.FedoraContentService">
         <property name="accessControlService" ref="aclService" />

--- a/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetDatastreamFilter.java
+++ b/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetDatastreamFilter.java
@@ -64,7 +64,7 @@ public class SetDatastreamFilter implements IndexDocumentFilter {
         }
 
         boolean ownedByOtherObject = contentObj instanceof WorkObject;
-        // Retrieve list of datastreams preserved with this object
+        // Retrieve list of datastreams associated with this object
         List<Datastream> datastreams = getDatastreams(fileObj, ownedByOtherObject);
         // Retrieve list of derivatives associated with the object
         List<Datastream> derivatives = getDerivatives(fileObj.getPid(), ownedByOtherObject);

--- a/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetDatastreamFilter.java
+++ b/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetDatastreamFilter.java
@@ -15,6 +15,9 @@
  */
 package edu.unc.lib.dl.data.ingest.solr.filter;
 
+import static edu.unc.lib.dl.model.DatastreamType.ORIGINAL_FILE;
+
+import java.io.File;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -27,12 +30,14 @@ import edu.unc.lib.dl.data.ingest.solr.exception.IndexingException;
 import edu.unc.lib.dl.data.ingest.solr.indexing.DocumentIndexingPackage;
 import edu.unc.lib.dl.fcrepo4.ContentObject;
 import edu.unc.lib.dl.fcrepo4.FileObject;
-import edu.unc.lib.dl.fcrepo4.RepositoryPathConstants;
 import edu.unc.lib.dl.fcrepo4.WorkObject;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.model.DatastreamType;
 import edu.unc.lib.dl.rdf.Ebucore;
 import edu.unc.lib.dl.rdf.Premis;
 import edu.unc.lib.dl.search.solr.model.Datastream;
 import edu.unc.lib.dl.search.solr.model.IndexDocumentBean;
+import edu.unc.lib.dl.util.DerivativeService;
 
 /**
  * Extracts datastreams from an object and sets related properties concerning the default datastream for the object.
@@ -44,6 +49,8 @@ import edu.unc.lib.dl.search.solr.model.IndexDocumentBean;
  */
 public class SetDatastreamFilter implements IndexDocumentFilter {
     private static final Logger log = LoggerFactory.getLogger(SetDatastreamFilter.class);
+
+    private DerivativeService derivativeService;
 
     @Override
     public void filter(DocumentIndexingPackage dip) throws IndexingException {
@@ -57,7 +64,11 @@ public class SetDatastreamFilter implements IndexDocumentFilter {
         }
 
         boolean ownedByOtherObject = contentObj instanceof WorkObject;
+        // Retrieve list of datastreams preserved with this object
         List<Datastream> datastreams = getDatastreams(fileObj, ownedByOtherObject);
+        // Retrieve list of derivatives associated with the object
+        List<Datastream> derivatives = getDerivatives(fileObj.getPid(), ownedByOtherObject);
+        datastreams.addAll(derivatives);
 
         IndexDocumentBean doc = dip.getDocument();
 
@@ -83,7 +94,7 @@ public class SetDatastreamFilter implements IndexDocumentFilter {
      * provided FileObject. If the datastreams are being recorded on an object
      * other than their owning file object, the pid of the owning file object is
      * recorded
-     * 
+     *
      * @param fileObj
      * @param ownedByOtherObject
      * @return
@@ -120,7 +131,7 @@ public class SetDatastreamFilter implements IndexDocumentFilter {
     /**
      * Returns the sum of filesizes for all datastreams which do no belong to
      * other objects
-     * 
+     *
      * @param datastreams
      * @return
      */
@@ -133,7 +144,7 @@ public class SetDatastreamFilter implements IndexDocumentFilter {
 
     private long getFilesize(List<Datastream> datastreams) throws IndexingException {
         Optional<Datastream> original = datastreams.stream()
-                .filter(ds -> RepositoryPathConstants.ORIGINAL_FILE.equals(ds.getName()))
+                .filter(ds -> ORIGINAL_FILE.getId().equals(ds.getName()))
                 .findFirst();
 
         if (!original.isPresent()) {
@@ -141,5 +152,31 @@ public class SetDatastreamFilter implements IndexDocumentFilter {
         }
 
         return original.get().getFilesize();
+    }
+
+    private List<Datastream> getDerivatives(PID pid, boolean ownedByOtherObject) {
+        return derivativeService.getDerivatives(pid).stream()
+                .map(deriv -> {
+                    String owner = (ownedByOtherObject ? pid.getId() : null);
+
+                    DatastreamType type = deriv.getType();
+                    String name = type.getId();
+                    String mimetype = type.getMimetype();
+                    String extension = type.getExtension();
+
+                    File derivFile = deriv.getFile();
+                    Long filesize = derivFile.length();
+                    String filename = derivFile.getName();
+
+                    return new Datastream(owner, name, filesize, mimetype, filename, extension, null);
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * @param derivativeService the derivativeService to set
+     */
+    public void setDerivativeService(DerivativeService derivativeService) {
+        this.derivativeService = derivativeService;
     }
 }

--- a/solr-ingest/src/test/java/edu/unc/lib/dl/data/ingest/solr/filter/SetDatastreamFilterTest.java
+++ b/solr-ingest/src/test/java/edu/unc/lib/dl/data/ingest/solr/filter/SetDatastreamFilterTest.java
@@ -15,9 +15,9 @@
  */
 package edu.unc.lib.dl.data.ingest.solr.filter;
 
-import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.LARGE_THUMBNAIL;
-import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.ORIGINAL_FILE;
-import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.TECHNICAL_METADATA;
+import static edu.unc.lib.dl.model.DatastreamType.ORIGINAL_FILE;
+import static edu.unc.lib.dl.model.DatastreamType.TECHNICAL_METADATA;
+import static edu.unc.lib.dl.model.DatastreamType.THUMBNAIL_LARGE;
 import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyListOf;
@@ -54,7 +54,7 @@ import edu.unc.lib.dl.rdf.Premis;
 import edu.unc.lib.dl.search.solr.model.IndexDocumentBean;
 
 /**
- * 
+ *
  * @author bbpennel
  *
  */
@@ -112,7 +112,7 @@ public class SetDatastreamFilterTest {
 
         when(fileObj.getBinaryObjects()).thenReturn(Arrays.asList(binObj));
         when(binObj.getResource()).thenReturn(
-                fileResource(ORIGINAL_FILE, FILE_SIZE, FILE_MIMETYPE, FILE_NAME, FILE_DIGEST));
+                fileResource(ORIGINAL_FILE.getId(), FILE_SIZE, FILE_MIMETYPE, FILE_NAME, FILE_DIGEST));
     }
 
     @Test
@@ -122,7 +122,7 @@ public class SetDatastreamFilterTest {
         filter.filter(dip);
 
         verify(idb).setDatastream(listCaptor.capture());
-        assertContainsDatastream(listCaptor.getValue(), ORIGINAL_FILE,
+        assertContainsDatastream(listCaptor.getValue(), ORIGINAL_FILE.getId(),
                 FILE_SIZE, FILE_MIMETYPE, FILE_NAME, FILE_DIGEST, null);
 
         verify(idb).setFilesizeSort(eq(FILE_SIZE));
@@ -133,11 +133,11 @@ public class SetDatastreamFilterTest {
     public void fileObjectMultipleBinariesTest() throws Exception {
         BinaryObject binObj2 = mock(BinaryObject.class);
         when(binObj2.getResource()).thenReturn(
-                fileResource(TECHNICAL_METADATA, FILE2_SIZE, FILE2_MIMETYPE, FILE2_NAME, FILE2_DIGEST));
+                fileResource(TECHNICAL_METADATA.getId(), FILE2_SIZE, FILE2_MIMETYPE, FILE2_NAME, FILE2_DIGEST));
 
         BinaryObject binObj3 = mock(BinaryObject.class);
         when(binObj3.getResource()).thenReturn(
-                fileResource(LARGE_THUMBNAIL, FILE3_SIZE, FILE3_MIMETYPE, FILE3_NAME, FILE3_DIGEST));
+                fileResource(THUMBNAIL_LARGE.getId(), FILE3_SIZE, FILE3_MIMETYPE, FILE3_NAME, FILE3_DIGEST));
 
         when(fileObj.getBinaryObjects()).thenReturn(Arrays.asList(binObj, binObj2, binObj3));
         when(dip.getContentObject()).thenReturn(fileObj);
@@ -145,11 +145,11 @@ public class SetDatastreamFilterTest {
         filter.filter(dip);
 
         verify(idb).setDatastream(listCaptor.capture());
-        assertContainsDatastream(listCaptor.getValue(), ORIGINAL_FILE,
+        assertContainsDatastream(listCaptor.getValue(), ORIGINAL_FILE.getId(),
                 FILE_SIZE, FILE_MIMETYPE, FILE_NAME, FILE_DIGEST, null);
-        assertContainsDatastream(listCaptor.getValue(), TECHNICAL_METADATA,
+        assertContainsDatastream(listCaptor.getValue(), TECHNICAL_METADATA.getId(),
                 FILE2_SIZE, FILE2_MIMETYPE, FILE2_NAME, FILE2_DIGEST, null);
-        assertContainsDatastream(listCaptor.getValue(), LARGE_THUMBNAIL,
+        assertContainsDatastream(listCaptor.getValue(), THUMBNAIL_LARGE.getId(),
                 FILE3_SIZE, FILE3_MIMETYPE, FILE3_NAME, FILE3_DIGEST, null);
 
         verify(idb).setFilesizeSort(eq(FILE_SIZE));
@@ -159,7 +159,7 @@ public class SetDatastreamFilterTest {
     @Test(expected = IndexingException.class)
     public void fileObjectNoOriginalTest() throws Exception {
         when(binObj.getResource()).thenReturn(
-                fileResource(TECHNICAL_METADATA, FILE2_SIZE, FILE2_MIMETYPE, FILE2_NAME, FILE2_DIGEST));
+                fileResource(TECHNICAL_METADATA.getId(), FILE2_SIZE, FILE2_MIMETYPE, FILE2_NAME, FILE2_DIGEST));
 
         when(fileObj.getBinaryObjects()).thenReturn(Arrays.asList(binObj));
         when(dip.getContentObject()).thenReturn(fileObj);
@@ -183,7 +183,7 @@ public class SetDatastreamFilterTest {
         filter.filter(dip);
 
         verify(idb).setDatastream(listCaptor.capture());
-        assertContainsDatastream(listCaptor.getValue(), ORIGINAL_FILE,
+        assertContainsDatastream(listCaptor.getValue(), ORIGINAL_FILE.getId(),
                 FILE_SIZE, FILE_MIMETYPE, FILE_NAME, FILE_DIGEST, fileId);
 
         // Sort size is based off primary object's size


### PR DESCRIPTION
* Enables display of thumbnails in the access ui
* Adds indexing of derivatives held outside of fedora
* Adds enum describing known datastreams and properties to allow for easier sharing of info about file type, storage policy, and permissions of datastreams.
* Thumbnails now coming from services application instead of access app in an effort to consolidate the API
* Moves some enhancement properties over into enum
* switch from CAPS file extensions for derivatives to lowercase.