### PR TITLE
Fixes to work against dev vm/fedora 5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,9 +72,9 @@ build-access:
 		static/css/fluid_cap.css \
 		static/css/structure_browse.css \
 		static/css/cdr-ui.css \
-		# Uncomment line in production mode
-		# static/js/vue-cdr-access/dist/css/app*.css \
 		> static/css/cdr_access.css
+		# Reinsert and uncomment line in production mode
+		# static/js/vue-cdr-access/dist/css/app*.css
 
 SUSPEND = "n"
 

--- a/access/pom.xml
+++ b/access/pom.xml
@@ -81,14 +81,14 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <configuration>
+                <!-- <configuration>
                     <webResources>
                         <resource>
                             <filtering>true</filtering>
                             <directory>../etc</directory>
                         </resource>
                     </webResources>
-                </configuration>
+                </configuration> -->
             </plugin>
             
             <plugin>

--- a/access/pom.xml
+++ b/access/pom.xml
@@ -12,7 +12,7 @@
     <url>http://cdr-dev.lib.unc.edu/</url>
     <description>Application for accessing the Digital Collections Repository</description>
     <build>
-        <finalName>ROOT</finalName>
+        <finalName>access</finalName>
         <resources>
             <resource>
                 <filtering>false</filtering>

--- a/access/src/main/webapp/WEB-INF/access-fedora-context.xml
+++ b/access/src/main/webapp/WEB-INF/access-fedora-context.xml
@@ -125,6 +125,9 @@
     <!--  -->
     <bean id="fcrepoClientFactory" class="edu.unc.lib.dl.fcrepo4.FcrepoClientFactory" factory-method="factory">
         <constructor-arg value="${fcrepo.baseUrl}" />
+        <constructor-arg value="${fcrepo.auth.host}" />
+        <constructor-arg value="${fcrepo.auth.user}" />
+        <constructor-arg value="${fcrepo.auth.password}" />
     </bean>
     
     <bean id="fcrepoClient" class="org.fcrepo.client.FcrepoClient"

--- a/admin/src/main/webapp/WEB-INF/service-context.xml
+++ b/admin/src/main/webapp/WEB-INF/service-context.xml
@@ -62,7 +62,7 @@
     
     <bean id="swordUrl" class="java.lang.String">
         <constructor-arg
-            value="${admin.services.url}${services.context}/sword/" />
+            value="${services.base.url}sword/" />
     </bean>
     
     <bean id="swordUsername" class="java.lang.String">

--- a/deposit/src/main/webapp/WEB-INF/fcrepo-clients-context.xml
+++ b/deposit/src/main/webapp/WEB-INF/fcrepo-clients-context.xml
@@ -17,6 +17,9 @@
     
     <bean id="fcrepoClientFactory" class="edu.unc.lib.dl.fcrepo4.FcrepoClientFactory" factory-method="factory">
         <constructor-arg value="${fcrepo.baseUrl}" />
+        <constructor-arg value="${fcrepo.auth.host}" />
+        <constructor-arg value="${fcrepo.auth.user}" />
+        <constructor-arg value="${fcrepo.auth.password}" />
     </bean>
     
     <bean id="fcrepoClient" class="org.fcrepo.client.FcrepoClient"

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
         <jena.fuseki.version>3.8.0</jena.fuseki.version>
         
         <fcrepo-camel.version>5.0.0</fcrepo-camel.version>
-        <camel.version>2.20.4</camel.version>
+        <camel.version>2.22.5</camel.version>
         <tika.version>1.19.1</tika.version>
         
         <maven.failsafe.version>2.22.1</maven.failsafe.version>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <cdr.version>4.0-SNAPSHOT</cdr.version>
         <fcrepo.version>3.8.0</fcrepo.version>
         <fcrepo4.version>5.0.1</fcrepo4.version>
-        <fcrepo-indexing-triplestore.version>4.7.1</fcrepo-indexing-triplestore.version>
+        <fcrepo-indexing-triplestore.version>5.0.0</fcrepo-indexing-triplestore.version>
         <clamavj.version>0.3</clamavj.version>
         
         <spring.version>4.3.20.RELEASE</spring.version>
@@ -120,8 +120,8 @@
         <jena.version>3.9.0</jena.version>
         <jena.fuseki.version>3.8.0</jena.fuseki.version>
         
-        <fcrepo-camel.version>4.5.0</fcrepo-camel.version>
-        <camel.version>2.22.1</camel.version>
+        <fcrepo-camel.version>5.0.0</fcrepo-camel.version>
+        <camel.version>2.20.4</camel.version>
         <tika.version>1.19.1</tika.version>
         
         <maven.failsafe.version>2.22.1</maven.failsafe.version>

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/enhancements/EnhancementRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/enhancements/EnhancementRouter.java
@@ -17,6 +17,7 @@ package edu.unc.lib.dl.services.camel.enhancements;
 
 import static edu.unc.lib.dl.rdf.Cdr.AdminUnit;
 import static edu.unc.lib.dl.rdf.Cdr.Collection;
