### PR TITLE
BXC-2453 - Return id of the object a role is assigned to

### DIFF
--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/acl/fcrepo4/AclFactory.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/acl/fcrepo4/AclFactory.java
@@ -16,10 +16,12 @@
 package edu.unc.lib.dl.acl.fcrepo4;
 
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import edu.unc.lib.dl.acl.service.PatronAccess;
+import edu.unc.lib.dl.acl.util.RoleAssignment;
 import edu.unc.lib.dl.fedora.PID;
 
 /**
@@ -38,6 +40,22 @@ public interface AclFactory {
      * @return
      */
     public Map<String, Set<String>> getPrincipalRoles(PID pid);
+
+    /**
+     * Retrieve staff role assignments for the specified object
+     *
+     * @param pid identifier for the object
+     * @return List of RoleAssignments for all the staff roles assigned to the object
+     */
+    public List<RoleAssignment> getStaffRoleAssignments(PID pid);
+
+    /**
+     * Retrieve patron role assignments for the specified object
+     *
+     * @param pid identifier for the object
+     * @return List of RoleAssignments for all the patron roles assigned to the object
+     */
+    public List<RoleAssignment> getPatronRoleAssignments(PID pid);
 
     /**
      * Returns the patron access setting for this object if specified, otherwise

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/acl/fcrepo4/InheritedAclFactoryTest.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/acl/fcrepo4/InheritedAclFactoryTest.java
@@ -16,12 +16,14 @@
 package edu.unc.lib.dl.acl.fcrepo4;
 
 import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.AUTHENTICATED_PRINC;
+import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.PUBLIC_PRINC;
 import static edu.unc.lib.dl.acl.util.UserRole.canAccess;
 import static edu.unc.lib.dl.acl.util.UserRole.canManage;
 import static edu.unc.lib.dl.acl.util.UserRole.canViewMetadata;
 import static edu.unc.lib.dl.acl.util.UserRole.canViewOriginals;
 import static edu.unc.lib.dl.acl.util.UserRole.unitOwner;
 import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.CONTENT_ROOT_ID;
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -50,6 +52,7 @@ import org.mockito.Mock;
 
 import edu.unc.lib.dl.acl.service.PatronAccess;
 import edu.unc.lib.dl.acl.util.Permission;
+import edu.unc.lib.dl.acl.util.RoleAssignment;
 import edu.unc.lib.dl.acl.util.UserRole;
 import edu.unc.lib.dl.fcrepo4.PIDs;
 import edu.unc.lib.dl.fedora.ContentPathFactory;
@@ -57,7 +60,6 @@ import edu.unc.lib.dl.fedora.PID;
 
 public class InheritedAclFactoryTest {
 
-    private static final String PATRON_PRINC = "everyone";
     private static final String MANAGE_PRINC = "manageGrp";
     private static final String OWNER_PRINC = "owner";
 
@@ -105,7 +107,7 @@ public class InheritedAclFactoryTest {
         Map<String, Set<String>> princRoles = aclFactory.getPrincipalRoles(pid);
 
         assertPrincipalHasRoles("Assumed patron assignment should be present for unit",
-                princRoles, PATRON_PRINC, canViewOriginals);
+                princRoles, PUBLIC_PRINC, canViewOriginals);
     }
 
     @Test
@@ -187,11 +189,11 @@ public class InheritedAclFactoryTest {
 
         Map<String, Set<String>> collPrincRoles = new HashMap<>();
         addPrincipalRoles(collPrincRoles, MANAGE_PRINC, canManage);
-        addPrincipalRoles(collPrincRoles, PATRON_PRINC, canViewMetadata);
+        addPrincipalRoles(collPrincRoles, PUBLIC_PRINC, canViewMetadata);
         when(objectAclFactory.getPrincipalRoles(eq(collPid)))
                 .thenReturn(collPrincRoles);
 
-        when(objectPermissionEvaluator.hasPatronAccess(eq(pid), eq(PATRON_PRINC), any(Permission.class)))
+        when(objectPermissionEvaluator.hasPatronAccess(eq(pid), eq(PUBLIC_PRINC), any(Permission.class)))
                 .thenReturn(true);
 
         Map<String, Set<String>> princRoles = aclFactory.getPrincipalRoles(pid);
@@ -201,7 +203,7 @@ public class InheritedAclFactoryTest {
         assertPrincipalHasRoles("Incorrect inherited roles for the manger principal",
                 princRoles, MANAGE_PRINC, canManage);
         assertPrincipalHasRoles("Incorrect inherited patron roles for the patron principal",
-                princRoles, PATRON_PRINC, canViewMetadata);
+                princRoles, PUBLIC_PRINC, canViewMetadata);
         assertPrincipalHasRoles("Owner principal role not set correctly",
                 princRoles, OWNER_PRINC, unitOwner);
     }
@@ -212,7 +214,7 @@ public class InheritedAclFactoryTest {
         PID collPid = addPidToAncestors();
 
         Map<String, Set<String>> collPrincRoles = new HashMap<>();
-        addPrincipalRoles(collPrincRoles, PATRON_PRINC, canViewMetadata);
+        addPrincipalRoles(collPrincRoles, PUBLIC_PRINC, canViewMetadata);
         when(objectAclFactory.getPrincipalRoles(eq(collPid)))
                 .thenReturn(collPrincRoles);
 
@@ -230,13 +232,13 @@ public class InheritedAclFactoryTest {
         PID collectionPid = addPidToAncestors();
 
         Map<String, Set<String>> collPrincRoles = new HashMap<>();
-        addPrincipalRoles(collPrincRoles, PATRON_PRINC, canViewMetadata);
+        addPrincipalRoles(collPrincRoles, PUBLIC_PRINC, canViewMetadata);
         addPrincipalRoles(collPrincRoles, AUTHENTICATED_PRINC, canViewOriginals);
         when(objectAclFactory.getPrincipalRoles(eq(collectionPid)))
                 .thenReturn(collPrincRoles);
 
         // revoke one patron but not the other
-        when(objectPermissionEvaluator.hasPatronAccess(eq(pid), eq(PATRON_PRINC), any(Permission.class)))
+        when(objectPermissionEvaluator.hasPatronAccess(eq(pid), eq(PUBLIC_PRINC), any(Permission.class)))
                 .thenReturn(false);
         when(objectPermissionEvaluator.hasPatronAccess(eq(pid), eq(AUTHENTICATED_PRINC), any(Permission.class)))
                 .thenReturn(true);
@@ -254,20 +256,20 @@ public class InheritedAclFactoryTest {
         PID collectionPid = addPidToAncestors();
 
         Map<String, Set<String>> collPrincRoles = new HashMap<>();
-        addPrincipalRoles(collPrincRoles, PATRON_PRINC, canViewOriginals);
+        addPrincipalRoles(collPrincRoles, PUBLIC_PRINC, canViewOriginals);
         when(objectAclFactory.getPrincipalRoles(eq(collectionPid)))
                 .thenReturn(collPrincRoles);
 
-        when(objectPermissionEvaluator.hasPatronAccess(eq(pid), eq(PATRON_PRINC), eq(Permission.viewMetadata)))
+        when(objectPermissionEvaluator.hasPatronAccess(eq(pid), eq(PUBLIC_PRINC), eq(Permission.viewMetadata)))
                 .thenReturn(true);
-        when(objectPermissionEvaluator.hasPatronAccess(eq(pid), eq(PATRON_PRINC), eq(Permission.viewOriginal)))
+        when(objectPermissionEvaluator.hasPatronAccess(eq(pid), eq(PUBLIC_PRINC), eq(Permission.viewOriginal)))
                 .thenReturn(false);
 
         Map<String, Set<String>> princRoles = aclFactory.getPrincipalRoles(pid);
 
         assertEquals("Only one patron principal should be present", 1, princRoles.size());
         assertPrincipalHasRoles("Patron should be reduced to have view metadata role",
-                princRoles, PATRON_PRINC, canViewMetadata);
+                princRoles, PUBLIC_PRINC, canViewMetadata);
     }
 
     @Test
@@ -281,7 +283,7 @@ public class InheritedAclFactoryTest {
                 .thenReturn(unitPrincRoles);
 
         Map<String, Set<String>> collPrincRoles = new HashMap<>();
-        addPrincipalRoles(collPrincRoles, PATRON_PRINC, canViewMetadata);
+        addPrincipalRoles(collPrincRoles, PUBLIC_PRINC, canViewMetadata);
         when(objectAclFactory.getPrincipalRoles(eq(pid)))
                 .thenReturn(collPrincRoles);
 
@@ -425,6 +427,152 @@ public class InheritedAclFactoryTest {
         assertEquals(0, princRoles.size());
     }
 
+    @Test
+    public void testGetStaffRoleAssignmentsDirectAssignment() {
+        PID unitPid = makePid();
+
+        mockObjStaffRoleAssignments(new RoleAssignment(OWNER_PRINC, UserRole.unitOwner, unitPid));
+
+        List<RoleAssignment> assignments = aclFactory.getStaffRoleAssignments(unitPid);
+        assertEquals(1, assignments.size());
+
+        RoleAssignment assignment = getAssignmentByPidAndRole(assignments, unitPid, UserRole.unitOwner);
+        assertEquals(OWNER_PRINC, assignment.getPrincipal());
+    }
+
+    @Test
+    public void testGetStaffRoleAssignmentsInheritedAndDirectAssignment() {
+        PID unitPid = addPidToAncestors();
+        PID collPid = makePid();
+
+        mockObjStaffRoleAssignments(new RoleAssignment(OWNER_PRINC, UserRole.unitOwner, unitPid));
+        mockObjStaffRoleAssignments(new RoleAssignment(MANAGE_PRINC, UserRole.canManage, collPid));
+
+        List<RoleAssignment> assignments = aclFactory.getStaffRoleAssignments(collPid);
+        assertEquals(2, assignments.size());
+
+        RoleAssignment assignment1 = getAssignmentByPidAndRole(assignments, unitPid, UserRole.unitOwner);
+        assertEquals(OWNER_PRINC, assignment1.getPrincipal());
+
+        RoleAssignment assignment2 = getAssignmentByPidAndRole(assignments, collPid, UserRole.canManage);
+        assertEquals(MANAGE_PRINC, assignment2.getPrincipal());
+    }
+
+    @Test
+    public void testGetStaffRoleAssignmentsInheritedOnFolder() {
+        PID unitPid = addPidToAncestors();
+        PID collPid = addPidToAncestors();
+        PID folderPid = makePid();
+
+        mockObjStaffRoleAssignments(new RoleAssignment(OWNER_PRINC, UserRole.unitOwner, unitPid));
+        mockObjStaffRoleAssignments(new RoleAssignment(MANAGE_PRINC, UserRole.canManage, collPid));
+
+        List<RoleAssignment> assignments = aclFactory.getStaffRoleAssignments(folderPid);
+        assertEquals(2, assignments.size());
+
+        RoleAssignment assignment1 = getAssignmentByPidAndRole(assignments, unitPid, UserRole.unitOwner);
+        assertEquals(OWNER_PRINC, assignment1.getPrincipal());
+
+        RoleAssignment assignment2 = getAssignmentByPidAndRole(assignments, collPid, UserRole.canManage);
+        assertEquals(MANAGE_PRINC, assignment2.getPrincipal());
+    }
+
+    @Test
+    public void testGetStaffRoleAssignmentsNoAssignments() {
+        addPidToAncestors();
+        PID collPid = makePid();
+
+        List<RoleAssignment> assignments = aclFactory.getStaffRoleAssignments(collPid);
+        assertTrue(assignments.isEmpty());
+    }
+
+    @Test
+    public void testGetStaffRoleAssignmentsMultipleInheritedAndDirectAssignment() {
+        PID unitPid = addPidToAncestors();
+        PID collPid = makePid();
+
+        mockObjStaffRoleAssignments(
+                new RoleAssignment(OWNER_PRINC, UserRole.unitOwner, unitPid),
+                new RoleAssignment(MANAGE_PRINC, UserRole.canAccess, unitPid));
+        mockObjStaffRoleAssignments(new RoleAssignment(MANAGE_PRINC, UserRole.canManage, collPid));
+
+        List<RoleAssignment> assignments = aclFactory.getStaffRoleAssignments(collPid);
+        assertEquals(3, assignments.size());
+
+        RoleAssignment assignment1 = getAssignmentByPidAndRole(assignments, unitPid, UserRole.unitOwner);
+        assertEquals(OWNER_PRINC, assignment1.getPrincipal());
+
+        RoleAssignment assignment2 = getAssignmentByPidAndRole(assignments, unitPid, UserRole.canAccess);
+        assertEquals(MANAGE_PRINC, assignment2.getPrincipal());
+
+        RoleAssignment assignment3 = getAssignmentByPidAndRole(assignments, collPid, UserRole.canManage);
+        assertEquals(MANAGE_PRINC, assignment3.getPrincipal());
+    }
+
+    @Test
+    public void testGetPatronRoleAssignmentsDirect() {
+        addPidToAncestors();
+        PID collPid = makePid();
+
+        mockObjPatronRoleAssignments(new RoleAssignment(PUBLIC_PRINC, UserRole.canViewOriginals, collPid));
+
+        List<RoleAssignment> assignments = aclFactory.getPatronRoleAssignments(collPid);
+        assertEquals(1, assignments.size());
+
+        RoleAssignment assignment = getAssignmentByPidAndRole(assignments, collPid, UserRole.canViewOriginals);
+        assertEquals(PUBLIC_PRINC, assignment.getPrincipal());
+    }
+
+    @Test
+    public void testGetPatronRoleAssignmentsInherited() {
+        addPidToAncestors();
+        PID collPid = addPidToAncestors();
+        PID folderPid = makePid();
+
+        mockObjPatronRoleAssignments(new RoleAssignment(PUBLIC_PRINC, UserRole.canViewAccessCopies, collPid),
+                new RoleAssignment(AUTHENTICATED_PRINC, UserRole.canViewOriginals, collPid));
+        mockObjPatronRoleAssignments(new RoleAssignment(PUBLIC_PRINC, UserRole.canViewMetadata, folderPid));
+
+        List<RoleAssignment> assignments = aclFactory.getPatronRoleAssignments(folderPid);
+        assertEquals(3, assignments.size());
+
+        RoleAssignment assignment1 = getAssignmentByPidAndRole(assignments, collPid, UserRole.canViewAccessCopies);
+        assertEquals(PUBLIC_PRINC, assignment1.getPrincipal());
+        RoleAssignment assignment2 = getAssignmentByPidAndRole(assignments, collPid, UserRole.canViewOriginals);
+        assertEquals(AUTHENTICATED_PRINC, assignment2.getPrincipal());
+
+        RoleAssignment assignment3 = getAssignmentByPidAndRole(assignments, folderPid, UserRole.canViewMetadata);
+        assertEquals(PUBLIC_PRINC, assignment3.getPrincipal());
+    }
+
+    @Test
+    public void testGetPatronRoleAssignmentsNone() {
+        addPidToAncestors();
+        PID collPid = makePid();
+
+        List<RoleAssignment> assignments = aclFactory.getPatronRoleAssignments(collPid);
+        assertTrue("No assignments should be returned", assignments.isEmpty());
+    }
+
+    private RoleAssignment getAssignmentByPidAndRole(List<RoleAssignment> assignments, PID pid, UserRole role) {
+        return assignments.stream()
+                .filter(a -> a.getRole().equals(role) && a.getAssignedTo().equals(pid.getId()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private void mockObjStaffRoleAssignments(RoleAssignment... assignments) {
+        PID pid = PIDs.get(assignments[0].getAssignedTo());
+        List<RoleAssignment> assigned = asList(assignments);
+        when(objectAclFactory.getStaffRoleAssignments(pid)).thenReturn(assigned);
+    }
+
+    private void mockObjPatronRoleAssignments(RoleAssignment... assignments) {
+        PID pid = PIDs.get(assignments[0].getAssignedTo());
+        List<RoleAssignment> assigned = asList(assignments);
+        when(objectAclFactory.getPatronRoleAssignments(pid)).thenReturn(assigned);
+    }
+
     private static void assertPrincipalHasRoles(String message, Map<String, Set<String>> princRoles,
             String principal, UserRole... expectedRoles) {
         try {
@@ -448,8 +596,12 @@ public class InheritedAclFactoryTest {
     }
 
     private PID addPidToAncestors() {
-        PID ancestor = PIDs.get(UUID.randomUUID().toString());
+        PID ancestor = makePid();
         ancestorPids.add(ancestor);
         return ancestor;
+    }
+
+    private PID makePid() {
+        return PIDs.get(UUID.randomUUID().toString());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,10 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.copyrightYear>2008</project.copyrightYear>
         
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <javax.annotation.version>1.3.2</javax.annotation.version>
+        
         <cdr.version>4.0-SNAPSHOT</cdr.version>
         <fcrepo.version>3.8.0</fcrepo.version>
         <fcrepo4.version>5.0.2</fcrepo4.version>
@@ -265,8 +269,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler.plugin.version}</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -678,6 +682,12 @@
                         <artifactId>httpclient</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            
+            <dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>${javax.annotation.version}</version>
             </dependency>
             
             <dependency>

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -55,5 +55,10 @@
             <groupId>edu.unc.lib.cdr</groupId>
             <artifactId>metadata</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/security/src/main/java/edu/unc/lib/dl/acl/util/RoleAssignment.java
+++ b/security/src/main/java/edu/unc/lib/dl/acl/util/RoleAssignment.java
@@ -15,6 +15,8 @@
  */
 package edu.unc.lib.dl.acl.util;
 
