### PR TITLE
Fix retrieval of user in jetty without ajp

### DIFF
--- a/security/src/main/java/edu/unc/lib/dl/acl/filter/RequireLoginFilter.java
+++ b/security/src/main/java/edu/unc/lib/dl/acl/filter/RequireLoginFilter.java
@@ -15,6 +15,9 @@
  */
 package edu.unc.lib.dl.acl.filter;
 
+import static edu.unc.lib.dl.acl.util.RemoteUserUtil.getRemoteUser;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
 import java.io.IOException;
 
 import javax.servlet.FilterChain;
@@ -29,7 +32,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
  * Http Filter which requires that the connection be made by an authenticated user
- * 
+ *
  * @author bbpennel
  *
  */
@@ -43,7 +46,8 @@ public class RequireLoginFilter extends OncePerRequestFilter {
     public void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws IOException, ServletException {
 
-        if (request.getRemoteUser() == null || "".equals(request.getRemoteUser().trim())) {
+        String user = getRemoteUser(request);
+        if (isBlank(user)) {
             if (forwardRequest) {
                 RequestDispatcher dispatcher = request.getRequestDispatcher(notLoggedInUrl);
                 dispatcher.forward(request, response);
@@ -52,7 +56,7 @@ public class RequireLoginFilter extends OncePerRequestFilter {
             }
             return;
         } else {
-            log.debug("User logged in as " + request.getRemoteUser());
+            log.debug("User logged in as {}", user);
             chain.doFilter(request, response);
         }
     }

--- a/security/src/main/java/edu/unc/lib/dl/acl/filter/StoreUserAccessControlFilter.java
+++ b/security/src/main/java/edu/unc/lib/dl/acl/filter/StoreUserAccessControlFilter.java
@@ -17,6 +17,7 @@ package edu.unc.lib.dl.acl.filter;
 
 import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.AUTHENTICATED_PRINC;
 import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.PUBLIC_PRINC;
+import static edu.unc.lib.dl.acl.util.RemoteUserUtil.getRemoteUser;
 import static edu.unc.lib.dl.httpclient.HttpClientUtil.FORWARDED_MAIL_HEADER;
 
 import java.io.IOException;
@@ -71,13 +72,7 @@ public class StoreUserAccessControlFilter extends OncePerRequestFilter implement
 
     protected void storeUserGroupData(HttpServletRequest request) {
         try {
-            String userName = request.getRemoteUser();
-            if (userName == null) {
-                userName = "";
-            } else {
-                userName = userName.trim();
-            }
-            GroupsThreadStore.storeUsername(userName);
+            GroupsThreadStore.storeUsername(getRemoteUser(request));
 
             String email = getEmailAddress(request);
             GroupsThreadStore.storeEmail(email);
@@ -109,7 +104,7 @@ public class StoreUserAccessControlFilter extends OncePerRequestFilter implement
         String forwardedGroups = request.getHeader(HttpClientUtil.FORWARDED_GROUPS_HEADER);
         if (log.isDebugEnabled()) {
             log.debug("Forwarding user {} logged in with forwarded groups {}",
-                    request.getRemoteUser(), forwardedGroups);
+                    GroupsThreadStore.getUsername(), forwardedGroups);
         }
         if (forwardedGroups == null) {
             return new AccessGroupSet();
@@ -124,7 +119,7 @@ public class StoreUserAccessControlFilter extends OncePerRequestFilter implement
     protected AccessGroupSet getGrouperGroups(HttpServletRequest request) {
         String shibGroups = request.getHeader(HttpClientUtil.SHIBBOLETH_GROUPS_HEADER);
         AccessGroupSet accessGroups = null;
-        String userName = request.getRemoteUser();
+        String userName = GroupsThreadStore.getUsername();
         if (log.isDebugEnabled()) {
             log.debug("Normal user " + userName + " logged in with groups " + shibGroups);
         }

--- a/security/src/main/java/edu/unc/lib/dl/acl/util/RemoteUserUtil.java
+++ b/security/src/main/java/edu/unc/lib/dl/acl/util/RemoteUserUtil.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.acl.util;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Utility for retrieving the remote user
+ *
+ * @author bbpennel
+ *
+ */
+public class RemoteUserUtil {
+
+    public static final String REMOTE_USER = "REMOTE_USER";
+
+    private RemoteUserUtil() {
+    }
+
+    /**
+     * Retrieve the remote user from the given request.
+     *
+     * @param request
+     * @return remote user or an empty string if none found.
+     */
+    public static String getRemoteUser(HttpServletRequest request) {
+        String user = request.getHeader(REMOTE_USER);
+        if (user == null) {
+            user = request.getRemoteUser();
+        }
+        if (user == null) {
+            user = "";
+        } else {
+            user = user.trim();
+        }
+        return user;
+    }
+}

--- a/sword-server/src/main/java/edu/unc/lib/dl/cdr/sword/server/filters/DepositorAccessControlFilter.java
+++ b/sword-server/src/main/java/edu/unc/lib/dl/cdr/sword/server/filters/DepositorAccessControlFilter.java
@@ -15,22 +15,24 @@
  */
 package edu.unc.lib.dl.cdr.sword.server.filters;
 
+import static edu.unc.lib.dl.acl.util.RemoteUserUtil.getRemoteUser;
+
 import javax.servlet.http.HttpServletRequest;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import edu.unc.lib.dl.acl.filter.StoreUserAccessControlFilter;
-import edu.unc.lib.dl.acl.util.AccessGroupConstants;
 import edu.unc.lib.dl.acl.util.AccessGroupSet;
+import edu.unc.lib.dl.acl.util.AccessPrincipalConstants;
 import edu.unc.lib.dl.cdr.sword.server.SwordConfigurationImpl;
 
 /**
  * Extension of basic access control filter which specifically handles sword depositors, adding in the
  * <depositor-namespace>:<user-name> group and the generic groups
- * 
+ *
  * @author bbpennel
- * 
+ *
  */
 public class DepositorAccessControlFilter extends StoreUserAccessControlFilter {
     private static final Logger log = LoggerFactory.getLogger(DepositorAccessControlFilter.class);
@@ -50,12 +52,13 @@ public class DepositorAccessControlFilter extends StoreUserAccessControlFilter {
     }
 
     protected AccessGroupSet getDepositorGroups(HttpServletRequest request) {
-        log.debug("SWORD depositor user " + request.getRemoteUser() + " logged in");
+        String user = getRemoteUser(request);
+        log.debug("SWORD depositor user {} logged in", user);
         AccessGroupSet accessGroups = new AccessGroupSet();
-        accessGroups.addAccessGroup(AccessGroupConstants.PUBLIC_GROUP);
-        accessGroups.addAccessGroup(AccessGroupConstants.AUTHENTICATED_GROUP);
-        if (request.getRemoteUser() != null) {
+        accessGroups.addAccessGroup(AccessPrincipalConstants.PUBLIC_PRINC);
+        if (user != null) {
             accessGroups.addAccessGroup(swordConfig.getDepositorNamespace() + request.getRemoteUser());
+            accessGroups.addAccessGroup(AccessPrincipalConstants.AUTHENTICATED_PRINC);
         }
         return accessGroups;
     }


### PR DESCRIPTION
User name was not able to be retrieved due to jetty setup, so user name is now retrieved from header when not available from request.