### PR TITLE
Fix Count Matching Index

### DIFF
--- a/solr-search/src/main/java/edu/unc/lib/dl/search/solr/service/ChildrenCountService.java
+++ b/solr-search/src/main/java/edu/unc/lib/dl/search/solr/service/ChildrenCountService.java
@@ -215,6 +215,6 @@ public class ChildrenCountService extends AbstractQueryService {
             // If the id starts with the search value, return match.  Else, compare and continue.
             return countId.indexOf(searchVal) == 0 ? 0 : countId.compareTo(searchValue);
         });
-        return matchIndex == -1 ? null : counts.get(matchIndex);
+        return matchIndex < 0 ? null : counts.get(matchIndex);
     }
 }


### PR DESCRIPTION
Fixes a bug which matching child counts to result entries in a search result which is causing list and search views to fail.