### PR TITLE
Bxc 2190 - Prioritize triple indexing

### DIFF
--- a/etc/services-camel.properties
+++ b/etc/services-camel.properties
@@ -56,6 +56,9 @@ cdr.solrupdate.stream.camel=activemq://activemq:queue:repository.solrupdate
 cdr.triplesupdate.stream=activemq:queue:repository.triplesupdate?asyncConsumer=true
 cdr.triplesupdate.stream.camel=activemq://activemq:queue:repository.triplesupdate
 
+cdr.enhancement.stream=activemq:queue:repository.enhancements
+cdr.enhancement.stream.camel=activemq://activemq:queue:repository.enhancements
+
 # The camel URI for the incoming message stream.
 fcrepo.stream=activemq:queue:fedora?asyncConsumer=true
 

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/BinaryMetadataProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/BinaryMetadataProcessor.java
@@ -50,13 +50,6 @@ public class BinaryMetadataProcessor implements Processor {
     private final int BINARY_PATH_DEPTH = 3;
     private String baseBinaryPath;
 
-    public BinaryMetadataProcessor(String baseBinaryPath) {
-        this.baseBinaryPath = baseBinaryPath;
-        if (!baseBinaryPath.endsWith("/")) {
-            this.baseBinaryPath += "/";
-        }
-    }
-
     @Override
     public void process(final Exchange exchange) throws Exception {
         final Message in = exchange.getIn();
@@ -94,6 +87,16 @@ public class BinaryMetadataProcessor implements Processor {
             }
         } finally {
             resources.close();
+        }
+    }
+
+    /**
+     * @param baseBinaryPath the baseBinaryPath to set
+     */
+    public void setBaseBinaryPath(String baseBinaryPath) {
+        this.baseBinaryPath = baseBinaryPath;
+        if (!baseBinaryPath.endsWith("/")) {
+            this.baseBinaryPath += "/";
         }
     }
 }

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/enhancements/EnhancementRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/enhancements/EnhancementRouter.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.services.camel.enhancements;
+
+import static edu.unc.lib.dl.rdf.Cdr.AdminUnit;
+import static edu.unc.lib.dl.rdf.Cdr.Collection;
+import static edu.unc.lib.dl.rdf.Cdr.DescriptiveMetadata;
+import static edu.unc.lib.dl.rdf.Cdr.FileObject;
+import static edu.unc.lib.dl.rdf.Cdr.Folder;
+import static edu.unc.lib.dl.rdf.Cdr.Work;
+import static edu.unc.lib.dl.rdf.Fcrepo4Repository.Binary;
+import static org.apache.camel.LoggingLevel.INFO;
+
+import org.apache.camel.BeanInject;
+import org.apache.camel.LoggingLevel;
+import org.apache.camel.PropertyInject;
+import org.apache.camel.builder.RouteBuilder;
+
+import edu.unc.lib.dl.services.camel.BinaryMetadataProcessor;
+import edu.unc.lib.dl.services.camel.CleanupBinaryProcessor;
+import edu.unc.lib.dl.services.camel.GetBinaryProcessor;
+
+/**
+ * Router which queues and triggers enhancement services.
+ *
+ * @author bbpennel
+ *
+ */
+public class EnhancementRouter extends RouteBuilder {
+
+    private static final String DEFAULT_ENHANCEMENTS = "thumbnails,imageAccessCopy,extractFulltext";
+
+    @BeanInject(value = "binaryMetadataProcessor")
+    private BinaryMetadataProcessor mdProcessor;
+
+    @PropertyInject(value = "cdr.enhancement.processingThreads")
+    private Integer enhancementThreads;
+
+    @BeanInject(value = "getBinaryProcessor")
+    private GetBinaryProcessor getBinaryProcessor;
+
+    @BeanInject(value = "cleanupBinaryProcessor")
+    private CleanupBinaryProcessor cleanupBinaryProcessor;
+
+    @Override
+    public void configure() throws Exception {
+        from("direct-vm:enhancements.fedora")
+            .routeId("QueueEnhancementsFromFedora")
+            .log(INFO, "Queuing enhancements from Fedora message for ${headers[CamelFcrepoUri]}")
+            .setHeader("CdrEnhancementSet", constant(DEFAULT_ENHANCEMENTS))
+            .to("{{cdr.enhancement.stream.camel}}");
+
+        from("{{cdr.enhancement.stream.camel}}")
+            .routeId("ProcessEnhancementQueue")
+            .log(INFO, "Processing queued enhancements ${headers[CdrEnhancementSet]} for ${headers[CamelFcrepoUri]}")
+            .to("fcrepo:{{fcrepo.baseUrl}}?preferInclude=ServerManaged&accept=text/turtle")
+            .multicast()
+            .to("direct:process.binary", "direct:process.solr");
+
+        from("direct:process.binary")
+            .routeId("ProcessOriginalBinary")
+            .filter(simple("${headers[CamelFcrepoUri]} contains '/original_file'"
+                    + " && ${headers[org.fcrepo.jms.resourceType]} contains '" + Binary.getURI() + "'"))
+            .process(mdProcessor)
+            .process(getBinaryProcessor)
+            .to("direct:process.enhancements")
+            .process(cleanupBinaryProcessor);
+
+        from("direct:process.enhancements")
+            .routeId("AddBinaryEnhancements")
+            .split(simple("${headers[CdrEnhancementSet]}"))
+                .log(LoggingLevel.INFO, "Calling enhancement direct-vm:process.enhancement.${body}")
+                .toD("direct-vm:process.enhancement.${body}");
+
+        from("direct:process.solr")
+            .routeId("IngestSolrIndexing")
+            .filter(simple("${headers[org.fcrepo.jms.resourceType]} contains '" + Work.getURI() + "'"
+                    + " || ${headers[org.fcrepo.jms.resourceType]} contains '" + FileObject.getURI() + "'"
+                    + " || ${headers[org.fcrepo.jms.resourceType]} contains '" + Folder.getURI() + "'"
+                    + " || ${headers[org.fcrepo.jms.resourceType]} contains '" + Collection.getURI() + "'"
+                    + " || ${headers[org.fcrepo.jms.resourceType]} contains '" + AdminUnit.getURI() + "'"
+                    ))
+            // Filter out descriptive md separately because camel simple filters don't support basic () operators
+            .filter(simple("${headers[org.fcrepo.jms.resourceType]} not contains '"
+                    + DescriptiveMetadata.getURI() + "'"))
+                .log(LoggingLevel.INFO, "Ingest solr indexing for ${headers[CamelFcrepoUri]}")
+                .to("direct-vm:solrIndexing");
+    }
+}

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/fulltext/FulltextRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/fulltext/FulltextRouter.java
@@ -43,7 +43,7 @@ public class FulltextRouter extends RouteBuilder {
             .backOffMultiplier("{{error.backOffMultiplier}}")
             .retryAttemptedLogLevel(LoggingLevel.WARN);
 
-        from("direct-vm:extractFulltext")
+        from("direct-vm:process.enhancement.extractFulltext")
             .routeId("CdrServiceFulltextExtraction")
             .log(LoggingLevel.DEBUG, "Calling text extraction route for ${headers[org.fcrepo.jms.identifier]}")
             .filter(simple("${headers[CdrMimeType]} regex '" + MIMETYPE_PATTERN + "'"))

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/images/ImageEnhancementsRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/images/ImageEnhancementsRouter.java
@@ -76,7 +76,7 @@ public class ImageEnhancementsRouter extends RouteBuilder {
 
         from("direct-vm:process.enhancement.imageAccessCopy")
             .routeId("AccessCopy")
-            .log(LoggingLevel.INFO, "Access copy triggered")
+            .log(LoggingLevel.DEBUG, "Access copy triggered")
             .filter(simple("${headers[CdrMimeType]} regex '" + MIMETYPE_PATTERN + "'"))
                 .log(LoggingLevel.INFO, "Creating/Updating JP2 access copy for ${headers[CdrBinaryPath]}")
                 .recipientList(simple("exec:/bin/sh?args=${properties:cdr.enhancement.bin}/convertJp2.sh "

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/images/ImageEnhancementsRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/images/ImageEnhancementsRouter.java
@@ -49,14 +49,14 @@ public class ImageEnhancementsRouter extends RouteBuilder {
             .backOffMultiplier("{{error.backOffMultiplier}}")
             .retryAttemptedLogLevel(LoggingLevel.WARN);
 
-        from("direct-vm:imageEnhancements")
-            .routeId("CdrImageEnhancementRoute")
-            .log(LoggingLevel.INFO, "Calling image route for ${headers[org.fcrepo.jms.identifier]}")
+        from("direct-vm:process.enhancement.thumbnails")
+            .routeId("ProcessThumbnails")
+            .log(LoggingLevel.INFO, "Thumbs ${headers[CdrBinaryPath]} with ${headers[CdrMimeType]}")
             .filter(simple("${headers[CdrMimeType]} regex '" + MIMETYPE_PATTERN + "'"))
-                .log(LoggingLevel.INFO, "Generating images for ${headers[org.fcrepo.jms.identifier]}"
+                .log(LoggingLevel.INFO, "Generating thumbnails for ${headers[org.fcrepo.jms.identifier]}"
                         + " of type ${headers[CdrMimeType]}")
                 .multicast()
-                .to("direct:small.thumbnail", "direct:large.thumbnail", "direct:accessCopy");
+                .to("direct:small.thumbnail", "direct:large.thumbnail");
 
         from("direct:small.thumbnail")
             .routeId("SmallThumbnail")
@@ -74,12 +74,14 @@ public class ImageEnhancementsRouter extends RouteBuilder {
                     + "${properties:services.tempDirectory}/${headers[CdrCheckSum]}-large"))
             .bean(addLargeThumbProcessor);
 
-        from("direct:accessCopy")
+        from("direct-vm:process.enhancement.imageAccessCopy")
             .routeId("AccessCopy")
-            .log(LoggingLevel.INFO, "Creating/Updating JP2 access copy for ${headers[CdrBinaryPath]}")
-            .recipientList(simple("exec:/bin/sh?args=${properties:cdr.enhancement.bin}/convertJp2.sh "
-                    + "${headers[CdrBinaryPath]} jp2 "
-                    + "${properties:services.tempDirectory}/${headers[CdrCheckSum]}-access"))
-            .bean(addAccessCopyProcessor);
+            .log(LoggingLevel.INFO, "Access copy triggered")
+            .filter(simple("${headers[CdrMimeType]} regex '" + MIMETYPE_PATTERN + "'"))
+                .log(LoggingLevel.INFO, "Creating/Updating JP2 access copy for ${headers[CdrBinaryPath]}")
+                .recipientList(simple("exec:/bin/sh?args=${properties:cdr.enhancement.bin}/convertJp2.sh "
+                        + "${headers[CdrBinaryPath]} jp2 "
+                        + "${properties:services.tempDirectory}/${headers[CdrCheckSum]}-access"))
+                .bean(addAccessCopyProcessor);
     }
 }

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/routing/MetaServicesRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/routing/MetaServicesRouter.java
@@ -15,14 +15,10 @@
  */
 package edu.unc.lib.dl.services.camel.routing;
 
-import static edu.unc.lib.dl.rdf.Fcrepo4Repository.Binary;
-
 import org.apache.camel.BeanInject;
-import org.apache.camel.LoggingLevel;
 import org.apache.camel.PropertyInject;
 import org.apache.camel.builder.RouteBuilder;
 
-import edu.unc.lib.dl.rdf.Cdr;
 import edu.unc.lib.dl.services.camel.BinaryMetadataProcessor;
 import edu.unc.lib.dl.services.camel.CleanupBinaryProcessor;
 import edu.unc.lib.dl.services.camel.GetBinaryProcessor;
@@ -51,7 +47,7 @@ public class MetaServicesRouter extends RouteBuilder {
         from("{{fcrepo.stream}}")
             .routeId("CdrMetaServicesRouter")
             .to("direct-vm:index.start")
-            .to("direct:process.enhancement");
+            .wireTap("direct:process.enhancement");
 
         from("direct:process.enhancement")
             .routeId("ProcessEnhancement")
@@ -59,56 +55,6 @@ public class MetaServicesRouter extends RouteBuilder {
                 .log("Performing enhancements for ${headers[org.fcrepo.jms.identifier]}")
                 .delay(simple("{{cdr.enhancement.postIndexingDelay}}"))
                 .removeHeaders("CamelHttp*")
-                .to("direct-vm:enhancements.queue.fedora");
-                // Trigger binary processing after an asynchronously
-//                .threads(enhancementThreads, enhancementThreads, "CdrEnhancementThread")
-//                .delay(simple("{{cdr.enhancement.postIndexingDelay}}"))
-//                .removeHeaders("CamelHttp*")
-//                .to("fcrepo:{{fcrepo.baseUrl}}?preferInclude=ServerManaged&accept=text/turtle")
-//                .multicast()
-//                .to("direct:process.binary", "direct:process.solr");
-
-        from("activemq://activemq:queue:repository.enhancements")
-            .routeId("ProcessEnhancementQueue")
-            .log("Pulled enhancement from queue ${headers[org.fcrepo.jms.identifier]}")
-            .delay(simple("500"))
-            .log("Finished enhancement in queue ${headers[org.fcrepo.jms.identifier]}");
-
-        from("direct:process.binary")
-            .routeId("ProcessOriginalBinary")
-            .filter(simple("${headers[org.fcrepo.jms.identifier]} regex '.*(original_file|techmd_fits)'"
-                    + " && ${headers[org.fcrepo.jms.resourceType]} contains '" + Binary.getURI() + "'"))
-                .process(mdProcessor)
-                .process(getBinaryProcessor)
-                .choice()
-                    .when(simple("${headers[org.fcrepo.jms.identifier]} regex '.*original_file'"))
-                        .to("direct-vm:replication")
-                        .to("direct:process.enhancements")
-                    .when(simple("${headers[org.fcrepo.jms.identifier]} regex '.*techmd_fits'"))
-                        .to("direct-vm:replication")
-                    .otherwise()
-                        .log(LoggingLevel.WARN,
-                                "Cannot process binary metadata for ${headers[org.fcrepo.jms.identifier]}")
-                .end()
-                .process(cleanupBinaryProcessor);
-
-        from("direct:process.enhancements")
-            .routeId("AddBinaryEnhancements")
-            .multicast()
-            .to("direct-vm:imageEnhancements","direct-vm:extractFulltext");
-
-        from("direct:process.solr")
-            .routeId("IngestSolrIndexing")
-            .filter(simple("${headers[org.fcrepo.jms.resourceType]} contains '" + Cdr.Work.getURI() + "'"
-                    + " || ${headers[org.fcrepo.jms.resourceType]} contains '" + Cdr.FileObject.getURI() + "'"
-                    + " || ${headers[org.fcrepo.jms.resourceType]} contains '" + Cdr.Folder.getURI() + "'"
-                    + " || ${headers[org.fcrepo.jms.resourceType]} contains '" + Cdr.Collection.getURI() + "'"
-                    + " || ${headers[org.fcrepo.jms.resourceType]} contains '" + Cdr.AdminUnit.getURI() + "'"
-                    ))
-            // Filter out descriptive md separately because camel simple filters don't support basic () operators
-            .filter(simple("${headers[org.fcrepo.jms.resourceType]} not contains '"
-                    + Cdr.DescriptiveMetadata.getURI() + "'"))
-                .log(LoggingLevel.INFO, "Ingest solr indexing for ${headers[org.fcrepo.jms.identifier]}")
-                .to("direct-vm:solrIndexing");
+                .to("direct-vm:enhancements.fedora");
     }
 }

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/util/CdrFcrepoHeaders.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/util/CdrFcrepoHeaders.java
@@ -32,4 +32,6 @@ public abstract class CdrFcrepoHeaders {
     public static final String CdrBinaryUri = "CdrBinaryUri";
 
     public static final String CdrUpdateAction = "CdrUpdateAction";
+
+    public static final String CdrEnhancementSet = "CdrEnhancementSet";
 }

--- a/services-camel/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel/src/main/webapp/WEB-INF/service-context.xml
@@ -214,6 +214,10 @@
         <camel:package>edu.unc.lib.dl.services.camel.cdrEvents</camel:package>
     </camel:camelContext>
     
+    <camel:camelContext id="CdrEnhancements">
+        <camel:package>edu.unc.lib.dl.services.camel.enhancements</camel:package>
+    </camel:camelContext>
+    
     <!-- Initialize metaServicesRouter after the routes it depends on -->
     <camel:camelContext id="MetaServicesRouter">
         <camel:package>edu.unc.lib.dl.services.camel.routing</camel:package>

--- a/services-camel/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel/src/main/webapp/WEB-INF/service-context.xml
@@ -144,7 +144,7 @@
     </bean>
     
     <bean id="binaryMetadataProcessor" class="edu.unc.lib.dl.services.camel.BinaryMetadataProcessor">
-        <constructor-arg value="${fcrepo.binaryBase}"/>
+        <property name="baseBinaryPath" value="${fcrepo.binaryBase}" />
     </bean>
 
     <bean id="addSmallThumbnailProcessor" class="edu.unc.lib.dl.services.camel.images.AddDerivativeProcessor">

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/BinaryMetadataProcessorTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/BinaryMetadataProcessorTest.java
@@ -31,7 +31,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.InputStream;
 
-import edu.unc.lib.dl.test.TestHelper;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.jena.rdf.model.Model;
@@ -49,6 +48,7 @@ import org.mockito.Mock;
 import edu.unc.lib.dl.rdf.Ebucore;
 import edu.unc.lib.dl.rdf.Fcrepo4Repository;
 import edu.unc.lib.dl.rdf.Premis;
+import edu.unc.lib.dl.test.TestHelper;
 
 /**
  *
@@ -82,7 +82,8 @@ public class BinaryMetadataProcessorTest {
 
         binaryBase = tmpFolder.newFolder().getAbsolutePath();
 
-        processor = new BinaryMetadataProcessor(binaryBase);
+        processor = new BinaryMetadataProcessor();
+        processor.setBaseBinaryPath(binaryBase);
 
         when(exchange.getIn()).thenReturn(message);
         when(exchange.getIn().getHeader("CamelFcrepoUri")).thenReturn(RESC_ID);

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/enhancements/EnhancementRouterIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/enhancements/EnhancementRouterIT.java
@@ -1,0 +1,152 @@
+package edu.unc.lib.dl.services.camel.enhancements;
+
+import static edu.unc.lib.dl.rdf.Fcrepo4Repository.Binary;
+import static edu.unc.lib.dl.rdf.Fcrepo4Repository.Container;
+import static edu.unc.lib.dl.services.camel.JmsHeaderConstants.EVENT_TYPE;
+import static edu.unc.lib.dl.services.camel.JmsHeaderConstants.IDENTIFIER;
+import static edu.unc.lib.dl.services.camel.JmsHeaderConstants.RESOURCE_TYPE;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.BeanInject;
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.NotifyBuilder;
+import org.apache.commons.io.FileUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import edu.unc.lib.dl.fcrepo4.BinaryObject;
+import edu.unc.lib.dl.fcrepo4.FileObject;
+import edu.unc.lib.dl.fcrepo4.FolderObject;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.rdf.Cdr;
+import edu.unc.lib.dl.services.camel.BinaryMetadataProcessor;
+import edu.unc.lib.dl.services.camel.images.AddDerivativeProcessor;
+import edu.unc.lib.dl.services.camel.solr.SolrIngestProcessor;
+import edu.unc.lib.dl.test.TestHelper;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextHierarchy({
+    @ContextConfiguration("/spring-test/test-fedora-container.xml"),
+    @ContextConfiguration("/spring-test/cdr-client-container.xml"),
+    @ContextConfiguration("/enhancement-router-it-context.xml")
+})
+public class EnhancementRouterIT {
+
+    private final static String FILE_CONTENT = "content";
+
+    @Rule
+    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+    private String baseBinaryPath;
+
+    @Autowired
+    private String baseAddress;
+
+    @Autowired
+    private RepositoryObjectFactory repoObjectFactory;
+
+    @Autowired
+    private CamelContext cdrEnhancements;
+
+    @Produce(uri = "direct-vm:enhancements.fedora")
+    private ProducerTemplate template;
+
+    @BeanInject(value = "addSmallThumbnailProcessor")
+    private AddDerivativeProcessor addSmallThumbnailProcessor;
+
+    @BeanInject(value = "addLargeThumbnailProcessor")
+    private AddDerivativeProcessor addLargeThumbnailProcessor;
+
+    @BeanInject(value = "addAccessCopyProcessor")
+    private AddDerivativeProcessor addAccessCopyProcessor;
+
+    @BeanInject(value = "solrIngestProcessor")
+    private SolrIngestProcessor solrIngestProcessor;
+
+    @BeanInject(value = "binaryMetadataProcessor")
+    private BinaryMetadataProcessor binaryMetadataProcessor;
+
+    @Before
+    public void init() throws Exception {
+        initMocks(this);
+
+        TestHelper.setContentBase(baseAddress);
+
+        baseBinaryPath = tmpFolder.getRoot().getAbsolutePath();
+        binaryMetadataProcessor.setBaseBinaryPath(baseBinaryPath);
+
+        File thumbScriptFile = new File("target/convertScaleStage.sh");
+        FileUtils.writeStringToFile(thumbScriptFile, "exit 0", "utf-8");
+        thumbScriptFile.deleteOnExit();
+
+        File jp2ScriptFile = new File("target/convertJp2.sh");
+        FileUtils.writeStringToFile(jp2ScriptFile, "exit 0", "utf-8");
+        jp2ScriptFile.deleteOnExit();
+    }
+
+    @Test
+    public void test() throws Exception {
+        FolderObject folderObject = repoObjectFactory.createFolderObject(null);
+
+        final Map<String, Object> headers = createEvent(folderObject.getPid(),
+                Cdr.Folder.getURI(), Container.getURI());
+        template.sendBodyAndHeaders("", headers);
+
+        NotifyBuilder notify = new NotifyBuilder(cdrEnhancements)
+                .whenCompleted(1)
+                .create();
+
+        notify.matches(5l, TimeUnit.SECONDS);
+
+        verify(solrIngestProcessor).process(any(Exchange.class));
+    }
+
+    @Test
+    public void testImageFile() throws Exception {
+        FileObject fileObj = repoObjectFactory.createFileObject(null);
+        BinaryObject binObj = fileObj.addOriginalFile(new ByteArrayInputStream(FILE_CONTENT.getBytes()),
+                null, "image/png", null, null);
+
+        final Map<String, Object> headers = createEvent(binObj.getPid(), Binary.getURI());
+        template.sendBodyAndHeaders("", headers);
+
+        NotifyBuilder notify = new NotifyBuilder(cdrEnhancements)
+                .whenCompleted(1)
+                .create();
+
+        notify.matches(5l, TimeUnit.SECONDS);
+
+        verify(addSmallThumbnailProcessor).process(any(Exchange.class));
+        verify(addLargeThumbnailProcessor).process(any(Exchange.class));
+        verify(addAccessCopyProcessor).process(any(Exchange.class));
+    }
+
+    private static Map<String, Object> createEvent(PID pid, String... type) {
+
+        final Map<String, Object> headers = new HashMap<>();
+        headers.put(IDENTIFIER, pid.getRepositoryPath());
+        headers.put(EVENT_TYPE, "ResourceCreation");
+        headers.put("CamelFcrepoUri", pid.getRepositoryPath());
+        headers.put(RESOURCE_TYPE, String.join(",", type));
+
+        return headers;
+    }
+}

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/routing/MetaServicesRouterTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/routing/MetaServicesRouterTest.java
@@ -16,19 +16,14 @@
 package edu.unc.lib.dl.services.camel.routing;
 
 import static edu.unc.lib.dl.rdf.Fcrepo4Repository.Binary;
-import static edu.unc.lib.dl.rdf.Fcrepo4Repository.Container;
 import static edu.unc.lib.dl.services.camel.JmsHeaderConstants.EVENT_TYPE;
 import static edu.unc.lib.dl.services.camel.JmsHeaderConstants.IDENTIFIER;
 import static edu.unc.lib.dl.services.camel.JmsHeaderConstants.RESOURCE_TYPE;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.verify;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.camel.BeanInject;
 import org.apache.camel.EndpointInject;
-import org.apache.camel.Exchange;
 import org.apache.camel.Produce;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.PropertyInject;
@@ -39,11 +34,6 @@ import org.junit.Test;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-import edu.unc.lib.dl.rdf.Cdr;
-import edu.unc.lib.dl.services.camel.BinaryMetadataProcessor;
-import edu.unc.lib.dl.services.camel.CleanupBinaryProcessor;
-import edu.unc.lib.dl.services.camel.GetBinaryProcessor;
-
 /**
  *
  * @author bbpennel
@@ -53,14 +43,10 @@ import edu.unc.lib.dl.services.camel.GetBinaryProcessor;
 public class MetaServicesRouterTest extends CamelSpringTestSupport {
 
     private static final String FILE_ID = "/file1/original_file";
-    private static final String FITS_ID = "/file1/techmd_fits";
     private static final String CONTAINER_ID = "/content/43/e2/27/ac/43e227ac-983a-4a18-94c9-c9cff8d28441";
 
     private static final String META_ROUTE = "CdrMetaServicesRouter";
     private static final String PROCESS_ENHANCEMENT_ROUTE = "ProcessEnhancement";
-    private static final String ORIGINAL_BINARY_ROUTE = "ProcessOriginalBinary";
-    private static final String ADD_BINARY_ENHANCEMENTS_ROUTE = "AddBinaryEnhancements";
-    private static final String SOLR_INGEST_ROUTE = "IngestSolrIndexing";
 
     @PropertyInject(value = "fcrepo.baseUri")
     private static String baseUri;
@@ -70,15 +56,6 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
 
     @Produce(uri = "direct:start")
     private ProducerTemplate template;
-
-    @BeanInject(value = "binaryMetadataProcessor")
-    private BinaryMetadataProcessor mdProcessor;
-
-    @BeanInject(value = "getBinaryProcessor")
-    private GetBinaryProcessor getBinaryProcessor;
-
-    @BeanInject(value = "cleanupBinaryProcessor")
-    private CleanupBinaryProcessor cleanupBinaryProcessor;
 
     @Override
     protected AbstractApplicationContext createApplicationContext() {
@@ -93,33 +70,6 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
         createContext(META_ROUTE);
 
         template.sendBodyAndHeaders("", createEvent(CONTAINER_ID, Binary.getURI()));
-
-        assertMockEndpointsSatisfied();
-    }
-
-    @Test
-    public void testProcessEnhancementContainer() throws Exception {
-        getMockEndpoint("mock:direct:process.binary").expectedMessageCount(1);
-        getMockEndpoint("mock:direct:process.solr").expectedMessageCount(1);
-
-        createContext(PROCESS_ENHANCEMENT_ROUTE);
-
-        final Map<String, Object> headers = createEvent(CONTAINER_ID, Binary.getURI());
-        headers.put(RESOURCE_TYPE, Container.getURI());
-        template.sendBodyAndHeaders("", headers);
-
-        assertMockEndpointsSatisfied();
-    }
-
-    @Test
-    public void testProcessFits() throws Exception {
-        getMockEndpoint("mock:direct-vm:replication").expectedMessageCount(1);
-        getMockEndpoint("mock:direct:process.enhancements").expectedMessageCount(0);
-
-        createContext(ORIGINAL_BINARY_ROUTE);
-
-        final Map<String, Object> headers = createEvent(FITS_ID, Binary.getURI());
-        template.sendBodyAndHeaders("", headers);
 
         assertMockEndpointsSatisfied();
     }
@@ -141,91 +91,10 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
 
     @Test
     public void testEventTypeFilterValid() throws Exception {
-        getMockEndpoint("mock:direct:process.binary").expectedMessageCount(1);
-        getMockEndpoint("mock:direct:process.solr").expectedMessageCount(1);
+        getMockEndpoint("mock:direct-vm:enhancements.fedora").expectedMessageCount(1);
 
         createContext(PROCESS_ENHANCEMENT_ROUTE);
         Map<String, Object> headers = createEvent(FILE_ID, Binary.getURI());
-        template.sendBodyAndHeaders("", headers);
-
-        assertMockEndpointsSatisfied();
-    }
-
-    @Test
-    public void testEnhancementIdentifierFilterValid() throws Exception {
-        getMockEndpoint("mock:direct-vm:imageEnhancements").expectedMessageCount(1);
-        getMockEndpoint("mock:direct-vm:extractFulltext").expectedMessageCount(1);
-
-        createContext(ADD_BINARY_ENHANCEMENTS_ROUTE);
-
-        Map<String, Object> headers = createEvent(FILE_ID, Binary.getURI());
-        template.sendBodyAndHeaders("", headers);
-
-        assertMockEndpointsSatisfied();
-    }
-
-    @Test
-    public void testProcessBinaryOriginal() throws Exception {
-        getMockEndpoint("mock:direct:process.enhancements").expectedMessageCount(1);
-        getMockEndpoint("mock:direct-vm:replication").expectedMessageCount(1);
-
-        createContext(ORIGINAL_BINARY_ROUTE);
-
-        Map<String, Object> headers = createEvent(FILE_ID, Binary.getURI());
-        template.sendBodyAndHeaders("", headers);
-
-        assertMockEndpointsSatisfied();
-
-        verify(mdProcessor).process(any(Exchange.class));
-        verify(getBinaryProcessor).process(any(Exchange.class));
-        verify(cleanupBinaryProcessor).process(any(Exchange.class));
-    }
-
-    @Test
-    public void testProcessBinaryOriginalFail() throws Exception {
-        getMockEndpoint("mock:direct-vm:imageEnhancements").expectedMessageCount(0);
-        getMockEndpoint("mock:direct-vm:extractFulltext").expectedMessageCount(0);
-
-        createContext(ORIGINAL_BINARY_ROUTE);
-
-        Map<String, Object> headers = createEvent("other_file", Binary.getURI());
-        template.sendBodyAndHeaders("", headers);
-
-        assertMockEndpointsSatisfied();
-    }
-
-    @Test
-    public void testProcessSolr() throws Exception {
-        getMockEndpoint("mock:direct-vm:solrIndexing").expectedMessageCount(1);
-
-        createContext(SOLR_INGEST_ROUTE);
-
-        Map<String, Object> headers = createEvent(RESOURCE_TYPE, Cdr.Work.getURI());
-        template.sendBodyAndHeaders("", headers);
-
-        assertMockEndpointsSatisfied();
-    }
-
-    @Test
-    public void testProcessSolrFail() throws Exception {
-        getMockEndpoint("mock:direct-vm:solrIndexing").expectedMessageCount(0);
-
-        createContext(SOLR_INGEST_ROUTE);
-
-        Map<String, Object> headers = createEvent(RESOURCE_TYPE, Binary.getURI());
-        template.sendBodyAndHeaders("", headers);
-
-        assertMockEndpointsSatisfied();
-    }
-
-    @Test
-    public void testProcessFilterOutDescriptiveMDSolr() throws Exception {
-        getMockEndpoint("mock:direct-vm:solrIndexing").expectedMessageCount(0);
-
-        createContext(SOLR_INGEST_ROUTE);
-
-        Map<String, Object> headers = createEvent("container",
-                Cdr.FileObject.getURI(), Cdr.DescriptiveMetadata.getURI());
         template.sendBodyAndHeaders("", headers);
 
         assertMockEndpointsSatisfied();

--- a/services-camel/src/test/resources/config.properties
+++ b/services-camel/src/test/resources/config.properties
@@ -9,11 +9,13 @@ fcrepo.authHost=
 
 cdr.enhancement.thumbnail.fileExtension=PNG
 cdr.enhancement.thumbnail.mimetype=image/png
-cdr.enhancement.fulltext.fileName=full_text.txt
 cdr.enhancement.jp2.fileExtension=JP2
 cdr.enhancement.jp2.mimetype=image/jp2
 cdr.enhancement.postIndexingDelay=500
 cdr.enhancement.processingThreads=2
+
+cdr.enhancement.bin=target
+services.tempDirectory=target
 
 error.retryDelay=0
 # In the event of failure, the maximum number of times a redelivery will be attempted.

--- a/services-camel/src/test/resources/enhancement-router-it-config.properties
+++ b/services-camel/src/test/resources/enhancement-router-it-config.properties
@@ -1,0 +1,76 @@
+fcrepo.baseUrl=http://localhost:8080/fcrepo/rest
+fcrepo.serverUri=http://localhost:8080/
+fcrepo.binaryBase=/var/lib/tomcat7/fcrepo4-data/fcrepo.binary.directory/
+services.tempDirectory=/tmp/
+
+fcrepo.authUsername=
+fcrepo.authPassword=
+fcrepo.authHost=
+
+cdr.enhancement.thumbnail.fileExtension=PNG
+cdr.enhancement.thumbnail.mimetype=image/png
+cdr.enhancement.fulltext.fileName=full_text.txt
+cdr.enhancement.jp2.fileExtension=JP2
+cdr.enhancement.jp2.mimetype=image/jp2
+cdr.enhancement.postIndexingDelay=500
+cdr.enhancement.processingThreads=2
+
+cdr.enhancement.bin=target
+
+error.retryDelay=0
+# In the event of failure, the maximum number of times a redelivery will be attempted.
+error.maxRedeliveries=2
+error.backOffMultiplier=1
+
+# If you would like to index only those objects with a type `indexing:Indexable`,
+# set this property to `true`
+indexing.predicate=false
+
+# SOLR Server (http, localhost, 80, solr) 
+solr.protocol=http
+solr.host=localhost
+solr.port=:8983
+solr.context=solr
+
+# The camel URI for the incoming message stream.
+fcrepo.stream=direct-vm:meta.start
+
+# Input stream to route to fcrepo-triplestore-router without having to override the fcrepo-camel-toolbox code
+input.stream=direct-vm:index.start
+
+# The URI for the incoming CDR message stream
+cdr.stream=activemq:queue:repository.events
+cdr.stream.camel=activemq://activemq:queue:repository.events
+
+cdr.enhancement.stream=activemq:queue:repository.enhancements
+cdr.enhancement.stream.camel=activemq://activemq:queue:repository.enhancements
+
+# The base URL of the triplestore being used.
+triplestore.baseUrl=http://localhost:8080/fuseki/test/update
+
+# A named graph for any objects being indexed in the triplestore. This value, if
+# not left blank, should be a valid URI.
+triplestore.namedGraph=
+
+# Use these values to control the prefer headers for the returned representation from
+# fedora. By default, ldp:contains triples are excluded, since for large repositories,
+# including them can lead to _extremely_ large response sizes that may easily exceed
+# what the triplestore HTTP interface can efficiently handle.
+prefer.omit=http://www.w3.org/ns/ldp#PreferContainment
+prefer.include=ServerManaged
+
+# Any URIs listed here will be excluded from processing. URIs should be comma-delimited
+filter.containers=http://localhost:8080/fcrepo/rest/audit,info:fedora/audit
+
+jms.brokerUrl=tcp://localhost:61616
+jms.username=
+jms.password=
+jms.consumers=1
+jms.connections=10
+
+access.group.admin=adminGrp
+services.indexing.collectionFilters=src/test/resources/application.properties
+conductor.solr.maxThreads=3
+conductor.solr.beforeExecuteDelay=50
+conductor.solr.beforeUpdateDelay=0
+conductor.solr.recoverableDelay=30000

--- a/services-camel/src/test/resources/enhancement-router-it-config.properties
+++ b/services-camel/src/test/resources/enhancement-router-it-config.properties
@@ -16,6 +16,7 @@ cdr.enhancement.postIndexingDelay=500
 cdr.enhancement.processingThreads=2
 
 cdr.enhancement.bin=target
+services.tempDirectory=target
 
 error.retryDelay=0
 # In the event of failure, the maximum number of times a redelivery will be attempted.

--- a/services-camel/src/test/resources/enhancement-router-it-context.xml
+++ b/services-camel/src/test/resources/enhancement-router-it-context.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:c="http://www.springframework.org/schema/c"
+    xmlns:p="http://www.springframework.org/schema/p" xmlns:context="http://www.springframework.org/schema/context"
+    xmlns:util="http://www.springframework.org/schema/util"
+    xmlns:camel="http://camel.apache.org/schema/spring"
+    xmlns:amq="http://activemq.apache.org/schema/core"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
+        http://www.springframework.org/schema/util 
+        http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.3.xsd
+        http://activemq.apache.org/schema/core
+        http://activemq.apache.org/schema/core/activemq-core.xsd
+        http://camel.apache.org/schema/spring
+        http://camel.apache.org/schema/spring/camel-spring.xsd">
+        
+    <bean id="properties" class="org.apache.camel.component.properties.PropertiesComponent">
+        <property name="location" value="classpath:enhancement-router-it-config.properties"/>
+    </bean>
+    
+    <bean id="bridgePropertyPlaceholder" class="org.apache.camel.spring.spi.BridgePropertyPlaceholderConfigurer">
+        <property name="location" value="classpath:enhancement-router-it-config.properties"/>
+    </bean>
+    
+    <bean id="jmsConfig" class="org.apache.camel.component.jms.JmsConfiguration">
+        <property name="connectionFactory" ref="jmsFactory" />
+        <property name="concurrentConsumers" value="2" />
+    </bean>
+
+    <bean id="activemq"
+        class="org.apache.activemq.camel.component.ActiveMQComponent">
+        <property name="configuration" ref="jmsConfig" />
+    </bean>
+
+    <!-- JMS ConnectionFactory to use, configuring the embedded broker using 
+        XML -->
+    <amq:connectionFactory id="jmsFactory"
+        brokerURL="vm://localhost" />
+
+    <amq:broker useJmx="false" persistent="false" useShutdownHook="false">
+        <amq:transportConnectors>
+            <amq:transportConnector uri="vm://localhost:61616" />
+        </amq:transportConnectors>
+    </amq:broker>
+    
+    <bean id="solrIngestProcessor" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.services.camel.solr.SolrIngestProcessor" />
+    </bean>
+    
+    <bean id="addSmallThumbnailProcessor" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.services.camel.images.AddDerivativeProcessor" />
+    </bean>
+    
+    <bean id="addLargeThumbnailProcessor" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.services.camel.images.AddDerivativeProcessor" />
+    </bean>
+    
+    <bean id="addAccessCopyProcessor" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.services.camel.images.AddDerivativeProcessor" />
+    </bean>
+    
+    <bean id="getBinaryProcessor" class="edu.unc.lib.dl.services.camel.GetBinaryProcessor">
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader"/>
+        <property name="tempDirectory" value="${services.tempDirectory}" />
+    </bean>
+
+    <bean id="cleanupBinaryProcessor" class="edu.unc.lib.dl.services.camel.CleanupBinaryProcessor">
+    </bean>
+    
+    <bean id="binaryMetadataProcessor" class="edu.unc.lib.dl.services.camel.BinaryMetadataProcessor">
+    </bean>
+    
+    <bean id="fulltextProcessor" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.services.camel.fulltext.FulltextProcessor" />
+    </bean>
+
+    <camel:camelContext id="CdrServiceImageEnhancements">
+        <camel:package>edu.unc.lib.dl.services.camel.images</camel:package>
+    </camel:camelContext>
+    
+    <camel:camelContext id="CdrServiceFulltextExtraction">
+        <camel:package>edu.unc.lib.dl.services.camel.fulltext</camel:package>
+    </camel:camelContext>
+    
+    <camel:camelContext id="CdrServiceSolr">
+        <camel:package>edu.unc.lib.dl.services.camel.solr</camel:package>
+    </camel:camelContext>
+    
+    <camel:camelContext id="cdrEnhancements">
+        <camel:package>edu.unc.lib.dl.services.camel.enhancements</camel:package>
+    </camel:camelContext>
+  
+</beans>

--- a/services-camel/src/test/resources/enhancement-router-it-context.xml
+++ b/services-camel/src/test/resources/enhancement-router-it-context.xml
@@ -63,7 +63,6 @@
     
     <bean id="getBinaryProcessor" class="edu.unc.lib.dl.services.camel.GetBinaryProcessor">
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader"/>
-        <property name="tempDirectory" value="${services.tempDirectory}" />
     </bean>
 
     <bean id="cleanupBinaryProcessor" class="edu.unc.lib.dl.services.camel.CleanupBinaryProcessor">
@@ -76,15 +75,15 @@
         <constructor-arg value="edu.unc.lib.dl.services.camel.fulltext.FulltextProcessor" />
     </bean>
 
-    <camel:camelContext id="CdrServiceImageEnhancements">
+    <camel:camelContext id="cdrServiceImageEnhancements">
         <camel:package>edu.unc.lib.dl.services.camel.images</camel:package>
     </camel:camelContext>
     
-    <camel:camelContext id="CdrServiceFulltextExtraction">
+    <camel:camelContext id="cdrServiceFulltextExtraction">
         <camel:package>edu.unc.lib.dl.services.camel.fulltext</camel:package>
     </camel:camelContext>
     
-    <camel:camelContext id="CdrServiceSolr">
+    <camel:camelContext id="cdrServiceSolr">
         <camel:package>edu.unc.lib.dl.services.camel.solr</camel:package>
     </camel:camelContext>
     


### PR DESCRIPTION
Resolves issues with solr indexing of new items before they are indexed in the triple store by breaking enhancements off into a separate queue and using cloned asynchronous calls to trigger them. The effect is that triple indexing is prioritized and generally happens very quickly.

Lays groundwork for allowing subsets of enhancements to be run and for enhancements to be triggered by user requests.

Replication is disabled for the time being while we revisit our approach