### PR TITLE
BXC-2443 - API For Updating Staff Roles

### DIFF
--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/FedoraTransaction.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/FedoraTransaction.java
@@ -72,16 +72,12 @@ public class FedoraTransaction {
         txManager.keepTransactionAlive(txUri);
     }
 
+    public void cancelAndIgnore() {
+        cancelTx();
+    }
+
     public void cancel(Throwable t) {
-        if (isSub) {
-            // sub tx defers to root
-            FedoraTransaction.rootTxThread.get().cancel();
-        } else if (!isCancelled) {
-            isCancelled = true;
-            txUriThread.remove();
-            rootTxThread.remove();
-            txManager.cancelTransaction(txUri);
-        }
+        cancelTx();
         if (t instanceof TransactionCancelledException) {
             throw (TransactionCancelledException) t;
         } else {
@@ -93,4 +89,15 @@ public class FedoraTransaction {
         cancel(null);
     }
 
+    private void cancelTx() {
+        if (isSub) {
+            // sub tx defers to root
+            FedoraTransaction.rootTxThread.get().cancel();
+        } else if (!isCancelled) {
+            isCancelled = true;
+            txUriThread.remove();
+            rootTxThread.remove();
+            txManager.cancelTransaction(txUri);
+        }
+    }
 }

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectLoader.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectLoader.java
@@ -135,7 +135,12 @@ public class RepositoryObjectLoader {
         try {
             return repositoryObjCache.get(pid);
         } catch (UncheckedExecutionException | ExecutionException e) {
-            throw (FedoraException) e.getCause();
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            } else {
+                throw new FedoraException((Exception) cause);
+            }
         }
     }
 

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/acl/StaffRoleAssignmentServiceIT.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/acl/StaffRoleAssignmentServiceIT.java
@@ -75,6 +75,7 @@ import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
 import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
 import edu.unc.lib.dl.fcrepo4.RepositoryPIDMinter;
 import edu.unc.lib.dl.fcrepo4.RepositoryPaths;
+import edu.unc.lib.dl.fcrepo4.TransactionManager;
 import edu.unc.lib.dl.fcrepo4.WorkObject;
 import edu.unc.lib.dl.fedora.FedoraException;
 import edu.unc.lib.dl.fedora.PID;