+import static edu.unc.lib.dl.rdf.Cdr.ContentRoot;
 import static edu.unc.lib.dl.rdf.Cdr.DescriptiveMetadata;
 import static edu.unc.lib.dl.rdf.Cdr.FileObject;
 import static edu.unc.lib.dl.rdf.Cdr.Folder;
@@ -96,6 +97,7 @@ public class EnhancementRouter extends RouteBuilder {
                     + " || ${headers[org.fcrepo.jms.resourceType]} contains '" + Folder.getURI() + "'"
                     + " || ${headers[org.fcrepo.jms.resourceType]} contains '" + Collection.getURI() + "'"
                     + " || ${headers[org.fcrepo.jms.resourceType]} contains '" + AdminUnit.getURI() + "'"
+                    + " || ${headers[org.fcrepo.jms.resourceType]} contains '" + ContentRoot.getURI() + "'"
                     ))
             // Filter out descriptive md separately because camel simple filters don't support basic () operators
             .filter(simple("${headers[org.fcrepo.jms.resourceType]} not contains '"

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/routing/MetaServicesRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/routing/MetaServicesRouter.java
@@ -15,6 +15,8 @@
  */
 package edu.unc.lib.dl.services.camel.routing;
 
+import static edu.unc.lib.dl.services.camel.util.EventTypes.EVENT_CREATE;
+
 import org.apache.camel.BeanInject;
 import org.apache.camel.PropertyInject;
 import org.apache.camel.builder.RouteBuilder;
@@ -51,7 +53,7 @@ public class MetaServicesRouter extends RouteBuilder {
 
         from("direct:process.enhancement")
             .routeId("ProcessEnhancement")
-            .filter(simple("${headers[org.fcrepo.jms.eventType]} contains 'ResourceCreation'"))
+            .filter(simple("${headers[org.fcrepo.jms.eventType]} contains '" + EVENT_CREATE + "'"))
                 .log("Performing enhancements for ${headers[org.fcrepo.jms.identifier]}")
                 .delay(simple("{{cdr.enhancement.postIndexingDelay}}"))
                 .removeHeaders("CamelHttp*")

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/util/EventTypes.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/util/EventTypes.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.services.camel.util;
+
+/**
+ * Constants related to Fedora JMS event types
+ *
+ * @author bbpennel
+ *
+ */
+public class EventTypes {
+
+    private EventTypes() {
+    }
+
+    public final static String EVENT_CREATE = "https://www.w3.org/ns/activitystreams#Create";
+    public final static String EVENT_DELETE = "https://www.w3.org/ns/activitystreams#Delete";
+    public final static String EVENT_UPDATE = "https://www.w3.org/ns/activitystreams#Update";
+    public final static String EVENT_MOVE = "https://www.w3.org/ns/activitystreams#Move";
+    public final static String EVENT_FOLLOW = "https://www.w3.org/ns/activitystreams#Follow";
+}

--- a/services-camel/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel/src/main/webapp/WEB-INF/service-context.xml
@@ -27,6 +27,9 @@
     
     <bean id="fcrepoClientFactory" class="edu.unc.lib.dl.fcrepo4.FcrepoClientFactory" factory-method="factory">
         <constructor-arg value="${fcrepo.baseUrl}" />
+        <constructor-arg value="${fcrepo.auth.host}" />
+        <constructor-arg value="${fcrepo.auth.user}" />
+        <constructor-arg value="${fcrepo.auth.password}" />
     </bean>
     
     <bean id="fcrepoClient" class="org.fcrepo.client.FcrepoClient"
@@ -184,9 +187,9 @@
     </bean>
     
     <bean id="fcrepo" class="org.fcrepo.camel.FcrepoComponent">
-        <property name="authUsername" value="${fcrepo.authUsername}"/>
-        <property name="authPassword" value="${fcrepo.authPassword}"/>
-        <property name="authHost" value="${fcrepo.authHost}"/>
+        <property name="authUsername" value="${fcrepo.auth.user}"/>
+        <property name="authPassword" value="${fcrepo.auth.password}"/>
+        <property name="authHost" value="${fcrepo.auth.host}"/>
         <property name="baseUrl" value="${fcrepo.baseUrl}"/>
     </bean>
 

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/routing/MetaServicesRouterTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/routing/MetaServicesRouterTest.java
@@ -19,6 +19,7 @@ import static edu.unc.lib.dl.rdf.Fcrepo4Repository.Binary;
 import static edu.unc.lib.dl.services.camel.JmsHeaderConstants.EVENT_TYPE;
 import static edu.unc.lib.dl.services.camel.JmsHeaderConstants.IDENTIFIER;
 import static edu.unc.lib.dl.services.camel.JmsHeaderConstants.RESOURCE_TYPE;
+import static edu.unc.lib.dl.services.camel.util.EventTypes.EVENT_CREATE;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -115,7 +116,7 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
     private static Map<String, Object> createEvent(final String identifier, final String... type) {
 
         final Map<String, Object> headers = new HashMap<>();
-        headers.put(EVENT_TYPE, "ResourceCreation");
+        headers.put(EVENT_TYPE, EVENT_CREATE);
         headers.put(IDENTIFIER, identifier);
         headers.put(RESOURCE_TYPE, String.join(",", type));
 

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/ItemInfoRestController.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/ItemInfoRestController.java
@@ -57,9 +57,6 @@ public class ItemInfoRestController implements ServletContextAware {
     @Resource
     private SolrQueryLayerService solrSearchService;
 
-    @Resource(name = "contextUrl")
-    protected String contextUrl = null;
-
     @RequestMapping(value = "{id}/solrRecord", method = RequestMethod.GET)
     public @ResponseBody
     BriefObjectMetadataBean getItemSolrRecord(HttpServletResponse response, @PathVariable("id") String id) {

--- a/services/src/main/webapp/WEB-INF/access-fedora-context.xml
+++ b/services/src/main/webapp/WEB-INF/access-fedora-context.xml
@@ -72,6 +72,9 @@
     
     <bean id="fcrepoClientFactory" class="edu.unc.lib.dl.fcrepo4.FcrepoClientFactory" factory-method="factory">
         <constructor-arg value="${fcrepo.baseUrl}" />
+        <constructor-arg value="${fcrepo.auth.host}" />
+        <constructor-arg value="${fcrepo.auth.user}" />
+        <constructor-arg value="${fcrepo.auth.password}" />
     </bean>
     
     <bean id="fcrepoClient" class="org.fcrepo.client.FcrepoClient"

--- a/services/src/main/webapp/WEB-INF/service-context.xml
+++ b/services/src/main/webapp/WEB-INF/service-context.xml
@@ -213,10 +213,6 @@
     </bean>
     
     <!-- Access related beans -->
-    <bean id="contextUrl" class="java.lang.String">
-        <constructor-arg
-            value="${repository.protocol}://${repository.host}${repository.port}/${services.context}" />
-    </bean>
     
     <bean name="storeAccessLevelFilter" class="edu.unc.lib.dl.ui.access.StoreAccessLevelFilter">
         <property name="queryLayer" ref="queryLayer" />

--- a/services/src/main/webapp/WEB-INF/sword-context.xml
+++ b/services/src/main/webapp/WEB-INF/sword-context.xml
@@ -28,7 +28,7 @@
 
     <bean id="swordPath" class="java.lang.String">
         <constructor-arg
-            value="${repository.protocol}://${repository.host}${repository.port}/${services.context}/${sword.context}" />
+            value="${services.base.url}sword" />
     </bean>
 
     <bean class="edu.unc.lib.dl.schematron.SchematronValidator" name="schematronValidator"
@@ -81,7 +81,7 @@
     <bean id="config" class="edu.unc.lib.dl.cdr.sword.server.SwordConfigurationImpl">
         <property name="authType" value="Basic"/>
         <property name="swordPath" ref="swordPath"/>
-        <property name="basePath" value="${repository.protocol}://${repository.host}${repository.port}/${repository.context}"/>
+        <property name="basePath" value="${services.base.url}"/>
         <property name="tempDirectory" value="${initial.batch.ingest.dir}"/>
         <property name="swordVersion" value="${sword.version}"/>
         <property name="generatorVersion" value="${project.version}"/>

--- a/static/js/admin/src/CreateContainerForm.js
+++ b/static/js/admin/src/CreateContainerForm.js
@@ -33,7 +33,7 @@ define('CreateContainerForm', [ 'jquery', 'jquery-ui', 'underscore', 'RemoteStat
 	CreateContainerForm.prototype.getContainerType = function (resultObject) {
 		var parentType = resultObject.type;
 
-		if (parentType === "RootObject") {
+		if (parentType === "ContentRoot") {
 			return "AdminUnit";
 		} else if (parentType === "AdminUnit") {
 			return "Collection";


### PR DESCRIPTION
* Enables basic auth against fedora, which is now the default
* Renames the ROOT.war to access.war for consistency
* Updates camel dependencies and behaviors for fedora5
* Fix to allow creation of AdminUnits
* Updates to properties being used to eliminate some unused or duplicate properties.

This will not work on qa at the moment since it requires fedora 5