### PR TITLE
BXC-2444 - Staff role assignment service

### DIFF
--- a/access/src/main/webapp/WEB-INF/access-fedora-context.xml
+++ b/access/src/main/webapp/WEB-INF/access-fedora-context.xml
@@ -86,7 +86,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="${cache.objectAcls.maxSize}" />
         <property name="cacheTimeToLive" value="${cache.objectAcls.timeToLive}" />
-        <property name="queryService" ref="sparqlQueryService" />
+        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
     </bean>
     
     <bean id="objectPermissionEvaluator" class="edu.unc.lib.dl.acl.fcrepo4.ObjectPermissionEvaluator">

--- a/admin/src/main/webapp/WEB-INF/access-fedora-context.xml
+++ b/admin/src/main/webapp/WEB-INF/access-fedora-context.xml
@@ -74,7 +74,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="${cache.objectAcls.maxSize}" />
         <property name="cacheTimeToLive" value="${cache.objectAcls.timeToLive}" />
-        <property name="queryService" ref="sparqlQueryService" />
+        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
     </bean>
     
     <bean id="objectPermissionEvaluator" class="edu.unc.lib.dl.acl.fcrepo4.ObjectPermissionEvaluator">

--- a/deposit/src/main/webapp/WEB-INF/service-context.xml
+++ b/deposit/src/main/webapp/WEB-INF/service-context.xml
@@ -207,7 +207,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="${cache.objectAcls.maxSize}" />
         <property name="cacheTimeToLive" value="${cache.objectAcls.timeToLive}" />
-        <property name="queryService" ref="sparqlQueryService" />
+        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
     </bean>
     
     <bean id="objectPermissionEvaluator" class="edu.unc.lib.dl.acl.fcrepo4.ObjectPermissionEvaluator">

--- a/deposit/src/test/resources/spring-test/cdr-client-container.xml
+++ b/deposit/src/test/resources/spring-test/cdr-client-container.xml
@@ -75,7 +75,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="100" />
         <property name="cacheTimeToLive" value="100" />
-        <property name="queryService" ref="sparqlQueryService" />
+        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
     </bean>
     
     <bean id="objectPermissionEvaluator" class="edu.unc.lib.dl.acl.fcrepo4.ObjectPermissionEvaluator">

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectLoader.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectLoader.java
@@ -59,9 +59,6 @@ public class RepositoryObjectLoader {
         cacheTimeToLive = timeToLive;
     }
 
