### PR TITLE
BXC-2419 - Reverse deposit to object link direction

### DIFF
--- a/deposit/src/main/java/edu/unc/lib/deposit/fcrepo4/IngestDepositRecordJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/fcrepo4/IngestDepositRecordJob.java
@@ -20,11 +20,9 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.jena.rdf.model.Bag;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
@@ -33,7 +31,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import edu.unc.lib.deposit.work.AbstractDepositJob;
-import edu.unc.lib.deposit.work.DepositGraphUtils;
 import edu.unc.lib.dl.event.PremisLogger;
 import edu.unc.lib.dl.fcrepo4.DepositRecord;
 import edu.unc.lib.dl.fcrepo4.RepositoryObject;
@@ -105,14 +102,6 @@ public class IngestDepositRecordJob extends AbstractDepositJob {
                 String path = URI.create(manifestPath).getPath();
                 depositRecord.addManifest(new File(path), "text/plain");
             }
-
-            // Add references to deposited objects
-            Bag depositBag = dModel.getBag(depositPID.getRepositoryPath());
-            List<Resource> children = new ArrayList<>();
-            // walks through the bag and adds children to the list
-            DepositGraphUtils.walkObjectsDepthFirst(depositBag, children);
-            depositRecord.addIngestedObjects(children);
-
         } catch (IOException | FedoraException e) {
             failJob(e, "Failed to ingest deposit record {0}", depositPID);
         }

--- a/deposit/src/main/java/edu/unc/lib/deposit/work/DepositSupervisor.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/work/DepositSupervisor.java
@@ -637,15 +637,15 @@ public class DepositSupervisor implements WorkerListener {
             return makeJob(ExtractTechnicalMetadataJob.class, depositUUID);
         }
 
-        // Ingest all content objects to repository
-        if (!successfulJobs.contains(IngestContentObjectsJob.class.getName())) {
-            return makeJob(IngestContentObjectsJob.class, depositUUID);
-        }
-
         boolean excludeDepositRecord = Boolean.parseBoolean(status.get(DepositField.excludeDepositRecord.name()));
         // Ingest the deposit record
         if (!excludeDepositRecord && !successfulJobs.contains(IngestDepositRecordJob.class.getName())) {
             return makeJob(IngestDepositRecordJob.class, depositUUID);
+        }
+
+        // Ingest all content objects to repository
+        if (!successfulJobs.contains(IngestContentObjectsJob.class.getName())) {
+            return makeJob(IngestContentObjectsJob.class, depositUUID);
         }
 
         return null;

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/DepositRecord.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/DepositRecord.java
@@ -23,8 +23,6 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.StmtIterator;
@@ -105,30 +103,12 @@ public class DepositRecord extends RepositoryObject {
     }
 
     /**
-     * Establishes a relationship between the deposit record and each object
-     * that was added to the deposit.
-     * @param depositPID
-     * @param children
-     * @return the DepositRecord itself, to allow method chaining
-     */
-    public DepositRecord addIngestedObjects(List<Resource> children) {
-        Model triples = ModelFactory.createDefaultModel();
-        Resource res = triples.createResource(getPid().getURI());
-        for (Resource child : children) {
-            res.addProperty(Cdr.hasIngestedObject, child);
-        }
-        // SPARQL update
-        repoObjFactory.createRelationships(this, triples);
-        return this;
-    }
-
-    /**
      * Retrieves a list of pids for objects contained by this deposit record
      * @return
      * @throws FedoraException
      */
     public List<PID> listDepositedObjects() throws FedoraException {
-        return addPidsToList(Cdr.hasIngestedObject);
+        return this.driver.listRelated(this, Cdr.originalDeposit);
     }
 
     /**

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectDriver.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectDriver.java
@@ -217,25 +217,37 @@ public class RepositoryObjectDriver {
      * @return a List of PIDs for member objects of the provided object.
      */
     public List<PID> listMembers(RepositoryObject obj) {
+        return listRelated(obj, PcdmModels.memberOf);
+    }
+
+    /**
+     * Produces a list of PIDs for objects which are related to the current object via
+     * the provided relationship property.
+     *
+     * @param obj the object
+     * @param relation relation predicate
+     * @return a List of PIDs for objects related by the given predicate
+     */
+    public List<PID> listRelated(RepositoryObject obj, Property relation) {
         PID pid = obj.getPid();
         String queryString = String.format("select ?pid where { ?pid <%1$s> <%2$s> }",
-                PcdmModels.memberOf, pid.getURI());
-        List<PID> members = new ArrayList<>();
+                relation, pid.getURI());
+        List<PID> related = new ArrayList<>();
 
         try (QueryExecution qexec = sparqlQueryService.executeQuery(queryString)) {
             ResultSet results = qexec.execSelect();
 
-            for (; results.hasNext();) {
+            while (results.hasNext()) {
                 QuerySolution soln = results.nextSolution();
                 Resource res = soln.getResource("pid");
 
                 if (res != null) {
-                    members.add(PIDs.get(res.getURI()));
+                    related.add(PIDs.get(res.getURI()));
                 }
             }
         }
 
-        return members;
+        return related;
     }
 
     /**

--- a/metadata/src/main/java/edu/unc/lib/dl/rdf/Cdr.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/rdf/Cdr.java
@@ -66,10 +66,6 @@ public class Cdr {
     public static final Property depositedOnBehalfOf = createProperty(
             "http://cdr.unc.edu/definitions/model#depositedOnBehalfOf" );
 
-    /** Relationship indicating that an ingested object was a part of a given deposit */
-    public static final Property hasIngestedObject = createProperty(
-            "http://cdr.unc.edu/definitions/model#hasIngestedObject");
-
     /** Relationship indicating ownership of a manifest by this deposit record */
     public static final Property hasManifest = createProperty(
             "http://cdr.unc.edu/definitions/model#hasManifest" );
@@ -121,6 +117,10 @@ public class Cdr {
     /** An invalid vocabulary term in this descriptive record. */
     public static final Property invalidTerm = createProperty(
             "http://cdr.unc.edu/definitions/model#invalidTerm" );
+
+    /** Relation which denotes the deposit record for the subject object. */
+    public static final Property originalDeposit = createProperty(
+            "http://cdr.unc.edu/definitions/model#originalDeposit" );
 
     /** Relation from a work to a child which will be treated as the primary
      *  object for this work.


### PR DESCRIPTION
* Switches to using cdr:originalDeposit relation to link to deposit records
* Deposit recorded created before content objects ingested, and originalDeposit link added during content ingest