+import edu.unc.lib.dl.fedora.PID;
+
 /**
  * Object representing the assignment of a single role to a single principal
  *
@@ -24,34 +26,27 @@ package edu.unc.lib.dl.acl.util;
 public class RoleAssignment {
     private String principal;
     private UserRole role;
+    private String assignedTo;
 
     public RoleAssignment() {
     }
 
-    public RoleAssignment(String principal, String role) {
-        this(principal, UserRole.valueOf(role));
-    }
-
-    public RoleAssignment(String principal, UserRole role) {
+    public RoleAssignment(String principal, UserRole role, PID pid) {
         setPrincipal(principal);
         setRole(role);
+        setAssignedTo(pid.getId());
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#hashCode()
-     */
     @Override
     public int hashCode() {
         final int prime = 31;
         int result = 1;
+        result = prime * result + ((assignedTo == null) ? 0 : assignedTo.hashCode());
         result = prime * result + ((principal == null) ? 0 : principal.hashCode());
         result = prime * result + ((role == null) ? 0 : role.hashCode());
         return result;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -64,6 +59,13 @@ public class RoleAssignment {
             return false;
         }
         RoleAssignment other = (RoleAssignment) obj;
+        if (assignedTo == null) {
+            if (other.assignedTo != null) {
+                return false;
+            }
+        } else if (!assignedTo.equals(other.assignedTo)) {
+            return false;
+        }
         if (principal == null) {
             if (other.principal != null) {
                 return false;
@@ -102,11 +104,22 @@ public class RoleAssignment {
         this.role = role;
     }
 
-    /* (non-Javadoc)
-     * @see java.lang.Object#toString()
+    /**
+     * @return get the id of the object this role is assigned to
      */
+    public String getAssignedTo() {
+        return assignedTo;
+    }
+
+    /**
+     * @param assignedTo the id of the object this role is assigned to
+     */
+    public void setAssignedTo(String assignedTo) {
+        this.assignedTo = assignedTo;
+    }
+
     @Override
     public String toString() {
-        return "RoleAssignment [principal=" + principal + ", role=" + role + "]";
+        return "RoleAssignment [principal=" + principal + ", role=" + role + ", assignedTo=" + assignedTo + "]";
     }
 }

--- a/security/src/main/java/edu/unc/lib/dl/acl/util/RoleAssignment.java
+++ b/security/src/main/java/edu/unc/lib/dl/acl/util/RoleAssignment.java
@@ -31,9 +31,13 @@ public class RoleAssignment {
     public RoleAssignment() {
     }
 
-    public RoleAssignment(String principal, UserRole role, PID pid) {
+    public RoleAssignment(String principal, UserRole role) {
         setPrincipal(principal);
         setRole(role);
+    }
+
+    public RoleAssignment(String principal, UserRole role, PID pid) {
+        this(principal, role);
         setAssignedTo(pid.getId());
     }
 

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/UpdateStaffRolesIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/UpdateStaffRolesIT.java
@@ -117,7 +117,7 @@ public class UpdateStaffRolesIT extends AbstractAPIIT {
                 .assertHasAccess(anyString(), eq(pid), any(AccessGroupSet.class), eq(assignStaffRoles));
 
         List<RoleAssignment> assignments = asList(
-                new RoleAssignment(USER_NAME, canAccess));
+                new RoleAssignment(USER_NAME, canAccess, pid));
 
         MvcResult result = mvc.perform(put("/edit/acl/staff/" + pid.getId())
                 .contentType(MediaType.APPLICATION_JSON)
@@ -159,7 +159,7 @@ public class UpdateStaffRolesIT extends AbstractAPIIT {
         PID pid = pidMinter.mintContentPid();
 
         List<RoleAssignment> assignments = asList(
-                new RoleAssignment(USER_NAME, canManage));
+                new RoleAssignment(USER_NAME, canManage, pid));
 
         mvc.perform(put("/edit/acl/staff/" + pid.getId())
                 .contentType(MediaType.APPLICATION_JSON)
@@ -259,7 +259,7 @@ public class UpdateStaffRolesIT extends AbstractAPIIT {
         PID pid = unit.getPid();
 
         List<RoleAssignment> assignments = asList(
-                new RoleAssignment(USER_NAME, canManage));
+                new RoleAssignment(USER_NAME, canManage, pid));
 
         MvcResult result = mvc.perform(put("/edit/acl/staff/" + pid.getId())
                 .contentType(MediaType.APPLICATION_JSON)

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/UpdateStaffRolesIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/UpdateStaffRolesIT.java
@@ -298,6 +298,24 @@ public class UpdateStaffRolesIT extends AbstractAPIIT {
         assertHasAssignment(USER_GROUPS, canManage, updated);
     }
 
+    @Test
+    public void testAssignMultipleRolesToSamePrincipal() throws Exception {
+        AdminUnit unit = repoObjFactory.createAdminUnit(null);
+        contentRoot.addMember(unit);
+        PID pid = unit.getPid();
+
+        List<RoleAssignment> assignments = asList(
+                new RoleAssignment(USER_NAME, canManage),
+                new RoleAssignment(USER_NAME, canAccess)
+                );
+
+        mvc.perform(put("/edit/acl/staff/" + pid.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(makeRequestBody(assignments)))
+                .andExpect(status().isBadRequest())
+            .andReturn();
+    }
+
     private void assertHasAssignment(String princ, UserRole role, ContentObject obj) {
         Resource resc = obj.getResource();
         assertTrue("Expected role " + role.name() + " was not assigned for " + princ,

--- a/static/js/admin/vue-permissions-editor/src/components/modalEditor.vue
+++ b/static/js/admin/vue-permissions-editor/src/components/modalEditor.vue
@@ -26,7 +26,7 @@
                                     <staff-roles v-else
                                                  :alert-handler="alertHandler"
                                                  :changes-check="checkForUnsavedChanges"
-                                                 :container-name="parentContainerName"
+                                                 :object-path="metadata.objectPath"
                                                  :container-type="metadata.type"
                                                  :uuid="metadata.id"
                                                  :title="metadata.title"

--- a/static/js/admin/vue-permissions-editor/src/components/staffRoles.vue
+++ b/static/js/admin/vue-permissions-editor/src/components/staffRoles.vue
@@ -15,7 +15,7 @@
             <tr v-for="inherited_staff_permission in current_staff_roles.inherited">
                 <td>{{ inherited_staff_permission.principal }}</td>
                 <td>{{ inherited_staff_permission.role }}</td>
-                <td>{{ containerName }}</td>
+                <td>{{ assignedToName(inherited_staff_permission) }}</td>
             </tr>
             </tbody>
         </table>
@@ -111,7 +111,7 @@
         props: {
             alertHandler: Object,
             changesCheck: Boolean,
-            containerName: String,
+            objectPath: Array,
             containerType: String,
             title: String,
             uuid: String
@@ -328,6 +328,19 @@
                 });
 
                 this.unsaved_changes = unsaved_staff_roles || this.deleted_users.length > 0 || this.user_name !== '';
+            },
+            
+            assignedToName(role_assignment) {
+                if (this.objectPath === undefined || this.objectPath === null) {
+                    return "--";
+                }
+                let assignedTo = role_assignment.assignedTo;
+                for (const pathObj of this.objectPath) {
+                    if (pathObj.pid === assignedTo) {
+                        return pathObj.name;
+                    }
+                }
+                return "--";
             }
         },
 

--- a/static/js/admin/vue-permissions-editor/tests/unit/staffRoles.spec.js
+++ b/static/js/admin/vue-permissions-editor/tests/unit/staffRoles.spec.js
@@ -24,7 +24,15 @@ describe('staffRoles.vue', () => {
                 alertHandler: {
                     alertHandler: jest.fn() // This method lives outside of the Vue app
                 },
-                containerName: 'Test Unit',
+                objectPath: [{ 
+                    pid: 'collections',
+                    name: 'Content Collections Root',
+                    container: true
+                }, {
+                    pid: '73bc003c-9603-4cd9-8a65-93a22520ef6a',
+                    name: 'Test Stuff',
+                    container: true
+                }],
                 containerType: 'AdminUnit',
                 title: 'Test Stuff',
                 uuid: '73bc003c-9603-4cd9-8a65-93a22520ef6a'
@@ -118,6 +126,59 @@ describe('staffRoles.vue', () => {
             let cells = wrapper.findAll('.inherited-permissions td');
             expect(cells.at(0).text()).toEqual(response.inherited[0].principal);
             expect(cells.at(1).text()).toEqual(response.inherited[0].role);
+            done();
+        });
+    });
+    
+    it("displays names of containers that roles are assigned to in inherited table", (done) => {
+        wrapper = shallowMount(staffRoles, {
+            localVue,
+            propsData: {
+                alertHandler: {
+                    alertHandler: jest.fn() // This method lives outside of the Vue app
+                },
+                objectPath: [{ 
+                    pid: 'collections',
+                    name: 'Content Collections Root',
+                    container: true
+                }, {
+                    pid: '73bc003c-9603-4cd9-8a65-93a22520ef6a',
+                    name: 'Test Unit',
+                    container: true
+                }, {
+                    pid: 'f88ff51e-7e74-4e0e-9ab9-259444393aeb',
+                    name: 'Test Collecton',
+                    container: true
+                }, {
+                    pid: '4f2be243-ce9e-4f26-91fc-08f1b592734d',
+                    name: 'Some Subfolder',
+                    container: true
+                }],
+                containerType: 'Folder',
+                title: 'Some Subfolder',
+                uuid: '4f2be243-ce9e-4f26-91fc-08f1b592734d'
+            }
+        });
+        
+        const response = {
+            inherited:[{ principal: 'test_admin', role: 'unitOwner', assignedTo: '73bc003c-9603-4cd9-8a65-93a22520ef6a' },
+                { principal: 'test_manager', role: 'canManage', assignedTo: 'f88ff51e-7e74-4e0e-9ab9-259444393aeb' }],
+            assigned:[]
+        };
+        
+        moxios.stubRequest(`/services/api/acl/staff/${wrapper.vm.uuid}`, {
+            status: 200,
+            response: JSON.stringify(response)
+        });
+        
+        moxios.wait(() => {
+            let cells = wrapper.findAll('.inherited-permissions td');
+            expect(cells.at(0).text()).toEqual(response.inherited[0].principal);
+            expect(cells.at(1).text()).toEqual(response.inherited[0].role);
+            expect(cells.at(2).text()).toEqual('Test Unit');
+            expect(cells.at(3).text()).toEqual(response.inherited[1].principal);
+            expect(cells.at(4).text()).toEqual(response.inherited[1].role);
+            expect(cells.at(5).text()).toEqual('Test Collecton');
             done();
         });
     });


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2453

* Returns the PID of the object where a role+principal is being assigned.
* After discussion, decided to leave multiple role assignments for the same principal in staff permission response since they now indicate where they are assigned.
* Explicitly disallow assigning multiple roles to a principal on the same object in the API, so it agrees with the UI.
* Some updates to java version setting and including javax stuff that causes problems if being built on system with java 11 installed.