-    public void setRepositoryObjectFactory(RepositoryObjectFactory repoObjFactory) {
-    }
-
     public AdminUnit getAdminUnit(PID pid) {
         RepositoryObject repoObj = getRepositoryObject(pid);
         if (!(repoObj instanceof AdminUnit)) {

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/acl/fcrepo4/AccessControlServiceImplIT.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/acl/fcrepo4/AccessControlServiceImplIT.java
@@ -36,11 +36,12 @@ import edu.unc.lib.dl.fcrepo4.CollectionObject;
 import edu.unc.lib.dl.fcrepo4.ContentRootObject;
 import edu.unc.lib.dl.fcrepo4.FolderObject;
 import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectCacheLoader;
 import edu.unc.lib.dl.fcrepo4.RepositoryPaths;
 import edu.unc.lib.dl.fcrepo4.WorkObject;
 import edu.unc.lib.dl.fedora.ContentPathFactory;
 import edu.unc.lib.dl.fedora.PID;
-import edu.unc.lib.dl.sparql.SparqlQueryService;
+import edu.unc.lib.dl.rdf.PcdmModels;
 import edu.unc.lib.dl.test.AclModelBuilder;
 
 /**
@@ -79,6 +80,8 @@ public class AccessControlServiceImplIT extends AbstractFedoraIT {
 
     @Autowired
     private ContentPathFactory pathFactory;
+    @Autowired
+    private RepositoryObjectCacheLoader repositoryObjectCacheLoader;
 
     private ObjectAclFactory aclFactory;
 
@@ -90,9 +93,6 @@ public class AccessControlServiceImplIT extends AbstractFedoraIT {
 
     private AccessControlServiceImpl aclService;
 
-    @Autowired
-    private SparqlQueryService sparqlService;
-
     @Before
     public void init() throws Exception {
         Properties properties = new Properties();
@@ -100,7 +100,7 @@ public class AccessControlServiceImplIT extends AbstractFedoraIT {
         globalPermissionEvaluator = new GlobalPermissionEvaluator(properties);
 
         aclFactory = new ObjectAclFactory();
-        aclFactory.setQueryService(sparqlService);
+        aclFactory.setRepositoryObjectCacheLoader(repositoryObjectCacheLoader);
         aclFactory.setCacheMaxSize(CACHE_MAX_SIZE);
         aclFactory.setCacheTimeToLive(CACHE_TIME_TO_LIVE);
         aclFactory.init();
@@ -359,7 +359,7 @@ public class AccessControlServiceImplIT extends AbstractFedoraIT {
     }
 
     private List<PID> getAllContentObjects() {
-        return queryModel.listResourcesWithProperty(RDF.type).toList().stream()
+        return queryModel.listResourcesWithProperty(RDF.type, PcdmModels.Object).toList().stream()
                 .map(p -> PIDs.get(p.getURI()))
                 .collect(Collectors.toList());
     }

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/test/AclModelBuilder.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/test/AclModelBuilder.java
@@ -17,6 +17,8 @@ package edu.unc.lib.dl.test;
 
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
 
+import java.util.Calendar;
+
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
@@ -63,6 +65,11 @@ public class AclModelBuilder {
 
     public AclModelBuilder addPatronAccess(String value) {
         return addProp(CdrAcl.patronAccess, value);
+    }
+
+    public AclModelBuilder addEmbargoUntil(Calendar date) {
+        resc.addLiteral(CdrAcl.embargoUntil, date);
+        return this;
     }
 
     private AclModelBuilder addProp(Property prop, String princ) {

--- a/fcrepo-clients/src/test/resources/spring-test/cdr-client-container.xml
+++ b/fcrepo-clients/src/test/resources/spring-test/cdr-client-container.xml
@@ -45,7 +45,6 @@
         <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
         <property name="cacheTimeToLive" ref="cacheTimeToLive" />
         <property name="cacheMaxSize" ref="cacheMaxSize" />
-        <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
     </bean>
     
     <bean id="repositoryObjectDriver" class="edu.unc.lib.dl.fcrepo4.RepositoryObjectDriver">

--- a/metadata/src/main/java/edu/unc/lib/dl/rdf/Memento.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/rdf/Memento.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.rdf;
+
+import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
+import static org.apache.jena.rdf.model.ResourceFactory.createResource;
+
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+
+/**
+ *
+ * @author bbpennel
+ *
+ */
+public class Memento {
+    private Memento() {
+    }
+
+    /** The namespace of the vocabulary as a string */
+    public static final String NS = "http://mementoweb.org/ns#";
+
+    public static final Resource Memento = createResource(
+            "http://mementoweb.org/ns#Memento" );
+
+    public static final Resource OriginalResource = createResource(
+            "http://mementoweb.org/ns#OriginalResource" );
+
+    public static final Resource TimeGate = createResource(
+            "http://mementoweb.org/ns#TimeGate" );
+
+    public static final Resource TimeMap = createResource(
+            "http://mementoweb.org/ns#TimeMap" );
+
+    public static final Property memento = createProperty(
+            "http://mementoweb.org/ns#memento" );
+
+    public static final Property mementoDatetime = createProperty(
+            "http://mementoweb.org/ns#mementoDatetime" );
+
+    public static final Property timegate = createProperty(
+            "http://mementoweb.org/ns#timegate" );
+
+    public static final Property timemap = createProperty(
+            "http://mementoweb.org/ns#timemap" );
+
+    public static final Property original = createProperty(
+            "http://mementoweb.org/ns#original" );
+}

--- a/metadata/src/main/java/edu/unc/lib/dl/rdf/Premis.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/rdf/Premis.java
@@ -112,6 +112,8 @@ public class Premis {
 
     public static final Property hasEventType = createProperty("http://www.loc.gov/premis/rdf/v1#hasEventType");
 
+    public static final Property hasFixity = createProperty("http://www.loc.gov/premis/rdf/v1#hasFixity");
+
     public static final Property hasMessageDigest = createProperty("http://www.loc.gov/premis/rdf/v1#hasMessageDigest");
 
     public static final Property hasOriginalName = createProperty("http://www.loc.gov/premis/rdf/v1#hasOriginalName");
@@ -234,6 +236,9 @@ public class Premis {
 
     public static final Resource Normalization = createResource(
             "http://id.loc.gov/vocabulary/preservation/eventType/nor");
+
+    public static final Resource PolicyAssignment = createResource(
+            "http://id.loc.gov/vocabulary/preservation/eventType/poa");
 
     public static final Resource Replication = createResource(
             "http://id.loc.gov/vocabulary/preservation/eventType/rep");

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/acl/StaffRoleAssignmentService.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/acl/StaffRoleAssignmentService.java
@@ -1,0 +1,201 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.persist.services.acl;
+
+import static edu.unc.lib.dl.acl.util.Permission.assignStaffRoles;
+import static org.springframework.util.Assert.notNull;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Resource;
+
+import edu.unc.lib.dl.acl.exception.InvalidAssignmentException;
+import edu.unc.lib.dl.acl.fcrepo4.InheritedAclFactory;
+import edu.unc.lib.dl.acl.service.AccessControlService;
+import edu.unc.lib.dl.acl.util.AgentPrincipals;
+import edu.unc.lib.dl.acl.util.RoleAssignment;
+import edu.unc.lib.dl.acl.util.UserRole;
+import edu.unc.lib.dl.fcrepo4.AdminUnit;
+import edu.unc.lib.dl.fcrepo4.CollectionObject;
+import edu.unc.lib.dl.fcrepo4.RepositoryObject;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.metrics.TimerFactory;
+import edu.unc.lib.dl.rdf.Premis;
+import edu.unc.lib.dl.services.OperationsMessageSender;
+import edu.unc.lib.dl.util.JMSMessageUtil.CDRActions;
+import io.dropwizard.metrics5.Timer;
+
+/**
+ * Service which replaces staff role assignments for content objects.
+ *
+ * @author bbpennel
+ *
+ */
+public class StaffRoleAssignmentService {
+    private final static String NEWLINE = System.getProperty("line.separator");
+
+    private AccessControlService aclService;
+    private RepositoryObjectLoader repositoryObjectLoader;
+    private RepositoryObjectFactory repositoryObjectFactory;
+    private InheritedAclFactory aclFactory;
+    private OperationsMessageSender operationsMessageSender;
+
+    private static final Timer timer = TimerFactory.createTimerForClass(StaffRoleAssignmentService.class);
+
+    /**
+     * Replaces all staff role assignments for the target object with the provided list of assignments.
+     *
+     * @param agent Agent requesting the operation
+     * @param target PID of the object whose roles will be updated.
+     * @param assignments List of maps, where each map contains one staff principal to role assignment.
+     *      Permissions are identified by name.
+     * @return job id
+     */
+    public String updateRoles(AgentPrincipals agent, PID target, Collection<RoleAssignment> assignments) {
+        notNull(agent, "Must provide an agent for this operation");
+        try (Timer.Context context = timer.time()) {
+            aclService.assertHasAccess("Insufficient privileges to assign staff roles for object " + target.getId(),
+                    target, agent.getPrincipals(), assignStaffRoles);
+
+            RepositoryObject repoObj = repositoryObjectLoader.getRepositoryObject(target);
+
+            // Verify that the target is a collection or admin unit
+            if (repoObj instanceof CollectionObject) {
+                // Ensure that unitOwner is not being set for collection object
+                if (containsUnitOwner(assignments)) {
+                    throw new InvalidAssignmentException("Cannot assign unit owner role on object " + target.getId()
+                        + " of type Collection");
+                }
+            } else if (!(repoObj instanceof AdminUnit)) {
+                throw new InvalidAssignmentException("Cannot assign staff roles to  object " + target.getId()
+                    + ", objects of type " + repoObj.getClass().getName() + " are not eligible.");
+            }
+
+            replaceStaffRoles(repoObj, assignments);
+
+            repoObj.getPremisLog().buildEvent(Premis.PolicyAssignment)
+                    .addImplementorAgent(agent.getUsernameUri())
+                    .addEventDetail(createEventDetails(target))
+                    .write();
+
+            return operationsMessageSender.sendOperationMessage(agent.getUsername(),
+                    CDRActions.EDIT_ACCESS_CONTROL,
+                    Collections.singletonList(target));
+        }
+    }
+
+    private boolean containsUnitOwner(Collection<RoleAssignment> assignments) {
+        return assignments.stream().anyMatch(a -> UserRole.unitOwner.equals(a.getRole()));
+    }
+
+    private void replaceStaffRoles(RepositoryObject repoObj, Collection<RoleAssignment> assignments) {
+        // Update a copy of the model for this object
+        Model model = ModelFactory.createDefaultModel().add(repoObj.getModel());
+        Resource resc = model.getResource(repoObj.getPid().getRepositoryPath());
+
+        // Clear out all the existing staff roles
+        for (UserRole role: UserRole.getStaffRoles()) {
+            resc.removeAll(role.getProperty());
+        }
+
+        // Add the new role assignments
+        for (RoleAssignment assignment: assignments) {
+            resc.addProperty(assignment.getRole().getProperty(), assignment.getPrincipal());
+        }
+
+        // Push the updated model back to fedora
+        repositoryObjectFactory.createOrTransformObject(repoObj.getUri(), model);
+    }
+
+    private String createEventDetails(PID targetPid) {
+        Map<String, Set<String>> princRoles = aclFactory.getPrincipalRoles(targetPid);
+        Map<UserRole, List<String>> rolePrincs = new EnumMap<>(UserRole.class);
+        // Flip things around, create a map of roles to all the principals that belong to them
+        princRoles.entrySet().forEach(princRolesEntry ->
+            princRolesEntry.getValue().forEach(role -> {
+                UserRole userRole = UserRole.getRoleByProperty(role);
+                if (userRole != null && userRole.isStaffRole()) {
+                    List<String> principals = rolePrincs.getOrDefault(userRole, new ArrayList<>());
+                    principals.add(princRolesEntry.getKey());
+                    rolePrincs.put(userRole, principals);
+                }
+            })
+        );
+
+        StringBuilder details = new StringBuilder("Staff roles for item set to:");
+        details.append(NEWLINE);
+        if (rolePrincs.isEmpty()) {
+            details.append("No roles assigned");
+        } else {
+            // Iterating through staff roles to ensure ordering is consistent
+            for (UserRole role: UserRole.getStaffRoles()) {
+                if (rolePrincs.containsKey(role)) {
+                    // Log principals in alphabetic order to avoid unnecessary variation
+                    Collections.sort(rolePrincs.get(role));
+                    details.append(role.name()).append(": ")
+                        .append(String.join(", ", rolePrincs.get(role))).append(NEWLINE);
+                }
+            }
+        }
+
+        return details.toString();
+    }
+
+    /**
+     * @param aclService the aclService to set
+     */
+    public void setAclService(AccessControlService aclService) {
+        this.aclService = aclService;
+    }
+
+    /**
+     * @param repositoryObjectLoader the repositoryObjectLoader to set
+     */
+    public void setRepositoryObjectLoader(RepositoryObjectLoader repositoryObjectLoader) {
+        this.repositoryObjectLoader = repositoryObjectLoader;
+    }
+
+    /**
+     * @param aclFactory the aclFactory to set
+     */
+    public void setAclFactory(InheritedAclFactory aclFactory) {
+        this.aclFactory = aclFactory;
+    }
+
+    /**
+     * @param operationsMessageSender the operationsMessageSender to set
+     */
+    public void setOperationsMessageSender(OperationsMessageSender operationsMessageSender) {
+        this.operationsMessageSender = operationsMessageSender;
+    }
+
+    /**
+     * @param repositoryObjectFactory the repositoryObjectFactory to set
+     */
+    public void setRepositoryObjectFactory(RepositoryObjectFactory repositoryObjectFactory) {
+        this.repositoryObjectFactory = repositoryObjectFactory;
+    }
+}

--- a/persistence/src/main/java/edu/unc/lib/dl/services/OperationsMessageSender.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/services/OperationsMessageSender.java
@@ -243,43 +243,6 @@ public class OperationsMessageSender extends AbstractMessageSender {
     }
 
     /**
-     * Sends a Published operation message, indicating that the publication
-     * status of objects has changed.
-     *
-     * @param userid id of user who triggered the operation
-     * @param pids objects changed
-     * @param publish Subjects are published if true, unpublished if false
-     * @return id of operation message
-     */
-    public String sendPublishOperation(String userid, Collection<PID> pids, boolean publish) {
-        Element contentEl = createAtomEntry(userid, pids.iterator().next(),
-                CDRActions.PUBLISH);
-
-        Element publishEl = new Element("publish", CDR_MESSAGE_NS);
-        contentEl.addContent(publishEl);
-
-        Element publishValueEl = new Element("value", CDR_MESSAGE_NS);
-        publishEl.addContent(publishValueEl);
-        if (publish) {
-            publishValueEl.setText("yes");
-        } else {
-            publishValueEl.setText("no");
-        }
-
-        Element subjects = new Element("subjects", CDR_MESSAGE_NS);
-        publishEl.addContent(subjects);
-        for (PID sub : pids) {
-            subjects.addContent(new Element("pid", CDR_MESSAGE_NS).setText(sub.getRepositoryPath()));
-        }
-
-        Document msg = contentEl.getDocument();
-        sendMessage(msg);
-        LOG.debug("sent publish operation JMS message using JMS template: {}", this.getJmsTemplate());
-
-        return getMessageId(msg);
-    }
-
-    /**
      * Sends Edit Type operation message.
      *
      * @param userid id of user who triggered the operation
@@ -361,6 +324,33 @@ public class OperationsMessageSender extends AbstractMessageSender {
         Document msg = contentEl.getDocument();
         sendMessage(msg);
         LOG.debug("sent set-as-primary-object operation JMS message using JMS template: {}", this.getJmsTemplate());
+
+        return getMessageId(msg);
+    }
+
+    /**
+     * Sends a message indicating that an action has occurred on a collection of objects
+     *
+     * @param userid id of user who triggered the operation
+     * @param pids objects affected.
+     * @return id of operation message
+     */
+    public String sendOperationMessage(String userid, CDRActions action, Collection<PID> pids) {
+        Element contentEl = createAtomEntry(userid, pids.iterator().next(),
+                action);
+
+        Element editAclEl = new Element(action.getName(), CDR_MESSAGE_NS);
+        contentEl.addContent(editAclEl);
+
+        Element subjects = new Element("subjects", CDR_MESSAGE_NS);
+        editAclEl.addContent(subjects);
+        for (PID sub : pids) {
+            subjects.addContent(new Element("pid", CDR_MESSAGE_NS).setText(sub.getRepositoryPath()));
+        }
+
+        Document msg = contentEl.getDocument();
+        sendMessage(msg);
+        LOG.debug("sent publish operation JMS message using JMS template: {}", this.getJmsTemplate());
 
         return getMessageId(msg);
     }

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/acl/StaffRoleAssignmentServiceIT.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/acl/StaffRoleAssignmentServiceIT.java
@@ -1,0 +1,500 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.persist.services.acl;
+
+import static edu.unc.lib.dl.acl.service.PatronAccess.authenticated;
+import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.USER_NAMESPACE;
+import static edu.unc.lib.dl.acl.util.UserRole.canAccess;
+import static edu.unc.lib.dl.acl.util.UserRole.canManage;
+import static edu.unc.lib.dl.acl.util.UserRole.canViewOriginals;
+import static edu.unc.lib.dl.acl.util.UserRole.unitOwner;
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.time.ZonedDateTime;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.rdf.model.StmtIterator;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+
+import edu.unc.lib.dl.acl.exception.AccessRestrictionException;
+import edu.unc.lib.dl.acl.exception.InvalidAssignmentException;
+import edu.unc.lib.dl.acl.fcrepo4.InheritedAclFactory;
+import edu.unc.lib.dl.acl.service.AccessControlService;
+import edu.unc.lib.dl.acl.util.AccessGroupSet;
+import edu.unc.lib.dl.acl.util.AgentPrincipals;
+import edu.unc.lib.dl.acl.util.Permission;
+import edu.unc.lib.dl.acl.util.RoleAssignment;
+import edu.unc.lib.dl.acl.util.UserRole;
+import edu.unc.lib.dl.fcrepo4.AdminUnit;
+import edu.unc.lib.dl.fcrepo4.CollectionObject;
+import edu.unc.lib.dl.fcrepo4.ContentObject;
+import edu.unc.lib.dl.fcrepo4.ContentRootObject;
+import edu.unc.lib.dl.fcrepo4.FolderObject;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
+import edu.unc.lib.dl.fcrepo4.RepositoryPIDMinter;
+import edu.unc.lib.dl.fcrepo4.RepositoryPaths;
+import edu.unc.lib.dl.fcrepo4.WorkObject;
+import edu.unc.lib.dl.fedora.FedoraException;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.rdf.CdrAcl;
+import edu.unc.lib.dl.rdf.Premis;
+import edu.unc.lib.dl.services.OperationsMessageSender;
+import edu.unc.lib.dl.test.AclModelBuilder;
+import edu.unc.lib.dl.test.RepositoryObjectTreeIndexer;
+import edu.unc.lib.dl.test.TestHelper;
+import edu.unc.lib.dl.util.JMSMessageUtil.CDRActions;
+
+/**
+ *
+ * @author bbpennel
+ *
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextHierarchy({
+    @ContextConfiguration("/spring-test/test-fedora-container.xml"),
+    @ContextConfiguration("/spring-test/cdr-client-container.xml"),
+    @ContextConfiguration("/spring-test/staff-role-service-container.xml"),
+})
+public class StaffRoleAssignmentServiceIT {
+
+    private static final String USER_PRINC = "user";
+    private static final String GRP_PRINC = "group";
+    private static final Calendar TOMORROW = GregorianCalendar.from(ZonedDateTime.now().plusDays(1));
+
+    @Autowired
+    private String baseAddress;
+    @Mock
+    private AccessControlService aclService;
+    @Autowired
+    private RepositoryObjectFactory repoObjFactory;
+    @Autowired
+    private RepositoryObjectLoader repoObjLoader;
+    @Autowired
+    private InheritedAclFactory aclFactory;
+    @Autowired
+    private RepositoryPIDMinter pidMinter;
+    @Mock
+    private OperationsMessageSender operationsMessageSender;
+    @Autowired
+    private RepositoryObjectTreeIndexer treeIndexer;
+    @Captor
+    private ArgumentCaptor<List<PID>> pidListCaptor;
+
+    private AgentPrincipals agent;
+    private AccessGroupSet groups;
+
+    private StaffRoleAssignmentService roleService;
+
+    private ContentRootObject contentRoot;
+
+    @Before
+    public void init() throws Exception {
+        initMocks(this);
+        TestHelper.setContentBase(baseAddress);
+
+        groups = new AccessGroupSet(GRP_PRINC);
+        agent = new AgentPrincipals(USER_PRINC, groups);
+
+        roleService = new StaffRoleAssignmentService();
+        roleService.setAclFactory(aclFactory);
+        roleService.setAclService(aclService);
+        roleService.setOperationsMessageSender(operationsMessageSender);
+        roleService.setRepositoryObjectLoader(repoObjLoader);
+        roleService.setRepositoryObjectFactory(repoObjFactory);
+
+        PID contentRootPid = RepositoryPaths.getContentRootPid();
+        try {
+            repoObjFactory.createContentRootObject(
+                    contentRootPid.getRepositoryUri(), null);
+        } catch (FedoraException e) {
+            // Ignore failure as the content root will already exist after first test
+        }
+        contentRoot = repoObjLoader.getContentRootObject(contentRootPid);
+    }
+
+    @Test(expected = AccessRestrictionException.class)
+    public void testInsufficientPermissions() throws Exception {
+        PID pid = pidMinter.mintContentPid();
+
+        doThrow(new AccessRestrictionException()).when(aclService)
+            .assertHasAccess(anyString(), eq(pid), any(AccessGroupSet.class), eq(Permission.assignStaffRoles));
+
+        Set<RoleAssignment> assignments = new HashSet<>(asList(
+                new RoleAssignment(USER_PRINC, canAccess)));
+
+        roleService.updateRoles(agent, pid, assignments);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNoAgent() throws Exception {
+        PID pid = pidMinter.mintContentPid();
+        AdminUnit unit = repoObjFactory.createAdminUnit(pid, null);
+        contentRoot.addMember(unit);
+        treeIndexer.indexAll(baseAddress);
+
+        Set<RoleAssignment> assignments = new HashSet<>(asList(
+                new RoleAssignment(USER_PRINC, canAccess)));
+
+        roleService.updateRoles(null, pid, assignments);
+    }
+
+    @Test
+    public void testEmptyAssignmentSet() throws Exception {
+        PID pid = pidMinter.mintContentPid();
+        AdminUnit unit = repoObjFactory.createAdminUnit(pid, null);
+        contentRoot.addMember(unit);
+        treeIndexer.indexAll(baseAddress);
+
+        Set<RoleAssignment> assignments = new HashSet<>();
+
+        roleService.updateRoles(agent, pid, assignments);
+
+        AdminUnit updated = repoObjLoader.getAdminUnit(pid);
+
+        assertNoStaffRoles(updated);
+
+        assertMessageSent(pid);
+
+        String eventDetail = assertEventCreatedAndGetDetail(updated);
+        assertThat(eventDetail, containsString("No roles assigned"));
+    }
+
+    @Test
+    public void testEmptyAssignmentForObjectWithRoles() throws Exception {
+        PID pid = pidMinter.mintContentPid();
+        AdminUnit unit = repoObjFactory.createAdminUnit(pid,
+                new AclModelBuilder("Admin Unit Can Manage")
+                .addCanManage(GRP_PRINC)
+                .addEmbargoUntil(TOMORROW)
+                .model);
+        contentRoot.addMember(unit);
+        treeIndexer.indexAll(baseAddress);
+
+        Set<RoleAssignment> assignments = new HashSet<>();
+
+        roleService.updateRoles(agent, pid, assignments);
+
+        AdminUnit updated = repoObjLoader.getAdminUnit(pid);
+
+        assertNoStaffRoles(updated);
+        // Verify that non-staff role acl was not cleared
+        assertEmbargoPresent(updated);
+
+        assertMessageSent(pid);
+
+        String eventDetail = assertEventCreatedAndGetDetail(updated);
+        assertThat(eventDetail, containsString("No roles assigned"));
+    }
+
+    @Test
+    public void testSetUnitOwnerForAdminUnit() throws Exception {
+        PID pid = pidMinter.mintContentPid();
+        AdminUnit unit = repoObjFactory.createAdminUnit(pid, null);
+        contentRoot.addMember(unit);
+        treeIndexer.indexAll(baseAddress);
+
+        Set<RoleAssignment> assignments = new HashSet<>(asList(
+                new RoleAssignment(USER_PRINC, unitOwner)));
+
+        roleService.updateRoles(agent, pid, assignments);
+
+        AdminUnit updated = repoObjLoader.getAdminUnit(pid);
+
+        assertHasAssignment(USER_PRINC, unitOwner, updated);
+
+        assertMessageSent(pid);
+
+        String eventDetail = assertEventCreatedAndGetDetail(updated);
+        assertThat(eventDetail, containsString(unitOwner.name() + ": " + USER_PRINC));
+    }
+
+    @Test(expected = InvalidAssignmentException.class)
+    public void testSetUnitOwnerForCollection() throws Exception {
+        PID pid = pidMinter.mintContentPid();
+        AdminUnit unit = repoObjFactory.createAdminUnit(null);
+        contentRoot.addMember(unit);
+        CollectionObject coll = repoObjFactory.createCollectionObject(pid, null);
+        unit.addMember(coll);
+        treeIndexer.indexAll(baseAddress);
+
+        Set<RoleAssignment> assignments = new HashSet<>(asList(
+                new RoleAssignment(USER_PRINC, unitOwner)));
+
+        roleService.updateRoles(agent, pid, assignments);
+    }
+
+    @Test(expected = InvalidAssignmentException.class)
+    public void testSetCanManageForFolder() throws Exception {
+        PID pid = pidMinter.mintContentPid();
+        AdminUnit unit = repoObjFactory.createAdminUnit(null);
+        contentRoot.addMember(unit);
+        CollectionObject coll = repoObjFactory.createCollectionObject(null);
+        unit.addMember(coll);
+        FolderObject folder = repoObjFactory.createFolderObject(pid, null);
+        coll.addMember(folder);
+        treeIndexer.indexAll(baseAddress);
+
+        Set<RoleAssignment> assignments = new HashSet<>(asList(
+                new RoleAssignment(USER_PRINC, canManage)));
+
+        roleService.updateRoles(agent, pid, assignments);
+    }
+
+    @Test(expected = InvalidAssignmentException.class)
+    public void testSetCanManageForWork() throws Exception {
+        PID pid = pidMinter.mintContentPid();
+        AdminUnit unit = repoObjFactory.createAdminUnit(null);
+        contentRoot.addMember(unit);
+        CollectionObject coll = repoObjFactory.createCollectionObject(null);
+        unit.addMember(coll);
+        WorkObject work = repoObjFactory.createWorkObject(pid, null);
+        coll.addMember(work);
+        treeIndexer.indexAll(baseAddress);
+
+        Set<RoleAssignment> assignments = new HashSet<>(asList(
+                new RoleAssignment(USER_PRINC, canManage)));
+
+        roleService.updateRoles(agent, pid, assignments);
+    }
+
+    @Test
+    public void testOverrideRoleAssignments() throws Exception {
+        PID pid = pidMinter.mintContentPid();
+        AdminUnit unit = repoObjFactory.createAdminUnit(pid,
+                new AclModelBuilder("Admin Unit Replace")
+                .addCanManage(GRP_PRINC)
+                .model);
+        contentRoot.addMember(unit);
+        treeIndexer.indexAll(baseAddress);
+
+        Set<RoleAssignment> assignments = new HashSet<>(asList(
+                new RoleAssignment(USER_PRINC, canManage)));
+
+        roleService.updateRoles(agent, pid, assignments);
+
+        AdminUnit updated = repoObjLoader.getAdminUnit(pid);
+
+        assertHasAssignment(USER_PRINC, canManage, updated);
+        assertNoAssignment(GRP_PRINC, canManage, updated);
+
+        assertMessageSent(pid);
+
+        String eventDetail = assertEventCreatedAndGetDetail(updated);
+        assertThat(eventDetail, containsString(canManage.name() + ": " + USER_PRINC));
+    }
+
+    @Test
+    public void testPrincipalWithMultipleRoles() throws Exception {
+        PID pid = pidMinter.mintContentPid();
+        AdminUnit unit = repoObjFactory.createAdminUnit(null);
+        contentRoot.addMember(unit);
+        CollectionObject coll = repoObjFactory.createCollectionObject(pid, null);
+        unit.addMember(coll);
+        treeIndexer.indexAll(baseAddress);
+
+        Set<RoleAssignment> assignments = new HashSet<>(asList(
+                new RoleAssignment(USER_PRINC, canManage),
+                new RoleAssignment(USER_PRINC, canAccess)));
+
+        roleService.updateRoles(agent, pid, assignments);
+
+        CollectionObject updated = repoObjLoader.getCollectionObject(pid);
+
+        assertHasAssignment(USER_PRINC, canManage, updated);
+        assertHasAssignment(USER_PRINC, canAccess, updated);
+
+        assertMessageSent(pid);
+
+        String eventDetail = assertEventCreatedAndGetDetail(updated);
+        assertThat(eventDetail, containsString(canManage.name() + ": " + USER_PRINC));
+        assertThat(eventDetail, containsString(canAccess.name() + ": " + USER_PRINC));
+    }
+
+    @Test
+    public void testRoleWithMultiplePrincipals() throws Exception {
+        PID pid = pidMinter.mintContentPid();
+        AdminUnit unit = repoObjFactory.createAdminUnit(null);
+        contentRoot.addMember(unit);
+        CollectionObject coll = repoObjFactory.createCollectionObject(pid, null);
+        unit.addMember(coll);
+        treeIndexer.indexAll(baseAddress);
+
+        Set<RoleAssignment> assignments = new HashSet<>(asList(
+                new RoleAssignment(USER_PRINC, canManage),
+                new RoleAssignment(GRP_PRINC, canManage)));
+
+        roleService.updateRoles(agent, pid, assignments);
+
+        CollectionObject updated = repoObjLoader.getCollectionObject(pid);
+
+        assertHasAssignment(USER_PRINC, canManage, updated);
+        assertHasAssignment(GRP_PRINC, canManage, updated);
+
+        assertMessageSent(pid);
+
+        String eventDetail = assertEventCreatedAndGetDetail(updated);
+        assertThat(eventDetail, containsString(
+                canManage.name() + ": " + GRP_PRINC + ", " + USER_PRINC));
+    }
+
+    @Test
+    public void testWithInheritedRole() throws Exception {
+        PID pid = pidMinter.mintContentPid();
+        AdminUnit unit = repoObjFactory.createAdminUnit(
+                new AclModelBuilder("Admin Unit With Owner")
+                .addUnitOwner(USER_PRINC)
+                .addCanManage("another")
+                .model);
+        contentRoot.addMember(unit);
+        CollectionObject coll = repoObjFactory.createCollectionObject(pid, null);
+        unit.addMember(coll);
+        treeIndexer.indexAll(baseAddress);
+
+        Set<RoleAssignment> assignments = new HashSet<>(asList(
+                new RoleAssignment(GRP_PRINC, canManage)));
+
+        roleService.updateRoles(agent, pid, assignments);
+
+        CollectionObject updated = repoObjLoader.getCollectionObject(pid);
+
+        assertHasAssignment(GRP_PRINC, canManage, updated);
+        // Inherited unit owner should not appear on the child
+        assertNoAssignment(USER_PRINC, unitOwner, updated);
+
+        assertMessageSent(pid);
+
+        // Inherited and local roles should be logged
+        String eventDetail = assertEventCreatedAndGetDetail(updated);
+        assertThat(eventDetail, containsString(
+                canManage.name() + ": another, " + GRP_PRINC));
+        assertThat(eventDetail, containsString(
+                unitOwner.name() + ": " + USER_PRINC));
+    }
+
+    @Test
+    public void testWithPatronRoles() throws Exception {
+        PID pid = pidMinter.mintContentPid();
+        AdminUnit unit = repoObjFactory.createAdminUnit(null);
+        contentRoot.addMember(unit);
+        CollectionObject coll = repoObjFactory.createCollectionObject(pid,
+                new AclModelBuilder("Collection with patrons")
+                .addCanViewOriginals(authenticated.name())
+                .model);
+        unit.addMember(coll);
+        treeIndexer.indexAll(baseAddress);
+
+        Set<RoleAssignment> assignments = new HashSet<>(asList(
+                new RoleAssignment(GRP_PRINC, canManage)));
+
+        roleService.updateRoles(agent, pid, assignments);
+
+        CollectionObject updated = repoObjLoader.getCollectionObject(pid);
+
+        assertHasAssignment(GRP_PRINC, canManage, updated);
+        // Ensure that existing patron role was not impacted
+        assertHasAssignment(authenticated.name(), canViewOriginals, updated);
+
+        assertMessageSent(pid);
+
+        String eventDetail = assertEventCreatedAndGetDetail(updated);
+        assertThat(eventDetail, containsString(
+                canManage.name() + ": " + GRP_PRINC));
+        // Must not contain the patron assignment
+        assertThat(eventDetail, not(containsString(authenticated.name())));
+    }
+
+    private void assertNoStaffRoles(ContentObject obj) {
+        List<UserRole> staffRoles = UserRole.getStaffRoles();
+
+        Resource resc = obj.getResource();
+        StmtIterator it = resc.listProperties();
+        while (it.hasNext()) {
+            Statement stmt = it.next();
+            UserRole role = UserRole.getRoleByProperty(stmt.getPredicate().getURI());
+            if (role != null) {
+                assertFalse("No staff roles should be set, but " + role + " present",
+                        staffRoles.contains(role));
+            }
+        }
+    }
+
+    private void assertHasAssignment(String princ, UserRole role, ContentObject obj) {
+        Resource resc = obj.getResource();
+        assertTrue("Expected role " + role.name() + " was not assigned for " + princ,
+                resc.hasProperty(role.getProperty(), princ));
+    }
+
+    private void assertNoAssignment(String princ, UserRole role, ContentObject obj) {
+        Resource resc = obj.getResource();
+        assertFalse("Unexpected role " + role.name() + " was assigned for " + princ,
+                resc.hasProperty(role.getProperty(), princ));
+    }
+
+    private void assertMessageSent(PID pid) {
+        verify(operationsMessageSender).sendOperationMessage(
+                eq(USER_PRINC), eq(CDRActions.EDIT_ACCESS_CONTROL), pidListCaptor.capture());
+        assertTrue(pidListCaptor.getValue().contains(pid));
+    }
+
+    private String assertEventCreatedAndGetDetail(ContentObject repoObj) {
+        Model eventsModel = repoObj.getPremisLog().getEventsModel();
+        Resource objResc = eventsModel.getResource(repoObj.getPid().getRepositoryPath());
+        Resource eventResc = objResc.getPropertyResourceValue(Premis.hasEvent);
+        assertTrue("Event type was not set",
+                eventResc.hasProperty(Premis.hasEventType, Premis.PolicyAssignment));
+        Resource agentResc = eventResc.getPropertyResourceValue(Premis.hasEventRelatedAgentImplementor);
+        assertTrue("Event agent was not set",
+                agentResc.hasLiteral(Premis.hasAgentName, USER_NAMESPACE + USER_PRINC));
+        String eventDetail = eventResc.getProperty(Premis.hasEventDetail).getString();
+        assertThat(eventDetail, containsString("Staff roles for item set to:"));
+        return eventDetail;
+    }
+
+    private void assertEmbargoPresent(ContentObject obj) {
+        Resource resc = obj.getResource();
+        assertTrue("Embargo was not present", resc.hasProperty(CdrAcl.embargoUntil));
+    }
+}

--- a/persistence/src/test/resources/spring-test/cdr-client-container.xml
+++ b/persistence/src/test/resources/spring-test/cdr-client-container.xml
@@ -159,4 +159,9 @@
     <bean id="objectPathFactory" class="org.mockito.Mockito" factory-method="mock">
         <constructor-arg value="edu.unc.lib.dl.search.solr.service.ObjectPathFactory" />
     </bean>
+    
+    <bean id="treeIndexer" class="edu.unc.lib.dl.test.RepositoryObjectTreeIndexer">
+        <constructor-arg ref="queryModel" />
+        <constructor-arg ref="fcrepoClient" />
+    </bean>
 </beans>

--- a/persistence/src/test/resources/spring-test/staff-role-service-container.xml
+++ b/persistence/src/test/resources/spring-test/staff-role-service-container.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+
+    <context:property-placeholder />
+    
+    <bean id="contentPathFactory" class="edu.unc.lib.dl.fedora.ContentPathFactory"
+            init-method="init">
+        <property name="cacheMaxSize" value="200" />
+        <property name="cacheTimeToLive" value="2000" />
+        <property name="queryService" ref="sparqlQueryService" />
+    </bean>
+    
+    <bean id="objectAclFactory" class="edu.unc.lib.dl.acl.fcrepo4.ObjectAclFactory"
+            init-method="init">
+        <property name="cacheMaxSize" value="0" />
+        <property name="cacheTimeToLive" value="0" />
+        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
+    </bean>
+    
+    <bean id="objectPermissionEvaluator" class="edu.unc.lib.dl.acl.fcrepo4.ObjectPermissionEvaluator">
+        <property name="aclFactory" ref="objectAclFactory" />
+    </bean>
+    
+    <bean id="inheritedAclFactory" class="edu.unc.lib.dl.acl.fcrepo4.InheritedAclFactory">
+        <property name="objectAclFactory" ref="objectAclFactory" />
+        <property name="pathFactory" ref="contentPathFactory" />
+        <property name="objectPermissionEvaluator" ref="objectPermissionEvaluator" />
+    </bean>
+</beans>

--- a/security/src/main/java/edu/unc/lib/dl/acl/util/RoleAssignment.java
+++ b/security/src/main/java/edu/unc/lib/dl/acl/util/RoleAssignment.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.acl.util;
+
+/**
+ * Object representing the assignment of a single role to a single principal
+ *
+ * @author bbpennel
+ *
+ */
+public class RoleAssignment {
+    private String principal;
+    private UserRole role;
+
+    public RoleAssignment() {
+    }
+
+    public RoleAssignment(String principal, String role) {
+        this(principal, UserRole.valueOf(role));
+    }
+
+    public RoleAssignment(String principal, UserRole role) {
+        setPrincipal(principal);
+        setRole(role);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof UserRole)) {
+            return false;
+        }
+        RoleAssignment other = (RoleAssignment) obj;
+        return other.principal.equals(principal) && other.role.equals(role);
+    }
+
+    /**
+     * @return the principal
+     */
+    public String getPrincipal() {
+        return principal;
+    }
+
+    /**
+     * @param principal the principal to set
+     */
+    public void setPrincipal(String principal) {
+        this.principal = principal;
+    }
+
+    /**
+     * @return the role
+     */
+    public UserRole getRole() {
+        return role;
+    }
+
+    /**
+     * @param role the role to set
+     */
+    public void setRole(UserRole role) {
+        this.role = role;
+    }
+}

--- a/security/src/main/java/edu/unc/lib/dl/acl/util/UserRole.java
+++ b/security/src/main/java/edu/unc/lib/dl/acl/util/UserRole.java
@@ -34,6 +34,7 @@ import static edu.unc.lib.dl.acl.util.Permission.viewHidden;
 import static edu.unc.lib.dl.acl.util.Permission.viewMetadata;
 import static edu.unc.lib.dl.acl.util.Permission.viewOriginal;
 import static java.util.stream.Collectors.toSet;
+import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -41,8 +42,11 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import org.apache.jena.rdf.model.Property;
 
 import edu.unc.lib.dl.rdf.CdrAcl;
 
@@ -88,13 +92,18 @@ public enum UserRole {
     private URI uri;
     private String predicate;
     private String propertyString;
+    private Property property;
     private Set<Permission> permissions;
     private Set<String> permissionNames;
     private Boolean isStaffRole;
 
+    private static List<UserRole> staffRoles;
+    private static List<UserRole> patronRoles;
+
     UserRole(String predicate, boolean isStaffRole, Permission... perms) {
         this.predicate = predicate;
         this.propertyString = CdrAcl.getURI() + predicate;
+        this.property = createProperty(propertyString);
         this.uri = URI.create(propertyString);
         this.isStaffRole = isStaffRole;
         this.permissions = new HashSet<>(Arrays.asList(perms));
@@ -159,10 +168,14 @@ public enum UserRole {
      *
      * @return
      */
-    public static Set<UserRole> getStaffRoles() {
-        return Arrays.stream(UserRole.values())
-            .filter(p -> p.isStaffRole != null && p.isStaffRole)
-            .collect(Collectors.toSet());
+    public static List<UserRole> getStaffRoles() {
+        if (staffRoles == null) {
+            staffRoles = Arrays.stream(UserRole.values())
+                    .filter(p -> p.isStaffRole != null && p.isStaffRole)
+                    .sorted()
+                    .collect(Collectors.toList());
+        }
+        return staffRoles;
     }
 
     /**
@@ -170,10 +183,14 @@ public enum UserRole {
      *
      * @return
      */
-    public static Set<UserRole> getPatronRoles() {
-        return Arrays.stream(UserRole.values())
-            .filter(p -> p.isStaffRole != null && !p.isStaffRole)
-            .collect(Collectors.toSet());
+    public static List<UserRole> getPatronRoles() {
+        if (patronRoles == null) {
+            patronRoles = Arrays.stream(UserRole.values())
+                    .filter(p -> p.isStaffRole != null && !p.isStaffRole)
+                    .sorted()
+                    .collect(Collectors.toList());
+        }
+        return patronRoles;
     }
 
     /**
@@ -199,6 +216,13 @@ public enum UserRole {
      */
     public String getPropertyString() {
         return this.propertyString;
+    }
+
+    /**
+     * @return the property
+     */
+    public Property getProperty() {
+        return property;
     }
 
     public URI getURI() {

--- a/services-camel/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel/src/main/webapp/WEB-INF/service-context.xml
@@ -99,7 +99,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="${cache.objectAcls.maxSize}" />
         <property name="cacheTimeToLive" value="${cache.objectAcls.timeToLive}" />
-        <property name="queryService" ref="sparqlQueryService" />
+        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
     </bean>
     
     <bean id="objectPermissionEvaluator" class="edu.unc.lib.dl.acl.fcrepo4.ObjectPermissionEvaluator">

--- a/services-camel/src/test/resources/solr-indexing-it-context.xml
+++ b/services-camel/src/test/resources/solr-indexing-it-context.xml
@@ -36,7 +36,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="100" />
         <property name="cacheTimeToLive" value="100" />
-        <property name="queryService" ref="sparqlQueryService" />
+        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
     </bean>
     
     <bean id="objectPermissionEvaluator" class="edu.unc.lib.dl.acl.fcrepo4.ObjectPermissionEvaluator">

--- a/services/src/main/webapp/WEB-INF/access-fedora-context.xml
+++ b/services/src/main/webapp/WEB-INF/access-fedora-context.xml
@@ -28,7 +28,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="${cache.objectAcls.maxSize}" />
         <property name="cacheTimeToLive" value="${cache.objectAcls.timeToLive}" />
-        <property name="queryService" ref="sparqlQueryService" />
+        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
     </bean>
     
     <bean id="objectPermissionEvaluator" class="edu.unc.lib.dl.acl.fcrepo4.ObjectPermissionEvaluator">

--- a/services/src/test/resources/access-control-retrieval-it-servlet.xml
+++ b/services/src/test/resources/access-control-retrieval-it-servlet.xml
@@ -67,7 +67,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="500" />
         <property name="cacheTimeToLive" value="5000" />
-        <property name="queryService" ref="sparqlQueryService" />
+        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
     </bean>
     
      <bean id="objectPermissionEvaluator" class="edu.unc.lib.dl.acl.fcrepo4.ObjectPermissionEvaluator">


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2444
* Adds service for committing role assignments to fedora
* Refactors ObjectAclFactory to retrieve ACLs from fedora directly rather than triple store, in order to allow for immediate retrieval without waiting for reindexing
* Updates server managed triple sanitization to match the requirements of fedora 5
* Updates to UserRole class to calculate common values once.