@@ -120,6 +121,8 @@ public class StaffRoleAssignmentServiceIT {
     private OperationsMessageSender operationsMessageSender;
     @Autowired
     private RepositoryObjectTreeIndexer treeIndexer;
+    @Autowired
+    private TransactionManager txManager;
     @Captor
     private ArgumentCaptor<List<PID>> pidListCaptor;
 
@@ -144,6 +147,7 @@ public class StaffRoleAssignmentServiceIT {
         roleService.setOperationsMessageSender(operationsMessageSender);
         roleService.setRepositoryObjectLoader(repoObjLoader);
         roleService.setRepositoryObjectFactory(repoObjFactory);
+        roleService.setTransactionManager(txManager);
 
         PID contentRootPid = RepositoryPaths.getContentRootPid();
         try {

--- a/security/src/main/java/edu/unc/lib/dl/acl/util/RoleAssignment.java
+++ b/security/src/main/java/edu/unc/lib/dl/acl/util/RoleAssignment.java
@@ -73,4 +73,12 @@ public class RoleAssignment {
     public void setRole(UserRole role) {
         this.role = role;
     }
+
+    /* (non-Javadoc)
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "RoleAssignment [principal=" + principal + ", role=" + role + "]";
+    }
 }

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/modify/UpdateAccessControlController.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/modify/UpdateAccessControlController.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.cdr.services.rest.modify;
+
+import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.USER_NAMESPACE;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import edu.unc.lib.dl.acl.exception.AccessRestrictionException;
+import edu.unc.lib.dl.acl.exception.InvalidAssignmentException;
+import edu.unc.lib.dl.acl.util.AgentPrincipals;
+import edu.unc.lib.dl.acl.util.RoleAssignment;
+import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fedora.AuthorizationException;
+import edu.unc.lib.dl.fedora.NotFoundException;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.persist.services.acl.StaffRoleAssignmentService;
+
+/**
+ * API endpoint for setting access control for objects
+ *
+ * @author bbpennel
+ *
+ */
+@Controller
+public class UpdateAccessControlController {
+    private static final Logger log = LoggerFactory.getLogger(UpdateAccessControlController.class);
+
+    @Autowired
+    private StaffRoleAssignmentService staffRoleService;
+
+    @PutMapping(value = "/edit/acl/staff/{id}", produces = "application/json; charset=UTF-8")
+    @ResponseBody
+    public ResponseEntity<Object> updateStaffRoles(@PathVariable("id") String id,
+            @RequestBody List<RoleAssignment> assignments) {
+
+        PID pid = PIDs.get(id);
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("action", "editStaffRoles");
+        result.put("pid", pid.getId());
+
+        for (RoleAssignment ra: assignments) {
+            // Catch any incomplete role assignments
+            if (isEmpty(ra.getPrincipal()) || ra.getRole() == null) {
+                result.put("error", "Invalid role assignments");
+                return new ResponseEntity<>(result, HttpStatus.BAD_REQUEST);
+            }
+            // Expand user principal assignments into uris
+            addUserPrefixIfMissing(ra);
+        }
+
+        try {
+            AgentPrincipals agent = AgentPrincipals.createFromThread();
+            String jobId = staffRoleService.updateRoles(agent, pid, assignments);
+            result.put("job", jobId);
+        } catch (InvalidAssignmentException e) {
+            result.put("error", e.getMessage());
+            log.debug("Invalid role assignment to {}", pid.getId(), e);
+            return new ResponseEntity<>(result, HttpStatus.BAD_REQUEST);
+        } catch (AccessRestrictionException | AuthorizationException e) {
+            result.put("error", e.getMessage());
+            return new ResponseEntity<>(result, HttpStatus.FORBIDDEN);
+        } catch (NotFoundException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        } catch (Exception e) {
+            result.put("error", "An unexpected problem occurred while setting staff roles");
+            log.error("Failed to update staff roles for {}", pid.getId(), e);
+            return new ResponseEntity<>(result, HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        result.put("timestamp", System.currentTimeMillis());
+        return new ResponseEntity<>(result, HttpStatus.OK);
+    }
+
+    private void addUserPrefixIfMissing(RoleAssignment ra) {
+        String principal = ra.getPrincipal();
+        if (!principal.matches("\\w+:.+")) {
+            ra.setPrincipal(USER_NAMESPACE + principal);
+        }
+    }
+}

--- a/services/src/main/webapp/WEB-INF/access-fedora-context.xml
+++ b/services/src/main/webapp/WEB-INF/access-fedora-context.xml
@@ -45,6 +45,19 @@
         <property name="objectPermissionEvaluator" ref="objectPermissionEvaluator" />
         <property name="pathFactory" ref="contentPathFactory" />
     </bean>
+    
+    <bean id="uncachedObjectAclFactory" class="edu.unc.lib.dl.acl.fcrepo4.ObjectAclFactory"
+            init-method="init">
+        <property name="cacheMaxSize" value="0" />
+        <property name="cacheTimeToLive" value="0" />
+        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
+    </bean>
+    
+    <bean id="uncachedInheritedAclFactory" class="edu.unc.lib.dl.acl.fcrepo4.InheritedAclFactory">
+        <property name="objectAclFactory" ref="uncachedObjectAclFactory" />
+        <property name="pathFactory" ref="contentPathFactory" />
+        <property name="objectPermissionEvaluator" ref="objectPermissionEvaluator" />
+    </bean>
 
     <bean name="aclPropertiesURI" class="java.lang.System"
             factory-method="getProperty">

--- a/services/src/main/webapp/WEB-INF/service-context.xml
+++ b/services/src/main/webapp/WEB-INF/service-context.xml
@@ -357,6 +357,14 @@
         <property name="derivativeService" ref="derivativeService" />
     </bean>
     
+    <bean id="staffRoleAssignmentService" class="edu.unc.lib.dl.persist.services.acl.StaffRoleAssignmentService">
+        <property name="aclService" ref="aclService" />
+        <property name="aclFactory" ref="uncachedInheritedAclFactory" />
+        <property name="operationsMessageSender" ref="operationsMessageSender" />
+        <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+    </bean>
+    
     <bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
         <property name="staticMethod" value="edu.unc.lib.dl.ui.util.SerializationUtil.injectSettings"/>
         <property name="arguments">

--- a/services/src/main/webapp/WEB-INF/service-context.xml
+++ b/services/src/main/webapp/WEB-INF/service-context.xml
@@ -363,6 +363,7 @@
         <property name="operationsMessageSender" ref="operationsMessageSender" />
         <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="transactionManager" ref="transactionManager" />
     </bean>
     
     <bean class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/UpdateStaffRolesIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/UpdateStaffRolesIT.java
@@ -1,0 +1,319 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.cdr.services.rest.modify;
+
+import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.USER_NAMESPACE;
+import static edu.unc.lib.dl.acl.util.Permission.assignStaffRoles;
+import static edu.unc.lib.dl.acl.util.UserRole.canAccess;
+import static edu.unc.lib.dl.acl.util.UserRole.canManage;
+import static edu.unc.lib.dl.acl.util.UserRole.unitOwner;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.core.MediaType;
+
+import org.apache.jena.rdf.model.Resource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.unc.lib.dl.acl.exception.AccessRestrictionException;
+import edu.unc.lib.dl.acl.util.AccessGroupSet;
+import edu.unc.lib.dl.acl.util.GroupsThreadStore;
+import edu.unc.lib.dl.acl.util.RoleAssignment;
+import edu.unc.lib.dl.acl.util.UserRole;
+import edu.unc.lib.dl.fcrepo4.AdminUnit;
+import edu.unc.lib.dl.fcrepo4.CollectionObject;
+import edu.unc.lib.dl.fcrepo4.ContentObject;
+import edu.unc.lib.dl.fcrepo4.ContentRootObject;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
+import edu.unc.lib.dl.fcrepo4.RepositoryPIDMinter;
+import edu.unc.lib.dl.fcrepo4.RepositoryPaths;
+import edu.unc.lib.dl.fedora.FedoraException;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.test.AclModelBuilder;
+
+/**
+ * @author bbpennel
+ */
+@ContextHierarchy({
+    @ContextConfiguration("/spring-test/test-fedora-container.xml"),
+    @ContextConfiguration("/spring-test/cdr-client-container.xml"),
+    @ContextConfiguration("/update-access-it-servlet.xml")
+})
+public class UpdateStaffRolesIT extends AbstractAPIIT {
+    private static final String USER_NAME = "adminuser";
+    private static final String USER_URI = USER_NAMESPACE + USER_NAME;
+    private static final String USER_GROUPS = "edu:lib:admin_grp";
+
+    @Autowired
+    private RepositoryObjectFactory repoObjFactory;
+    @Autowired
+    private RepositoryObjectLoader repoObjLoader;
+    @Autowired
+    private RepositoryPIDMinter pidMinter;
+
+    private ContentRootObject contentRoot;
+
+    @Before
+    public void setup() throws Exception {
+        AccessGroupSet testPrincipals = new AccessGroupSet(USER_GROUPS);
+
+        GroupsThreadStore.storeUsername(USER_NAME);
+        GroupsThreadStore.storeGroups(testPrincipals);
+
+        PID contentRootPid = RepositoryPaths.getContentRootPid();
+        try {
+            repoObjFactory.createContentRootObject(
+                    contentRootPid.getRepositoryUri(), null);
+        } catch (FedoraException e) {
+            // Ignore failure as the content root will already exist after first test
+        }
+        contentRoot = repoObjLoader.getContentRootObject(contentRootPid);
+    }
+
+    @After
+    public void teardown() throws Exception {
+        GroupsThreadStore.clearStore();
+    }
+
+    @Test
+    public void testInsufficientPermissions() throws Exception {
+        AdminUnit unit = repoObjFactory.createAdminUnit(null);
+        contentRoot.addMember(unit);
+        PID pid = unit.getPid();
+
+        doThrow(new AccessRestrictionException()).when(aclService)
+                .assertHasAccess(anyString(), eq(pid), any(AccessGroupSet.class), eq(assignStaffRoles));
+
+        List<RoleAssignment> assignments = asList(
+                new RoleAssignment(USER_NAME, canAccess));
+
+        MvcResult result = mvc.perform(put("/edit/acl/staff/" + pid.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(makeRequestBody(assignments)))
+                .andExpect(status().isForbidden())
+            .andReturn();
+
+        Map<String, Object> respMap = getMapFromResponse(result);
+        assertEquals(pid.getId(), respMap.get("pid"));
+        assertEquals("editStaffRoles", respMap.get("action"));
+        assertTrue(respMap.containsKey("error"));
+    }
+
+    @Test
+    public void testInvalidUnitOwnerAssignment() throws Exception {
+        AdminUnit unit = repoObjFactory.createAdminUnit(null);
+        contentRoot.addMember(unit);
+        CollectionObject coll = repoObjFactory.createCollectionObject(null);
+        unit.addMember(coll);
+        PID pid = coll.getPid();
+
+        List<RoleAssignment> assignments = asList(
+                new RoleAssignment(USER_NAME, unitOwner));
+
+        MvcResult result = mvc.perform(put("/edit/acl/staff/" + pid.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(makeRequestBody(assignments)))
+                .andExpect(status().isBadRequest())
+            .andReturn();
+
+        Map<String, Object> respMap = getMapFromResponse(result);
+        assertEquals(pid.getId(), respMap.get("pid"));
+        assertEquals("editStaffRoles", respMap.get("action"));
+        assertTrue(((String) respMap.get("error")).contains("Cannot assign unit owner"));
+    }
+
+    @Test
+    public void testTargetDoesNotExist() throws Exception {
+        PID pid = pidMinter.mintContentPid();
+
+        List<RoleAssignment> assignments = asList(
+                new RoleAssignment(USER_NAME, canManage));
+
+        mvc.perform(put("/edit/acl/staff/" + pid.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(makeRequestBody(assignments)))
+                .andExpect(status().isNotFound())
+            .andReturn();
+    }
+
+    @Test
+    public void testNoAssignments() throws Exception {
+        PID pid = pidMinter.mintContentPid();
+        AdminUnit unit = repoObjFactory.createAdminUnit(pid,
+                new AclModelBuilder("Admin Unit Can Manage")
+                .addCanManage(USER_NAME)
+                .model);
+        contentRoot.addMember(unit);
+
+        List<RoleAssignment> assignments = Collections.emptyList();
+
+        MvcResult result = mvc.perform(put("/edit/acl/staff/" + pid.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(makeRequestBody(assignments)))
+                .andExpect(status().isOk())
+            .andReturn();
+
+        Map<String, Object> respMap = getMapFromResponse(result);
+        assertEquals(pid.getId(), respMap.get("pid"));
+        assertEquals("editStaffRoles", respMap.get("action"));
+
+        AdminUnit updated = repoObjLoader.getAdminUnit(pid);
+        // Verify that existing assignment was cleared
+        assertNoAssignment(USER_NAME, canManage, updated);
+    }
+
+    @Test
+    public void testInvalidRolesBody() throws Exception {
+        AdminUnit unit = repoObjFactory.createAdminUnit(null);
+        contentRoot.addMember(unit);
+        PID pid = unit.getPid();
+
+        String assignments = "[ { \"no\" : \"thanks\" } ]";
+
+        mvc.perform(put("/edit/acl/staff/" + pid.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(assignments.getBytes()))
+                .andExpect(status().isBadRequest())
+            .andReturn();
+    }
+
+    @Test
+    public void testNoRolesBody() throws Exception {
+        AdminUnit unit = repoObjFactory.createAdminUnit(null);
+        contentRoot.addMember(unit);
+        PID pid = unit.getPid();
+
+        mvc.perform(put("/edit/acl/staff/" + pid.getId())
+                .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+            .andReturn();
+    }
+
+    @Test
+    public void testNoPrincipal() throws Exception {
+        AdminUnit unit = repoObjFactory.createAdminUnit(null);
+        contentRoot.addMember(unit);
+        PID pid = unit.getPid();
+
+        List<RoleAssignment> assignments = asList(
+                new RoleAssignment("", canManage));
+
+        mvc.perform(put("/edit/acl/staff/" + pid.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(makeRequestBody(assignments)))
+                .andExpect(status().isBadRequest())
+            .andReturn();
+    }
+
+    @Test
+    public void testInvalidRole() throws Exception {
+        AdminUnit unit = repoObjFactory.createAdminUnit(null);
+        contentRoot.addMember(unit);
+        PID pid = unit.getPid();
+
+        String assignments = "[ { \"principal\" : \"user\", \"role\" : \"dunno\" } ]";
+
+        mvc.perform(put("/edit/acl/staff/" + pid.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(assignments.getBytes()))
+                .andExpect(status().isBadRequest())
+            .andReturn();
+    }
+
+    @Test
+    public void testAssignRoles() throws Exception {
+        AdminUnit unit = repoObjFactory.createAdminUnit(null);
+        contentRoot.addMember(unit);
+        PID pid = unit.getPid();
+
+        List<RoleAssignment> assignments = asList(
+                new RoleAssignment(USER_NAME, canManage));
+
+        MvcResult result = mvc.perform(put("/edit/acl/staff/" + pid.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(makeRequestBody(assignments)))
+                .andExpect(status().isOk())
+            .andReturn();
+
+        Map<String, Object> respMap = getMapFromResponse(result);
+        assertEquals(pid.getId(), respMap.get("pid"));
+        assertEquals("editStaffRoles", respMap.get("action"));
+
+        AdminUnit updated = repoObjLoader.getAdminUnit(pid);
+        assertHasAssignment(USER_URI, canManage, updated);
+    }
+
+    @Test
+    public void testAssignGroup() throws Exception {
+        AdminUnit unit = repoObjFactory.createAdminUnit(null);
+        contentRoot.addMember(unit);
+        PID pid = unit.getPid();
+
+        List<RoleAssignment> assignments = asList(
+                new RoleAssignment(USER_GROUPS, canManage));
+
+        MvcResult result = mvc.perform(put("/edit/acl/staff/" + pid.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(makeRequestBody(assignments)))
+                .andExpect(status().isOk())
+            .andReturn();
+
+        Map<String, Object> respMap = getMapFromResponse(result);
+        assertEquals(pid.getId(), respMap.get("pid"));
+        assertEquals("editStaffRoles", respMap.get("action"));
+
+        AdminUnit updated = repoObjLoader.getAdminUnit(pid);
+        assertHasAssignment(USER_GROUPS, canManage, updated);
+    }
+
+    private byte[] makeRequestBody(List<RoleAssignment> assignments) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsBytes(assignments);
+    }
+
+    private void assertHasAssignment(String princ, UserRole role, ContentObject obj) {
+        Resource resc = obj.getResource();
+        assertTrue("Expected role " + role.name() + " was not assigned for " + princ,
+                resc.hasProperty(role.getProperty(), princ));
+    }
+
+    private void assertNoAssignment(String princ, UserRole role, ContentObject obj) {
+        Resource resc = obj.getResource();
+        assertFalse("Unexpected role " + role.name() + " was assigned for " + princ,
+                resc.hasProperty(role.getProperty(), princ));
+    }
+}

--- a/services/src/test/resources/update-access-it-servlet.xml
+++ b/services/src/test/resources/update-access-it-servlet.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2008 The University of North Carolina at Chapel Hill
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:mvc="http://www.springframework.org/schema/mvc"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context 
+        http://www.springframework.org/schema/context/spring-context-3.0.xsd
+        http://www.springframework.org/schema/mvc
+        http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd">
+        
+    <mvc:annotation-driven/>
+
+    <context:component-scan resource-pattern="**/UpdateAccessControlController*" base-package="edu.unc.lib.dl.cdr.services.rest.modify"/>
+    
+    <bean id="staffRoleAssignmentService" class="edu.unc.lib.dl.persist.services.acl.StaffRoleAssignmentService">
+        <property name="aclService" ref="aclService" />
+        <property name="aclFactory" ref="inheritedAclFactory" />
+        <property name="operationsMessageSender" ref="operationsMessageSender" />
+        <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+    </bean>
+    
+    <bean id="aclService" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.acl.fcrepo4.AccessControlServiceImpl" />
+    </bean>
+    
+    <bean id="contentPathFactory" class="edu.unc.lib.dl.fedora.ContentPathFactory"
+            init-method="init">
+        <property name="cacheMaxSize" value="200" />
+        <property name="cacheTimeToLive" value="200" />
+        <property name="queryService" ref="sparqlQueryService" />
+    </bean>
+    
+    <bean id="objectAclFactory" class="edu.unc.lib.dl.acl.fcrepo4.ObjectAclFactory"
+            init-method="init">
+        <property name="cacheMaxSize" value="0" />
+        <property name="cacheTimeToLive" value="0" />
+        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
+    </bean>
+    
+    <bean id="objectPermissionEvaluator" class="edu.unc.lib.dl.acl.fcrepo4.ObjectPermissionEvaluator">
+        <property name="aclFactory" ref="objectAclFactory" />
+    </bean>
+    
+    <bean id="inheritedAclFactory" class="edu.unc.lib.dl.acl.fcrepo4.InheritedAclFactory">
+        <property name="objectAclFactory" ref="objectAclFactory" />
+        <property name="pathFactory" ref="contentPathFactory" />
+        <property name="objectPermissionEvaluator" ref="objectPermissionEvaluator" />
+    </bean>
+</beans>

--- a/services/src/test/resources/update-access-it-servlet.xml
+++ b/services/src/test/resources/update-access-it-servlet.xml
@@ -38,6 +38,7 @@
         <property name="operationsMessageSender" ref="operationsMessageSender" />
         <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="transactionManager" ref="transactionManager" />
     </bean>
     
     <bean id="aclService" class="org.mockito.Mockito" factory-method="mock">


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2443
* Adds API endpoint for setting staff roles
* Updates staff role setting to take place in a transaction with its premis log updates
* Add method for cancelling transactions that doesn't throw an exception, so that we can throw the original unwrapped exception.