### PR TITLE
BXC-2442 - Retrieve patron access control info

### DIFF
--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/test/AclModelBuilder.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/test/AclModelBuilder.java
@@ -59,6 +59,10 @@ public class AclModelBuilder {
         return addProp(CdrAcl.canAccess, princ);
     }
 
+    public AclModelBuilder addCanViewMetadata(String princ) {
+        return addProp(CdrAcl.canViewMetadata, princ);
+    }
+
     public AclModelBuilder addCanViewOriginals(String princ) {
         return addProp(CdrAcl.canViewOriginals, princ);
     }
@@ -69,6 +73,11 @@ public class AclModelBuilder {
 
     public AclModelBuilder addEmbargoUntil(Calendar date) {
         resc.addLiteral(CdrAcl.embargoUntil, date);
+        return this;
+    }
+
+    public AclModelBuilder markForDeletion() {
+        resc.addLiteral(CdrAcl.markedForDeletion, true);
         return this;
     }
 

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/AccessControlRetrievalController.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/AccessControlRetrievalController.java
@@ -108,8 +108,13 @@ public class AccessControlRetrievalController {
         stripUserPrefix(inherited);
         stripUserPrefix(assigned);
 
-        result.put(INHERITED_ROLES, inherited);
-        result.put(ASSIGNED_ROLES, assigned);
+        Map<String, Object> inheritedInfo = new HashMap<>();
+        inheritedInfo.put(ROLES_KEY, inherited);
+        Map<String, Object> assignedInfo = new HashMap<>();
+        assignedInfo.put(ROLES_KEY, assigned);
+
+        result.put(INHERITED_ROLES, inheritedInfo);
+        result.put(ASSIGNED_ROLES, assignedInfo);
 
         return new ResponseEntity<>(result, HttpStatus.OK);
     }

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/modify/UpdateAccessControlController.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/modify/UpdateAccessControlController.java
@@ -61,7 +61,7 @@ public class UpdateAccessControlController {
     @PutMapping(value = "/edit/acl/staff/{id}", produces = "application/json; charset=UTF-8")
     @ResponseBody
     public ResponseEntity<Object> updateStaffRoles(@PathVariable("id") String id,
-            @RequestBody List<RoleAssignment> assignments) {
+            @RequestBody UpdateStaffRequest assignments) {
 
         PID pid = PIDs.get(id);
 
@@ -70,7 +70,7 @@ public class UpdateAccessControlController {
         result.put("pid", pid.getId());
 
         Set<String> alreadyAssignedPrincipals = new HashSet<>();
-        for (RoleAssignment ra: assignments) {
+        for (RoleAssignment ra: assignments.getRoles()) {
             // Catch any incomplete role assignments
             if (isEmpty(ra.getPrincipal()) || ra.getRole() == null) {
                 result.put("error", "Invalid role assignments");
@@ -89,7 +89,7 @@ public class UpdateAccessControlController {
 
         try {
             AgentPrincipals agent = AgentPrincipals.createFromThread();
-            String jobId = staffRoleService.updateRoles(agent, pid, assignments);
+            String jobId = staffRoleService.updateRoles(agent, pid, assignments.getRoles());
             result.put("job", jobId);
         } catch (InvalidAssignmentException e) {
             result.put("error", e.getMessage());
@@ -114,6 +114,18 @@ public class UpdateAccessControlController {
         String principal = ra.getPrincipal();
         if (!principal.matches("\\w+:.+")) {
             ra.setPrincipal(USER_NAMESPACE + principal);
+        }
+    }
+
+    public static class UpdateStaffRequest {
+        private List<RoleAssignment> roles;
+
+        public List<RoleAssignment> getRoles() {
+            return roles;
+        }
+
+        public void setRoles(List<RoleAssignment> roles) {
+            this.roles = roles;
         }
     }
 }

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/DatastreamRestControllerIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/DatastreamRestControllerIT.java
@@ -54,7 +54,6 @@ import edu.unc.lib.dl.acl.service.AccessControlService;
 import edu.unc.lib.dl.acl.util.AccessGroupSet;
 import edu.unc.lib.dl.cdr.services.rest.modify.AbstractAPIIT;
 import edu.unc.lib.dl.fcrepo4.FileObject;
-import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.model.DatastreamType;
 import edu.unc.lib.dl.ui.service.DerivativeContentService;
@@ -78,9 +77,6 @@ public class DatastreamRestControllerIT extends AbstractAPIIT {
 
     @Autowired
     private AccessControlService accessControlService;
-
-    @Autowired
-    private RepositoryObjectFactory repositoryObjectFactory;
 
     @Autowired
     private DerivativeContentService derivativeContentService;

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/RetrieveMODSIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/RetrieveMODSIT.java
@@ -33,7 +33,6 @@ import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.ContextHierarchy;
 import org.springframework.test.web.servlet.MvcResult;
@@ -41,7 +40,6 @@ import org.springframework.test.web.servlet.MvcResult;
 import edu.unc.lib.dl.acl.exception.AccessRestrictionException;
 import edu.unc.lib.dl.acl.util.AccessGroupSet;
 import edu.unc.lib.dl.cdr.services.rest.modify.AbstractAPIIT;
-import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
 import edu.unc.lib.dl.fcrepo4.WorkObject;
 import edu.unc.lib.dl.fedora.PID;
 
@@ -56,9 +54,6 @@ import edu.unc.lib.dl.fedora.PID;
     @ContextConfiguration("/retrieve-mods-it-servlet.xml")
 })
 public class RetrieveMODSIT extends AbstractAPIIT {
-
-    @Autowired
-    private RepositoryObjectFactory repositoryObjectFactory;
 
     @Test
     public void testRetrieveMODSFromWork() throws Exception {

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/RetrievePatronRolesIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/RetrievePatronRolesIT.java
@@ -1,0 +1,655 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.cdr.services.rest;
+
+import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.AUTHENTICATED_PRINC;
+import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.PUBLIC_PRINC;
+import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.USER_NAMESPACE;
+import static edu.unc.lib.dl.acl.util.UserRole.canViewMetadata;
+import static edu.unc.lib.dl.acl.util.UserRole.canViewOriginals;
+import static edu.unc.lib.dl.cdr.services.rest.AccessControlRetrievalController.ASSIGNED_ROLES;
+import static edu.unc.lib.dl.cdr.services.rest.AccessControlRetrievalController.INHERITED_ROLES;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.io.InputStream;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.activemq.util.ByteArrayInputStream;
+import org.apache.jena.rdf.model.Model;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.web.servlet.MvcResult;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import edu.unc.lib.dl.acl.util.AccessGroupSet;
+import edu.unc.lib.dl.acl.util.GroupsThreadStore;
+import edu.unc.lib.dl.acl.util.RoleAssignment;
+import edu.unc.lib.dl.acl.util.UserRole;
+import edu.unc.lib.dl.cdr.services.rest.modify.AbstractAPIIT;
+import edu.unc.lib.dl.fcrepo4.AdminUnit;
+import edu.unc.lib.dl.fcrepo4.CollectionObject;
+import edu.unc.lib.dl.fcrepo4.FileObject;
+import edu.unc.lib.dl.fcrepo4.FolderObject;
+import edu.unc.lib.dl.fcrepo4.WorkObject;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.test.AclModelBuilder;
+
+/**
+*
+* @author bbpennel
+*
+*/
+@ContextHierarchy({
+   @ContextConfiguration("/spring-test/test-fedora-container.xml"),
+   @ContextConfiguration("/spring-test/cdr-client-container.xml"),
+   @ContextConfiguration("/access-control-retrieval-it-servlet.xml")
+})
+public class RetrievePatronRolesIT extends AbstractAPIIT {
+    private static final String USER_PRINC = "user";
+    private static final String USER_NS_PRINC = USER_NAMESPACE + USER_PRINC;
+
+    private static final String origBodyString = "Original data";
+    private static final String origFilename = "original.txt";
+    private static final String origMimetype = "text/plain";
+
+    private AdminUnit adminUnit;
+    private CollectionObject collObj;
+
+
+    @Before
+    public void init_() throws Exception {
+        AccessGroupSet testPrincipals = new AccessGroupSet(PUBLIC_PRINC);
+        GroupsThreadStore.storeUsername(USER_PRINC);
+        GroupsThreadStore.storeGroups(testPrincipals);
+        setupContentRoot();
+    }
+
+    @After
+    public void teardown() throws Exception {
+        GroupsThreadStore.clearStore();
+    }
+
+    @Test
+    public void insufficientPermissions() throws Exception {
+        // Creating unit/coll with no permissions granted
+        AdminUnit unit = repositoryObjectFactory.createAdminUnit(null);
+        contentRoot.addMember(unit);
+        PID pid = pidMinter.mintContentPid();
+        CollectionObject coll = repositoryObjectFactory.createCollectionObject(pid, null);
+        unit.addMember(coll);
+
+        treeIndexer.indexAll(baseAddress);
+
+        mvc.perform(get("/acl/staff/" + pid.getId()))
+                .andExpect(status().isForbidden())
+                .andReturn();
+    }
+
+    @Test
+    public void objectNotFound() throws Exception {
+        PID pid = pidMinter.mintContentPid();
+
+        treeIndexer.indexAll(baseAddress);
+
+        mvc.perform(get("/acl/staff/" + pid.getId()))
+                .andExpect(status().isNotFound())
+                .andReturn();
+    }
+
+    @Test
+    public void getFromUnit() throws Exception {
+        createCollectionInUnit(null);
+
+        treeIndexer.indexAll(baseAddress);
+
+        mvc.perform(get("/acl/patron/" + adminUnit.getPid().getId()))
+                .andExpect(status().isBadRequest())
+                .andReturn();
+    }
+
+    @Test
+    public void getFromCollectionWithNoPatrons() throws Exception {
+        createCollectionInUnit(null);
+
+        treeIndexer.indexAll(baseAddress);
+
+        MvcResult mvcResult = mvc.perform(get("/acl/patron/" + collObj.getPid().getId()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Map<String, PatronAccessInfo> result = parseResponse(mvcResult);
+
+        PatronAccessInfo inherited = result.get(INHERITED_ROLES);
+        assertInfoEmpty(inherited);
+
+        PatronAccessInfo assigned = result.get(ASSIGNED_ROLES);
+        assertInfoEmpty(assigned);
+    }
+
+    @Test
+    public void getFromCollectionWithPatrons() throws Exception {
+        createCollectionInUnit(new AclModelBuilder("Collection")
+                .addCanViewMetadata(PUBLIC_PRINC)
+                .addCanViewOriginals(AUTHENTICATED_PRINC)
+                .model);
+
+        treeIndexer.indexAll(baseAddress);
+
+        MvcResult mvcResult = mvc.perform(get("/acl/patron/" + collObj.getPid().getId()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Map<String, PatronAccessInfo> result = parseResponse(mvcResult);
+        assertInfoEmpty(result.get(INHERITED_ROLES));
+
+        PatronAccessInfo assigned = result.get(ASSIGNED_ROLES);
+        assertEquals(2, assigned.getRoles().size());
+        assertHasRole(assigned, PUBLIC_PRINC, canViewMetadata);
+        assertHasRole(assigned, AUTHENTICATED_PRINC, canViewOriginals);
+        assertFalse(assigned.isDeleted());
+        assertNull(assigned.getEmbargo());
+    }
+
+    @Test
+    public void getFromCollectionWithPatronsInDeletedUnit() throws Exception {
+        createCollectionInUnit(
+                new AclModelBuilder("Collection")
+                    .addCanViewMetadata(PUBLIC_PRINC)
+                    .addCanViewOriginals(AUTHENTICATED_PRINC)
+                    .model,
+                new AclModelBuilder("Deleted Unit")
+                    .addUnitOwner(USER_NS_PRINC)
+                    .markForDeletion()
+                    .model);
+
+        treeIndexer.indexAll(baseAddress);
+
+        MvcResult mvcResult = mvc.perform(get("/acl/patron/" + collObj.getPid().getId()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Map<String, PatronAccessInfo> result = parseResponse(mvcResult);
+
+        PatronAccessInfo inherited = result.get(INHERITED_ROLES);
+        assertNull(inherited.getRoles());
+        assertTrue(inherited.isDeleted());
+        assertNull(inherited.getEmbargo());
+
+        PatronAccessInfo assigned = result.get(ASSIGNED_ROLES);
+        assertEquals(2, assigned.getRoles().size());
+        assertHasRole(assigned, PUBLIC_PRINC, canViewMetadata);
+        assertHasRole(assigned, AUTHENTICATED_PRINC, canViewOriginals);
+        assertFalse(assigned.isDeleted());
+        assertNull(assigned.getEmbargo());
+    }
+
+    @Test
+    public void getFromCollectionWithPatronsDeleted() throws Exception {
+        createCollectionInUnit(new AclModelBuilder("Collection")
+                .addCanViewMetadata(PUBLIC_PRINC)
+                .addCanViewOriginals(AUTHENTICATED_PRINC)
+                .markForDeletion()
+                .model);
+
+        treeIndexer.indexAll(baseAddress);
+
+        MvcResult mvcResult = mvc.perform(get("/acl/patron/" + collObj.getPid().getId()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Map<String, PatronAccessInfo> result = parseResponse(mvcResult);
+        assertInfoEmpty(result.get(INHERITED_ROLES));
+
+        PatronAccessInfo assigned = result.get(ASSIGNED_ROLES);
+        assertEquals(2, assigned.getRoles().size());
+        assertHasRole(assigned, PUBLIC_PRINC, canViewMetadata);
+        assertHasRole(assigned, AUTHENTICATED_PRINC, canViewOriginals);
+        assertTrue(assigned.isDeleted());
+        assertNull(assigned.getEmbargo());
+    }
+
+    @Test
+    public void getFromCollectionWithPatronsEmbargoed() throws Exception {
+        Calendar embargoUntil = getNextYear();
+        createCollectionInUnit(new AclModelBuilder("Collection")
+                .addCanViewMetadata(PUBLIC_PRINC)
+                .addCanViewOriginals(AUTHENTICATED_PRINC)
+                .addEmbargoUntil(embargoUntil)
+                .model);
+
+        treeIndexer.indexAll(baseAddress);
+
+        MvcResult mvcResult = mvc.perform(get("/acl/patron/" + collObj.getPid().getId()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Map<String, PatronAccessInfo> result = parseResponse(mvcResult);
+        assertInfoEmpty(result.get(INHERITED_ROLES));
+
+        PatronAccessInfo assigned = result.get(ASSIGNED_ROLES);
+        assertEquals(2, assigned.getRoles().size());
+        assertHasRole(assigned, PUBLIC_PRINC, canViewMetadata);
+        assertHasRole(assigned, AUTHENTICATED_PRINC, canViewOriginals);
+        assertFalse(assigned.isDeleted());
+        assertEquals(embargoUntil.getTime(), assigned.getEmbargo());
+    }
+
+    @Test
+    public void getFromFolderWithNoPatrons() throws Exception {
+        createCollectionInUnit(null);
+        FolderObject folder = repositoryObjectFactory.createFolderObject(null);
+        collObj.addMember(folder);
+
+        treeIndexer.indexAll(baseAddress);
+
+        MvcResult mvcResult = mvc.perform(get("/acl/patron/" + folder.getPid().getId()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Map<String, PatronAccessInfo> result = parseResponse(mvcResult);
+        assertInfoEmpty(result.get(INHERITED_ROLES));
+        assertInfoEmpty(result.get(ASSIGNED_ROLES));
+    }
+
+    @Test
+    public void getFromFolderWithAssignedPatronsNoInherited() throws Exception {
+        createCollectionInUnit(null);
+        FolderObject folder = repositoryObjectFactory.createFolderObject(
+                new AclModelBuilder("Folder with patrons")
+                    .addCanViewMetadata(PUBLIC_PRINC)
+                    .addCanViewOriginals(AUTHENTICATED_PRINC)
+                    .model);
+        collObj.addMember(folder);
+
+        treeIndexer.indexAll(baseAddress);
+
+        MvcResult mvcResult = mvc.perform(get("/acl/patron/" + folder.getPid().getId()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Map<String, PatronAccessInfo> result = parseResponse(mvcResult);
+        assertInfoEmpty(result.get(INHERITED_ROLES));
+
+        PatronAccessInfo assigned = result.get(ASSIGNED_ROLES);
+        assertEquals(2, assigned.getRoles().size());
+        assertHasRole(assigned, PUBLIC_PRINC, canViewMetadata);
+        assertHasRole(assigned, AUTHENTICATED_PRINC, canViewOriginals);
+        assertFalse(assigned.isDeleted());
+        assertNull(assigned.getEmbargo());
+    }
+
+    @Test
+    public void getFromFolderWithInheritedPatrons() throws Exception {
+        createCollectionInUnit(new AclModelBuilder("Collection")
+                .addCanViewMetadata(PUBLIC_PRINC)
+                .addCanViewOriginals(AUTHENTICATED_PRINC)
+                .model);
+        FolderObject folder = repositoryObjectFactory.createFolderObject(null);
+        collObj.addMember(folder);
+
+        treeIndexer.indexAll(baseAddress);
+
+        MvcResult mvcResult = mvc.perform(get("/acl/patron/" + folder.getPid().getId()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Map<String, PatronAccessInfo> result = parseResponse(mvcResult);
+        PatronAccessInfo inherited = result.get(INHERITED_ROLES);
+        assertEquals(2, inherited.getRoles().size());
+        assertHasRole(inherited, PUBLIC_PRINC, canViewMetadata);
+        assertHasRole(inherited, AUTHENTICATED_PRINC, canViewOriginals);
+        assertFalse(inherited.isDeleted());
+        assertNull(inherited.getEmbargo());
+
+        assertInfoEmpty(result.get(ASSIGNED_ROLES));
+    }
+
+    @Test
+    public void getFromFolderWithInheritedAndAssignedPatrons() throws Exception {
+        createCollectionInUnit(new AclModelBuilder("Collection")
+                .addCanViewMetadata(PUBLIC_PRINC)
+                .addCanViewOriginals(AUTHENTICATED_PRINC)
+                .model);
+        FolderObject folder = repositoryObjectFactory.createFolderObject(
+                new AclModelBuilder("Folder with patrons")
+                    .addCanViewMetadata(AUTHENTICATED_PRINC)
+                    .model);
+        collObj.addMember(folder);
+
+        treeIndexer.indexAll(baseAddress);
+
+        MvcResult mvcResult = mvc.perform(get("/acl/patron/" + folder.getPid().getId()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Map<String, PatronAccessInfo> result = parseResponse(mvcResult);
+        PatronAccessInfo inherited = result.get(INHERITED_ROLES);
+        assertEquals(2, inherited.getRoles().size());
+        assertHasRole(inherited, PUBLIC_PRINC, canViewMetadata);
+        assertHasRole(inherited, AUTHENTICATED_PRINC, canViewOriginals);
+        assertFalse(inherited.isDeleted());
+        assertNull(inherited.getEmbargo());
+
+        PatronAccessInfo assigned = result.get(ASSIGNED_ROLES);
+        assertEquals(1, assigned.getRoles().size());
+        assertHasRole(assigned, AUTHENTICATED_PRINC, canViewMetadata);
+        assertFalse(assigned.isDeleted());
+        assertNull(assigned.getEmbargo());
+    }
+
+    @Test
+    public void getFromFolderWithInheritedRevoke() throws Exception {
+        createCollectionInUnit(new AclModelBuilder("Collection with none")
+                .addNoneRole(PUBLIC_PRINC)
+                .model);
+        FolderObject folder = repositoryObjectFactory.createFolderObject(
+                new AclModelBuilder("Folder with patrons")
+                    .addCanViewMetadata(PUBLIC_PRINC)
+                    .model);
+        collObj.addMember(folder);
+
+        treeIndexer.indexAll(baseAddress);
+
+        MvcResult mvcResult = mvc.perform(get("/acl/patron/" + folder.getPid().getId()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Map<String, PatronAccessInfo> result = parseResponse(mvcResult);
+        assertInfoEmpty(result.get(INHERITED_ROLES));
+
+        PatronAccessInfo assigned = result.get(ASSIGNED_ROLES);
+        assertEquals(1, assigned.getRoles().size());
+        assertHasRole(assigned, PUBLIC_PRINC, canViewMetadata);
+        assertFalse(assigned.isDeleted());
+        assertNull(assigned.getEmbargo());
+    }
+
+    @Test
+    public void getFromFolderWithInheritedDeletion() throws Exception {
+        createCollectionInUnit(new AclModelBuilder("Collection")
+                .addCanViewOriginals(PUBLIC_PRINC)
+                .markForDeletion()
+                .model);
+        FolderObject folder = repositoryObjectFactory.createFolderObject(null);
+        collObj.addMember(folder);
+
+        treeIndexer.indexAll(baseAddress);
+
+        MvcResult mvcResult = mvc.perform(get("/acl/patron/" + folder.getPid().getId()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Map<String, PatronAccessInfo> result = parseResponse(mvcResult);
+        PatronAccessInfo inherited = result.get(INHERITED_ROLES);
+        assertEquals(0, inherited.getRoles().size());
+        assertTrue(inherited.isDeleted());
+        assertNull(inherited.getEmbargo());
+
+        assertInfoEmpty(result.get(ASSIGNED_ROLES));
+    }
+
+    @Test
+    public void getFromFolderWithInheritedEmbargoed() throws Exception {
+        Calendar embargoUntil = getNextYear();
+        createCollectionInUnit(new AclModelBuilder("Collection")
+                .addCanViewMetadata(PUBLIC_PRINC)
+                .addCanViewOriginals(AUTHENTICATED_PRINC)
+                .addEmbargoUntil(embargoUntil)
+                .model);
+        FolderObject folder = repositoryObjectFactory.createFolderObject(null);
+        collObj.addMember(folder);
+
+        treeIndexer.indexAll(baseAddress);
+
+        MvcResult mvcResult = mvc.perform(get("/acl/patron/" + folder.getPid().getId()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Map<String, PatronAccessInfo> result = parseResponse(mvcResult);
+        PatronAccessInfo inherited = result.get(INHERITED_ROLES);
+        assertEquals(2, inherited.getRoles().size());
+        assertHasRole(inherited, PUBLIC_PRINC, canViewMetadata);
+        // Auth principal role reflects the applied embargo
+        assertHasRole(inherited, AUTHENTICATED_PRINC, canViewMetadata);
+        assertFalse(inherited.isDeleted());
+        assertEquals(embargoUntil.getTime(), inherited.getEmbargo());
+
+        assertInfoEmpty(result.get(ASSIGNED_ROLES));
+    }
+
+    @Test
+    public void getFromFolderDeleted() throws Exception {
+        createCollectionInUnit(
+                new AclModelBuilder("Collection")
+                    .addCanViewOriginals(PUBLIC_PRINC)
+                    .model);
+        FolderObject folder = repositoryObjectFactory.createFolderObject(
+                new AclModelBuilder("Folder deleted")
+                    .addCanViewOriginals(PUBLIC_PRINC)
+                    .markForDeletion()
+                    .model);
+        collObj.addMember(folder);
+
+        treeIndexer.indexAll(baseAddress);
+
+        MvcResult mvcResult = mvc.perform(get("/acl/patron/" + folder.getPid().getId()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Map<String, PatronAccessInfo> result = parseResponse(mvcResult);
+        PatronAccessInfo inherited = result.get(INHERITED_ROLES);
+        assertEquals(1, inherited.getRoles().size());
+        assertHasRole(inherited, PUBLIC_PRINC, canViewOriginals);
+        assertFalse(inherited.isDeleted());
+        assertNull(inherited.getEmbargo());
+
+        PatronAccessInfo assigned = result.get(ASSIGNED_ROLES);
+        assertEquals(1, assigned.getRoles().size());
+        // Assigned role should still be returned despite deleted status
+        assertHasRole(assigned, PUBLIC_PRINC, canViewOriginals);
+        assertTrue(assigned.isDeleted());
+        assertNull(assigned.getEmbargo());
+    }
+
+    @Test
+    public void getFromFolderEmbargoed() throws Exception {
+        Calendar embargoUntil = getNextYear();
+        createCollectionInUnit(
+                new AclModelBuilder("Collection")
+                    .addCanViewOriginals(PUBLIC_PRINC)
+                    .model);
+        FolderObject folder = repositoryObjectFactory.createFolderObject(
+                new AclModelBuilder("Folder deleted")
+                    .addCanViewOriginals(PUBLIC_PRINC)
+                    .addEmbargoUntil(embargoUntil)
+                    .model);
+        collObj.addMember(folder);
+
+        treeIndexer.indexAll(baseAddress);
+
+        MvcResult mvcResult = mvc.perform(get("/acl/patron/" + folder.getPid().getId()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Map<String, PatronAccessInfo> result = parseResponse(mvcResult);
+        PatronAccessInfo inherited = result.get(INHERITED_ROLES);
+        assertEquals(1, inherited.getRoles().size());
+        assertHasRole(inherited, PUBLIC_PRINC, canViewOriginals);
+        assertFalse(inherited.isDeleted());
+        assertNull(inherited.getEmbargo());
+
+        PatronAccessInfo assigned = result.get(ASSIGNED_ROLES);
+        assertEquals(1, assigned.getRoles().size());
+        // Role should be unaffected by embargo in assigned
+        assertHasRole(assigned, PUBLIC_PRINC, canViewOriginals);
+        assertFalse(assigned.isDeleted());
+        assertEquals(embargoUntil.getTime(), assigned.getEmbargo());
+    }
+
+    @Test
+    public void getFromWorkWithAllTheThings() throws Exception {
+        Calendar embargoUntil = getNextYear();
+        createCollectionInUnit(
+                new AclModelBuilder("Collection")
+                    .addCanViewOriginals(PUBLIC_PRINC)
+                    .addCanViewOriginals(AUTHENTICATED_PRINC)
+                    .markForDeletion()
+                    .addEmbargoUntil(embargoUntil)
+                    .model);
+        WorkObject work = repositoryObjectFactory.createWorkObject(
+                new AclModelBuilder("Work")
+                    .addCanViewMetadata(PUBLIC_PRINC)
+                    .markForDeletion()
+                    .addEmbargoUntil(embargoUntil)
+                    .model);
+        collObj.addMember(work);
+
+        treeIndexer.indexAll(baseAddress);
+
+        MvcResult mvcResult = mvc.perform(get("/acl/patron/" + work.getPid().getId()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Map<String, PatronAccessInfo> result = parseResponse(mvcResult);
+        PatronAccessInfo inherited = result.get(INHERITED_ROLES);
+        assertTrue(inherited.getRoles().isEmpty());
+        assertTrue(inherited.isDeleted());
+        assertEquals(embargoUntil.getTime(), inherited.getEmbargo());
+
+        PatronAccessInfo assigned = result.get(ASSIGNED_ROLES);
+        assertEquals(1, assigned.getRoles().size());
+        assertHasRole(assigned, PUBLIC_PRINC, canViewMetadata);
+        assertTrue(assigned.isDeleted());
+        assertEquals(embargoUntil.getTime(), assigned.getEmbargo());
+    }
+
+    @Test
+    public void getFromFileWithRevokedRole() throws Exception {
+        createCollectionInUnit(
+                new AclModelBuilder("Collection")
+                    .addCanViewOriginals(PUBLIC_PRINC)
+                    .model);
+        WorkObject work = repositoryObjectFactory.createWorkObject(null);
+        collObj.addMember(work);
+        InputStream contentStream = new ByteArrayInputStream(origBodyString.getBytes());
+        FileObject fileObj = work.addDataFile(contentStream, origFilename, origMimetype, null, null,
+                new AclModelBuilder("Work")
+                    .addNoneRole(PUBLIC_PRINC)
+                    .model);
+
+        treeIndexer.indexAll(baseAddress);
+
+        MvcResult mvcResult = mvc.perform(get("/acl/patron/" + fileObj.getPid().getId()))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Map<String, PatronAccessInfo> result = parseResponse(mvcResult);
+        PatronAccessInfo inherited = result.get(INHERITED_ROLES);
+        assertEquals(1, inherited.getRoles().size());
+        assertHasRole(inherited, PUBLIC_PRINC, canViewOriginals);
+        assertFalse(inherited.isDeleted());
+        assertNull(inherited.getEmbargo());
+
+        PatronAccessInfo assigned = result.get(ASSIGNED_ROLES);
+        assertEquals(1, assigned.getRoles().size());
+        assertHasRole(assigned, PUBLIC_PRINC, UserRole.none);
+        assertFalse(assigned.isDeleted());
+        assertNull(assigned.getEmbargo());
+    }
+
+    private void assertInfoEmpty(PatronAccessInfo info) {
+        assertTrue(info.getRoles() == null || info.getRoles().isEmpty());
+        assertFalse(info.isDeleted());
+        assertNull(info.getEmbargo());
+    }
+
+    private void assertHasRole(PatronAccessInfo info, String princ, UserRole role) {
+        assertTrue("Response info does not contain required assigned role " + princ + " " + role,
+                info.getRoles().stream()
+                .anyMatch(a -> a.getPrincipal().equals(princ) && a.getRole().equals(role)));
+    }
+
+    private void createCollectionInUnit(Model collModel, Model unitModel) {
+        adminUnit = repositoryObjectFactory.createAdminUnit(unitModel);
+        contentRoot.addMember(adminUnit);
+        collObj = repositoryObjectFactory.createCollectionObject(collModel);
+        adminUnit.addMember(collObj);
+    }
+
+    private void createCollectionInUnit(Model collModel) {
+        createCollectionInUnit(collModel,
+                new AclModelBuilder("Admin Unit with owner")
+                .addUnitOwner(USER_NS_PRINC)
+                .model);
+    }
+
+    private Map<String, PatronAccessInfo> parseResponse(MvcResult result) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.readValue(result.getResponse().getContentAsString(),
+                new TypeReference<Map<String, PatronAccessInfo>>() {});
+    }
+
+    private Calendar getNextYear() {
+        Date dt = new Date();
+        Calendar c = Calendar.getInstance();
+        c.setTime(dt);
+        c.add(Calendar.DATE, 365);
+        return c;
+    }
+
+    public static class PatronAccessInfo {
+        private List<RoleAssignment> roles;
+        private Date embargo;
+        private boolean deleted;
+
+        public List<RoleAssignment> getRoles() {
+            return roles;
+        }
+
+        public void setRoles(List<RoleAssignment> roles) {
+            this.roles = roles;
+        }
+
+        public Date getEmbargo() {
+            return embargo;
+        }
+
+        public void setEmbargo(Date embargo) {
+            this.embargo = embargo;
+        }
+
+        public boolean isDeleted() {
+            return deleted;
+        }
+
+        public void setDeleted(boolean deleted) {
+            this.deleted = deleted;
+        }
+    }
+}

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/RetrieveStaffRolesIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/RetrieveStaffRolesIT.java
@@ -22,6 +22,7 @@ import static edu.unc.lib.dl.acl.util.UserRole.canManage;
 import static edu.unc.lib.dl.acl.util.UserRole.unitOwner;
 import static edu.unc.lib.dl.cdr.services.rest.AccessControlRetrievalController.ASSIGNED_ROLES;
 import static edu.unc.lib.dl.cdr.services.rest.AccessControlRetrievalController.INHERITED_ROLES;
+import static edu.unc.lib.dl.cdr.services.rest.AccessControlRetrievalController.ROLES_KEY;
 import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -114,7 +115,7 @@ public class RetrieveStaffRolesIT extends AbstractAPIIT {
                 .andExpect(status().is2xxSuccessful())
                 .andReturn();
 
-        Map<String, List<RoleAssignment>> respMap = getRolesFromResponse(result);
+        Map<String, Map<String, List<RoleAssignment>>> respMap = getRolesFromResponse(result);
 
         assertNoInheritedRoles(respMap);
         assertNoAssignedRoles(respMap);
@@ -140,7 +141,7 @@ public class RetrieveStaffRolesIT extends AbstractAPIIT {
                 .andExpect(status().is2xxSuccessful())
                 .andReturn();
 
-        Map<String, List<RoleAssignment>> respMap = getRolesFromResponse(result);
+        Map<String, Map<String, List<RoleAssignment>>> respMap = getRolesFromResponse(result);
 
         assertNoInheritedRoles(respMap);
         assertHasAssignedRole(GRP_PRINC, canManage, pid, respMap);
@@ -161,7 +162,7 @@ public class RetrieveStaffRolesIT extends AbstractAPIIT {
                 .andExpect(status().is2xxSuccessful())
                 .andReturn();
 
-        Map<String, List<RoleAssignment>> respMap = getRolesFromResponse(result);
+        Map<String, Map<String, List<RoleAssignment>>> respMap = getRolesFromResponse(result);
 
         assertNoInheritedRoles(respMap);
         assertHasAssignedRole(GRP_PRINC, canManage, unitPid, respMap);
@@ -181,7 +182,7 @@ public class RetrieveStaffRolesIT extends AbstractAPIIT {
                 .andExpect(status().is2xxSuccessful())
                 .andReturn();
 
-        Map<String, List<RoleAssignment>> respMap = getRolesFromResponse(result);
+        Map<String, Map<String, List<RoleAssignment>>> respMap = getRolesFromResponse(result);
 
         assertNoAssignedRoles(respMap);
         assertHasInheritedRole(GRP_PRINC, canManage, unit.getPid(), respMap);
@@ -203,7 +204,7 @@ public class RetrieveStaffRolesIT extends AbstractAPIIT {
                 .andExpect(status().is2xxSuccessful())
                 .andReturn();
 
-        Map<String, List<RoleAssignment>> respMap = getRolesFromResponse(result);
+        Map<String, Map<String, List<RoleAssignment>>> respMap = getRolesFromResponse(result);
 
         assertHasAssignedRole(USER_PRINC, canAccess, pid, respMap);
         assertHasInheritedRole(GRP_PRINC, canManage, unit.getPid(), respMap);
@@ -225,7 +226,7 @@ public class RetrieveStaffRolesIT extends AbstractAPIIT {
                 .andExpect(status().is2xxSuccessful())
                 .andReturn();
 
-        Map<String, List<RoleAssignment>> respMap = getRolesFromResponse(result);
+        Map<String, Map<String, List<RoleAssignment>>> respMap = getRolesFromResponse(result);
 
         assertNoAssignedRoles(respMap);
         assertHasInheritedRole(GRP_PRINC, canManage, unit.getPid(), respMap);
@@ -248,7 +249,7 @@ public class RetrieveStaffRolesIT extends AbstractAPIIT {
                 .andExpect(status().is2xxSuccessful())
                 .andReturn();
 
-        Map<String, List<RoleAssignment>> respMap = getRolesFromResponse(result);
+        Map<String, Map<String, List<RoleAssignment>>> respMap = getRolesFromResponse(result);
 
         assertNoAssignedRoles(respMap);
         assertHasInheritedRole(GRP_PRINC, canManage, unit.getPid(), respMap);
@@ -280,7 +281,7 @@ public class RetrieveStaffRolesIT extends AbstractAPIIT {
                 .andExpect(status().is2xxSuccessful())
                 .andReturn();
 
-        Map<String, List<RoleAssignment>> respMap = getRolesFromResponse(result);
+        Map<String, Map<String, List<RoleAssignment>>> respMap = getRolesFromResponse(result);
 
         assertNoAssignedRoles(respMap);
         assertHasInheritedRole(GRP_PRINC, canAccess, unit.getPid(), respMap);
@@ -298,7 +299,7 @@ public class RetrieveStaffRolesIT extends AbstractAPIIT {
                 .andExpect(status().is2xxSuccessful())
                 .andReturn();
 
-        Map<String, List<RoleAssignment>> respMap = getRolesFromResponse(result);
+        Map<String, Map<String, List<RoleAssignment>>> respMap = getRolesFromResponse(result);
 
         assertNoAssignedRoles(respMap);
         assertHasInheritedRole(GRP_PRINC, canManage, unit.getPid(), respMap);
@@ -317,7 +318,7 @@ public class RetrieveStaffRolesIT extends AbstractAPIIT {
                 .andExpect(status().is2xxSuccessful())
                 .andReturn();
 
-        Map<String, List<RoleAssignment>> respMap = getRolesFromResponse(result);
+        Map<String, Map<String, List<RoleAssignment>>> respMap = getRolesFromResponse(result);
 
         assertNoAssignedRoles(respMap);
         assertHasInheritedRole(GRP_PRINC, canManage, unit.getPid(), respMap);
@@ -342,32 +343,32 @@ public class RetrieveStaffRolesIT extends AbstractAPIIT {
     }
 
     private void assertHasInheritedRole(String princ, UserRole role, PID pid,
-            Map<String, List<RoleAssignment>> respMap) {
-        List<RoleAssignment> inherited = respMap.get(INHERITED_ROLES);
+            Map<String, Map<String, List<RoleAssignment>>> respMap) {
+        List<RoleAssignment> inherited = respMap.get(INHERITED_ROLES).get(ROLES_KEY);
         assertTrue("Response did not contain required inherited role " + princ + " " + role,
                 inherited.contains(new RoleAssignment(princ, role, pid)));
     }
 
     private void assertHasAssignedRole(String princ, UserRole role, PID pid,
-            Map<String, List<RoleAssignment>> respMap) {
-        List<RoleAssignment> assigned = respMap.get(ASSIGNED_ROLES);
+            Map<String, Map<String, List<RoleAssignment>>> respMap) {
+        List<RoleAssignment> assigned = respMap.get(ASSIGNED_ROLES).get(ROLES_KEY);
         assertTrue("Response did not contain required assigned role " + princ + " " + role,
                 assigned.contains(new RoleAssignment(princ, role, pid)));
     }
 
-    private void assertNoInheritedRoles(Map<String, List<RoleAssignment>> respMap) {
-        List<RoleAssignment> inherited = respMap.get(INHERITED_ROLES);
+    private void assertNoInheritedRoles(Map<String, Map<String, List<RoleAssignment>>> respMap) {
+        List<RoleAssignment> inherited = respMap.get(INHERITED_ROLES).get(ROLES_KEY);
         assertTrue("Inherited role map was expected to be empty", inherited.isEmpty());
     }
 
-    private void assertNoAssignedRoles(Map<String, List<RoleAssignment>> respMap) {
-        List<RoleAssignment> assigned = respMap.get(ASSIGNED_ROLES);
+    private void assertNoAssignedRoles(Map<String, Map<String, List<RoleAssignment>>> respMap) {
+        List<RoleAssignment> assigned = respMap.get(ASSIGNED_ROLES).get(ROLES_KEY);
         assertTrue("Assigned role map was expected to be empty", assigned.isEmpty());
     }
 
-    protected Map<String, List<RoleAssignment>> getRolesFromResponse(MvcResult result) throws Exception {
+    protected Map<String, Map<String, List<RoleAssignment>>> getRolesFromResponse(MvcResult result) throws Exception {
         ObjectMapper mapper = new ObjectMapper();
         return mapper.readValue(result.getResponse().getContentAsString(),
-                new TypeReference<Map<String, List<RoleAssignment>>>() {});
+                new TypeReference<Map<String, Map<String, List<RoleAssignment>>>>() {});
     }
 }

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/AbstractAPIIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/AbstractAPIIT.java
@@ -16,6 +16,7 @@
 package edu.unc.lib.dl.cdr.services.rest.modify;
 
 import static com.fasterxml.jackson.databind.type.TypeFactory.defaultInstance;
+import static edu.unc.lib.dl.fcrepo4.RepositoryPaths.getContentRootPid;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -38,8 +39,14 @@ import com.fasterxml.jackson.databind.type.MapType;
 import edu.unc.lib.dl.acl.service.AccessControlService;
 import edu.unc.lib.dl.acl.util.AccessGroupSet;
 import edu.unc.lib.dl.acl.util.GroupsThreadStore;
+import edu.unc.lib.dl.fcrepo4.ContentRootObject;
 import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
+import edu.unc.lib.dl.fcrepo4.RepositoryPIDMinter;
+import edu.unc.lib.dl.fedora.FedoraException;
 import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.test.RepositoryObjectTreeIndexer;
 import edu.unc.lib.dl.test.TestHelper;
 
 /**
@@ -51,10 +58,22 @@ import edu.unc.lib.dl.test.TestHelper;
 @WebAppConfiguration
 public abstract class AbstractAPIIT {
 
+    @Autowired(required = false)
+    protected String baseAddress;
     @Autowired
     protected WebApplicationContext context;
     @Autowired
     protected AccessControlService aclService;
+    @Autowired(required = false)
+    protected RepositoryObjectFactory repositoryObjectFactory;
+    @Autowired(required = false)
+    protected RepositoryObjectLoader repositoryObjectLoader;
+    @Autowired(required = false)
+    protected RepositoryPIDMinter pidMinter;
+    @Autowired(required = false)
+    protected RepositoryObjectTreeIndexer treeIndexer;
+
+    protected ContentRootObject contentRoot;
 
     protected MockMvc mvc;
 
@@ -75,6 +94,16 @@ public abstract class AbstractAPIIT {
     @After
     public void tearDown() {
         GroupsThreadStore.clearStore();
+    }
+
+    protected void setupContentRoot() {
+        try {
+            repositoryObjectFactory.createContentRootObject(
+                    getContentRootPid().getRepositoryUri(), null);
+        } catch (FedoraException e) {
+            // Ignore failure as the content root will already exist after first test
+        }
+        contentRoot = repositoryObjectLoader.getContentRootObject(getContentRootPid());
     }
 
     protected PID makePid() {

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/AddContainerIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/AddContainerIT.java
@@ -17,7 +17,6 @@ package edu.unc.lib.dl.cdr.services.rest.modify;
 
 import static edu.unc.lib.dl.acl.util.Permission.ingest;
 import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.CONTENT_ROOT_ID;
-import static edu.unc.lib.dl.fcrepo4.RepositoryPaths.getContentRootPid;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -33,7 +32,6 @@ import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.ContextHierarchy;
 import org.springframework.test.web.servlet.MvcResult;
@@ -44,15 +42,10 @@ import edu.unc.lib.dl.fcrepo4.AdminUnit;
 import edu.unc.lib.dl.fcrepo4.CollectionObject;
 import edu.unc.lib.dl.fcrepo4.ContentContainerObject;
 import edu.unc.lib.dl.fcrepo4.ContentObject;
-import edu.unc.lib.dl.fcrepo4.ContentRootObject;
 import edu.unc.lib.dl.fcrepo4.FolderObject;
-import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
-import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
 import edu.unc.lib.dl.fcrepo4.WorkObject;
-import edu.unc.lib.dl.fedora.FedoraException;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.rdf.DcElements;
-import edu.unc.lib.dl.test.RepositoryObjectTreeIndexer;
 
 /**
  *
@@ -65,27 +58,9 @@ import edu.unc.lib.dl.test.RepositoryObjectTreeIndexer;
     @ContextConfiguration("/add-container-it-servlet.xml")
 })
 public class AddContainerIT extends AbstractAPIIT {
-
-    @Autowired
-    private String baseAddress;
-    @Autowired
-    private RepositoryObjectFactory repositoryObjectFactory;
-    @Autowired
-    private RepositoryObjectLoader repositoryObjectLoader;
-    @Autowired
-    private RepositoryObjectTreeIndexer treeIndexer;
-
-    private ContentRootObject contentRoot;
-
     @Before
     public void initRoot() {
-        try {
-            repositoryObjectFactory.createContentRootObject(
-                    getContentRootPid().getRepositoryUri(), null);
-        } catch (FedoraException e) {
-            // Ignore failure as the content root will already exist after first test
-        }
-        contentRoot = repositoryObjectLoader.getContentRootObject(getContentRootPid());
+        setupContentRoot();
     }
 
     @Test

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/EditLabelIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/EditLabelIT.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.ContextHierarchy;
 import org.springframework.test.web.servlet.MvcResult;
@@ -37,8 +36,6 @@ import org.springframework.test.web.servlet.MvcResult;
 import edu.unc.lib.dl.acl.exception.AccessRestrictionException;
 import edu.unc.lib.dl.acl.util.AccessGroupSet;
 import edu.unc.lib.dl.acl.util.Permission;
-import edu.unc.lib.dl.fcrepo4.FolderObject;
-import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
 import edu.unc.lib.dl.fcrepo4.WorkObject;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.rdf.DcElements;
@@ -54,9 +51,6 @@ import edu.unc.lib.dl.rdf.DcElements;
     @ContextConfiguration("/edit-label-it-servlet.xml")
 })
 public class EditLabelIT extends AbstractAPIIT {
-
-    @Autowired
-    private RepositoryObjectFactory repositoryObjectFactory;
 
     @Test
     public void testCreateLabelWhereNoneExists() throws UnsupportedOperationException, Exception {
@@ -106,7 +100,7 @@ public class EditLabelIT extends AbstractAPIIT {
     @Test
     public void testAuthorizationFailure() throws Exception {
         PID pid = makePid();
-        FolderObject folder = repositoryObjectFactory.createFolderObject(pid, null);
+        repositoryObjectFactory.createFolderObject(pid, null);
 
         doThrow(new AccessRestrictionException()).when(aclService)
                 .assertHasAccess(anyString(), eq(pid), any(AccessGroupSet.class), eq(Permission.editDescription));

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/ExportXMLIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/ExportXMLIT.java
@@ -52,7 +52,6 @@ import edu.unc.lib.dl.acl.util.AccessGroupSet;
 import edu.unc.lib.dl.acl.util.GroupsThreadStore;
 import edu.unc.lib.dl.cdr.services.rest.modify.ExportXMLController.XMLExportRequest;
 import edu.unc.lib.dl.fcrepo4.ContentObject;
-import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.persist.services.EmailHandler;
 
@@ -67,9 +66,6 @@ import edu.unc.lib.persist.services.EmailHandler;
     @ContextConfiguration("/export-xml-it-servlet.xml")
 })
 public class ExportXMLIT extends AbstractAPIIT {
-
-    @Autowired
-    private RepositoryObjectFactory repositoryObjectFactory;
 
     @Autowired
     private EmailHandler emailHandler;

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/MarkForDeletionIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/MarkForDeletionIT.java
@@ -34,7 +34,6 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
 import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.ContextHierarchy;
 import org.springframework.test.web.servlet.MvcResult;
@@ -42,8 +41,6 @@ import org.springframework.test.web.servlet.MvcResult;
 import edu.unc.lib.dl.acl.exception.AccessRestrictionException;
 import edu.unc.lib.dl.acl.util.AccessGroupSet;
 import edu.unc.lib.dl.fcrepo4.RepositoryObject;
-import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
-import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.rdf.CdrAcl;
 import edu.unc.lib.dl.rdf.Premis;
@@ -59,11 +56,6 @@ import edu.unc.lib.dl.rdf.Premis;
     @ContextConfiguration("/mark-for-deletion-it-servlet.xml")
 })
 public class MarkForDeletionIT extends AbstractAPIIT {
-
-    @Autowired
-    private RepositoryObjectFactory repositoryObjectFactory;
-    @Autowired
-    private RepositoryObjectLoader repositoryObjectLoader;
 
     @Test
     public void testMarkSingle() throws Exception {

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/MoveObjectsIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/MoveObjectsIT.java
@@ -32,7 +32,6 @@ import javax.ws.rs.core.MediaType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.ContextHierarchy;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -45,14 +44,8 @@ import edu.unc.lib.dl.fcrepo4.AdminUnit;
 import edu.unc.lib.dl.fcrepo4.CollectionObject;
 import edu.unc.lib.dl.fcrepo4.ContentContainerObject;
 import edu.unc.lib.dl.fcrepo4.ContentObject;
-import edu.unc.lib.dl.fcrepo4.ContentRootObject;
 import edu.unc.lib.dl.fcrepo4.FolderObject;
-import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
-import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
-import edu.unc.lib.dl.fcrepo4.RepositoryPaths;
-import edu.unc.lib.dl.fedora.FedoraException;
 import edu.unc.lib.dl.fedora.PID;
-import edu.unc.lib.dl.test.RepositoryObjectTreeIndexer;
 
 /**
  *
@@ -67,16 +60,6 @@ import edu.unc.lib.dl.test.RepositoryObjectTreeIndexer;
 })
 public class MoveObjectsIT extends AbstractAPIIT {
 
-    @Autowired
-    private String baseAddress;
-    @Autowired
-    private RepositoryObjectFactory repositoryObjectFactory;
-    @Autowired
-    private RepositoryObjectLoader repositoryObjectLoader;
-    @Autowired
-    private RepositoryObjectTreeIndexer treeIndexer;
-
-    private ContentRootObject rootObj;
     private AdminUnit unitObj;
     private CollectionObject collObj;
     private ContentContainerObject sourceContainer;
@@ -84,23 +67,17 @@ public class MoveObjectsIT extends AbstractAPIIT {
 
     @Before
     public void setup() {
+        setupContentRoot();
         createHierarchy();
     }
 
     private void createHierarchy() {
-        PID rootPid = RepositoryPaths.getContentRootPid();
-        try {
-            repositoryObjectFactory.createContentRootObject(rootPid.getRepositoryUri(), null);
-        } catch (FedoraException e) {
-        }
-        rootObj = repositoryObjectLoader.getContentRootObject(rootPid);
-
         unitObj = repositoryObjectFactory.createAdminUnit(null);
         collObj = repositoryObjectFactory.createCollectionObject(null);
         sourceContainer = repositoryObjectFactory.createFolderObject(null);
         destContainer = repositoryObjectFactory.createFolderObject(null);
 
-        rootObj.addMember(unitObj);
+        contentRoot.addMember(unitObj);
         unitObj.addMember(collObj);
         collObj.addMember(destContainer);
         collObj.addMember(sourceContainer);

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/SetAsPrimaryObjectIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/SetAsPrimaryObjectIT.java
@@ -30,7 +30,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.Map;
 
 import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.ContextHierarchy;
 import org.springframework.test.web.servlet.MvcResult;
@@ -39,10 +38,8 @@ import edu.unc.lib.dl.acl.exception.AccessRestrictionException;
 import edu.unc.lib.dl.acl.util.AccessGroupSet;
 import edu.unc.lib.dl.fcrepo4.FileObject;
 import edu.unc.lib.dl.fcrepo4.RepositoryObject;
-import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
 import edu.unc.lib.dl.fcrepo4.WorkObject;
 import edu.unc.lib.dl.fedora.PID;
-import edu.unc.lib.dl.test.RepositoryObjectTreeIndexer;
 
 /**
  *
@@ -55,13 +52,6 @@ import edu.unc.lib.dl.test.RepositoryObjectTreeIndexer;
     @ContextConfiguration("/set-as-primary-object-it-servlet.xml")
 })
 public class SetAsPrimaryObjectIT extends AbstractAPIIT {
-
-    @Autowired
-    private String baseAddress;
-    @Autowired
-    private RepositoryObjectFactory repositoryObjectFactory;
-    @Autowired
-    private RepositoryObjectTreeIndexer treeIndexer;
 
     private WorkObject parent;
     private PID parentPid;

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/UpdateDescriptionIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/UpdateDescriptionIT.java
@@ -34,7 +34,6 @@ import java.util.Map;
 
 import org.apache.tika.io.IOUtils;
 import org.junit.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.ContextHierarchy;
 import org.springframework.test.web.servlet.MvcResult;
@@ -42,8 +41,6 @@ import org.springframework.test.web.servlet.MvcResult;
 import edu.unc.lib.dl.acl.exception.AccessRestrictionException;
 import edu.unc.lib.dl.acl.util.AccessGroupSet;
 import edu.unc.lib.dl.fcrepo4.ContentObject;
-import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
-import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
 import edu.unc.lib.dl.fedora.PID;
 
 /**
@@ -57,11 +54,6 @@ import edu.unc.lib.dl.fedora.PID;
     @ContextConfiguration("/update-description-it-servlet.xml")
 })
 public class UpdateDescriptionIT extends AbstractAPIIT {
-
-    @Autowired
-    private RepositoryObjectLoader repoObjLoader;
-    @Autowired
-    private RepositoryObjectFactory repoFactory;
 
     @Test
     public void testUpdateDescription() throws Exception {
@@ -131,16 +123,16 @@ public class UpdateDescriptionIT extends AbstractAPIIT {
     }
 
     private PID makeWorkObject() {
-        return repoFactory.createWorkObject(makePid(), null).getPid();
+        return repositoryObjectFactory.createWorkObject(makePid(), null).getPid();
     }
 
     private void assertDescriptionUpdated(PID objPid) {
-        ContentObject obj = (ContentObject) repoObjLoader.getRepositoryObject(objPid);
+        ContentObject obj = (ContentObject) repositoryObjectLoader.getRepositoryObject(objPid);
         assertNotNull(obj.getDescription());
     }
 
     private void assertDescriptionNotUpdated(PID objPid) {
-        ContentObject obj = (ContentObject) repoObjLoader.getRepositoryObject(objPid);
+        ContentObject obj = (ContentObject) repositoryObjectLoader.getRepositoryObject(objPid);
         assertNull(obj.getDescription());
     }
 

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/UpdateStaffRolesIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/UpdateStaffRolesIT.java
@@ -50,6 +50,7 @@ import edu.unc.lib.dl.acl.util.AccessGroupSet;
 import edu.unc.lib.dl.acl.util.GroupsThreadStore;
 import edu.unc.lib.dl.acl.util.RoleAssignment;
 import edu.unc.lib.dl.acl.util.UserRole;
+import edu.unc.lib.dl.cdr.services.rest.modify.UpdateAccessControlController.UpdateStaffRequest;
 import edu.unc.lib.dl.fcrepo4.AdminUnit;
 import edu.unc.lib.dl.fcrepo4.CollectionObject;
 import edu.unc.lib.dl.fcrepo4.ContentObject;
@@ -100,7 +101,7 @@ public class UpdateStaffRolesIT extends AbstractAPIIT {
 
         MvcResult result = mvc.perform(put("/edit/acl/staff/" + pid.getId())
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(makeRequestBody(assignments)))
+                .content(serializeAssignments(assignments)))
                 .andExpect(status().isForbidden())
             .andReturn();
 
@@ -125,7 +126,7 @@ public class UpdateStaffRolesIT extends AbstractAPIIT {
 
         MvcResult result = mvc.perform(put("/edit/acl/staff/" + pid.getId())
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(makeRequestBody(assignments)))
+                .content(serializeAssignments(assignments)))
                 .andExpect(status().isBadRequest())
             .andReturn();
 
@@ -144,7 +145,7 @@ public class UpdateStaffRolesIT extends AbstractAPIIT {
 
         mvc.perform(put("/edit/acl/staff/" + pid.getId())
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(makeRequestBody(assignments)))
+                .content(serializeAssignments(assignments)))
                 .andExpect(status().isNotFound())
             .andReturn();
     }
@@ -164,7 +165,7 @@ public class UpdateStaffRolesIT extends AbstractAPIIT {
 
         MvcResult result = mvc.perform(put("/edit/acl/staff/" + pid.getId())
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(makeRequestBody(assignments)))
+                .content(serializeAssignments(assignments)))
                 .andExpect(status().isOk())
             .andReturn();
 
@@ -221,7 +222,7 @@ public class UpdateStaffRolesIT extends AbstractAPIIT {
 
         mvc.perform(put("/edit/acl/staff/" + pid.getId())
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(makeRequestBody(assignments)))
+                .content(serializeAssignments(assignments)))
                 .andExpect(status().isBadRequest())
             .andReturn();
     }
@@ -256,7 +257,7 @@ public class UpdateStaffRolesIT extends AbstractAPIIT {
 
         MvcResult result = mvc.perform(put("/edit/acl/staff/" + pid.getId())
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(makeRequestBody(assignments)))
+                .content(serializeAssignments(assignments)))
                 .andExpect(status().isOk())
             .andReturn();
 
@@ -281,7 +282,7 @@ public class UpdateStaffRolesIT extends AbstractAPIIT {
 
         MvcResult result = mvc.perform(put("/edit/acl/staff/" + pid.getId())
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(makeRequestBody(assignments)))
+                .content(serializeAssignments(assignments)))
                 .andExpect(status().isOk())
             .andReturn();
 
@@ -308,7 +309,7 @@ public class UpdateStaffRolesIT extends AbstractAPIIT {
 
         mvc.perform(put("/edit/acl/staff/" + pid.getId())
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(makeRequestBody(assignments)))
+                .content(serializeAssignments(assignments)))
                 .andExpect(status().isBadRequest())
             .andReturn();
     }
@@ -323,5 +324,12 @@ public class UpdateStaffRolesIT extends AbstractAPIIT {
         Resource resc = obj.getResource();
         assertFalse("Unexpected role " + role.name() + " was assigned for " + princ,
                 resc.hasProperty(role.getProperty(), princ));
+    }
+
+    private byte[] serializeAssignments(List<RoleAssignment> assignments) throws Exception {
+        UpdateStaffRequest updateRequest = new UpdateStaffRequest();
+        updateRequest.setRoles(assignments);
+
+        return makeRequestBody(updateRequest);
     }
 }

--- a/static/js/admin/vue-permissions-editor/src/components/staffRoles.vue
+++ b/static/js/admin/vue-permissions-editor/src/components/staffRoles.vue
@@ -3,7 +3,7 @@
         <h1 v-if="canSetPermissions">Set Staff Permissions</h1>
         <h1 v-else>Inherited Staff Permissions</h1>
 
-        <table class="border inherited-permissions" v-if="current_staff_roles.inherited !== undefined && current_staff_roles.inherited.length > 0">
+        <table class="border inherited-permissions" v-if="current_staff_roles.inherited !== undefined && current_staff_roles.inherited.roles.length > 0">
             <thead>
             <tr>
                 <th>Staff</th>
@@ -12,7 +12,7 @@
             </tr>
             </thead>
             <tbody>
-            <tr v-for="inherited_staff_permission in current_staff_roles.inherited">
+            <tr v-for="inherited_staff_permission in current_staff_roles.inherited.roles">
                 <td>{{ inherited_staff_permission.principal }}</td>
                 <td>{{ inherited_staff_permission.role }}</td>
                 <td>{{ assignedToName(inherited_staff_permission) }}</td>
@@ -119,7 +119,7 @@
 
         data() {
             return {
-                current_staff_roles: { inherited: [], assigned: [] },
+                current_staff_roles: { inherited: { roles: [] }, assigned: { roles: [] } },
                 deleted_users: [],
                 is_closing_modal: false,
                 is_error_message: true,
@@ -158,7 +158,7 @@
                         /* Add as clone so it doesn't update this.current_staff_roles.assigned by reference
                            when a user is is added/updated */
                         let update_roles = cloneDeep(response.data);
-                        this.updated_staff_roles = update_roles.assigned;
+                        this.updated_staff_roles = update_roles.assigned.roles;
                     }
                 }).catch((error) => {
                     let response_msg = `Unable load current staff roles for: ${this.title}`;
@@ -181,7 +181,7 @@
                 axios({
                     method: 'put',
                     url: `/services/api/edit/acl/staff/${this.uuid}`,
-                    data: JSON.stringify(this.updated_staff_roles),
+                    data: JSON.stringify( { roles: this.updated_staff_roles } ),
                     headers: {'content-type': 'application/json; charset=utf-8'}
                 }).then((response) => {
                     this.getRoles(); // Reset role list so user can close modal without a prompt.
@@ -323,7 +323,7 @@
              */
             unsavedUpdates() {
                 let unsaved_staff_roles = this.updated_staff_roles.some((user) => {
-                    let current_user = this.current_staff_roles.assigned.find((u) => user.principal === u.principal);
+                    let current_user = this.current_staff_roles.assigned.roles.find((u) => user.principal === u.principal);
                     return (current_user === undefined || current_user.role !== user.role);
                 });
 

--- a/static/js/admin/vue-permissions-editor/tests/unit/staffRoles.spec.js
+++ b/static/js/admin/vue-permissions-editor/tests/unit/staffRoles.spec.js
@@ -4,8 +4,8 @@ import moxios from "moxios";
 
 const localVue = createLocalVue();
 const response = {
-    inherited:[{ principal: 'test_admin', role: 'administrator' }],
-    assigned:[{ principal: 'test_user', role: 'canIngest' }]
+    inherited: { roles: [{ principal: 'test_admin', role: 'administrator' }] },
+    assigned: { roles: [{ principal: 'test_user', role: 'canIngest' }] }
 };
 
 const user_role = { principal: 'test_user_2', role: 'canManage', type: 'new' };
@@ -50,7 +50,7 @@ describe('staffRoles.vue', () => {
     it("retrieves current staff roles data from the server", (done) => {
         moxios.wait(() => {
             expect(wrapper.vm.current_staff_roles).toEqual(response);
-            expect(wrapper.vm.updated_staff_roles).toEqual(response.assigned);
+            expect(wrapper.vm.updated_staff_roles).toEqual(response.assigned.roles);
             done();
         });
     });
@@ -99,14 +99,14 @@ describe('staffRoles.vue', () => {
         moxios.wait(() => {
             let request = moxios.requests.mostRecent();
             expect(request.config.method).toEqual('put');
-            expect(JSON.parse(request.config.data)).toEqual([...response.assigned, ...[{ principal: 'test_user_7', role: 'canDescribe', type: 'new'}]]);
+            expect(JSON.parse(request.config.data)).toEqual( { roles: [...response.assigned.roles, ...[{ principal: 'test_user_7', role: 'canDescribe', type: 'new'}]] } );
             done();
         });
     });
 
     it("it adds un-added users and then sends current staff roles to the server", (done) => {
         let added_user = { principal: 'dean', role: 'canAccess', type: 'new' };
-        let all_users = [...response.assigned, ...[added_user]];
+        let all_users = { roles: [...response.assigned.roles, ...[added_user]] };
 
         wrapper.setData({
             user_name: 'dean'
@@ -124,8 +124,8 @@ describe('staffRoles.vue', () => {
     it("displays inherited staff roles", (done) => {
         moxios.wait(() => {
             let cells = wrapper.findAll('.inherited-permissions td');
-            expect(cells.at(0).text()).toEqual(response.inherited[0].principal);
-            expect(cells.at(1).text()).toEqual(response.inherited[0].role);
+            expect(cells.at(0).text()).toEqual(response.inherited.roles[0].principal);
+            expect(cells.at(1).text()).toEqual(response.inherited.roles[0].role);
             done();
         });
     });
@@ -161,9 +161,13 @@ describe('staffRoles.vue', () => {
         });
         
         const response = {
-            inherited:[{ principal: 'test_admin', role: 'unitOwner', assignedTo: '73bc003c-9603-4cd9-8a65-93a22520ef6a' },
-                { principal: 'test_manager', role: 'canManage', assignedTo: 'f88ff51e-7e74-4e0e-9ab9-259444393aeb' }],
-            assigned:[]
+            inherited: {
+                roles: [{ principal: 'test_admin', role: 'unitOwner', assignedTo: '73bc003c-9603-4cd9-8a65-93a22520ef6a' },
+                { principal: 'test_manager', role: 'canManage', assignedTo: 'f88ff51e-7e74-4e0e-9ab9-259444393aeb' }]
+            },
+            assigned: {
+                roles: []
+            }
         };
         
         moxios.stubRequest(`/services/api/acl/staff/${wrapper.vm.uuid}`, {
@@ -173,11 +177,11 @@ describe('staffRoles.vue', () => {
         
         moxios.wait(() => {
             let cells = wrapper.findAll('.inherited-permissions td');
-            expect(cells.at(0).text()).toEqual(response.inherited[0].principal);
-            expect(cells.at(1).text()).toEqual(response.inherited[0].role);
+            expect(cells.at(0).text()).toEqual(response.inherited.roles[0].principal);
+            expect(cells.at(1).text()).toEqual(response.inherited.roles[0].role);
             expect(cells.at(2).text()).toEqual('Test Unit');
-            expect(cells.at(3).text()).toEqual(response.inherited[1].principal);
-            expect(cells.at(4).text()).toEqual(response.inherited[1].role);
+            expect(cells.at(3).text()).toEqual(response.inherited.roles[1].principal);
+            expect(cells.at(4).text()).toEqual(response.inherited.roles[1].role);
             expect(cells.at(5).text()).toEqual('Test Collecton');
             done();
         });
@@ -186,7 +190,7 @@ describe('staffRoles.vue', () => {
     it("does not display an inherited roles table if there are no inherited roles", (done) => {
         moxios.wait(() => {
             wrapper.setData({
-                current_staff_roles: { inherited: [], assigned: [] }
+                current_staff_roles: { inherited: { roles: [] }, assigned: { roles: [] } }
             });
             expect(wrapper.find('p').text()).toEqual('There are no inherited staff permissions.');
             done()
@@ -196,7 +200,7 @@ describe('staffRoles.vue', () => {
     it("displays assigned staff roles", (done) => {
         moxios.wait(() => {
             let cells = wrapper.findAll('.assigned-permissions td');
-            expect(cells.at(0).text()).toEqual(response.assigned[0].principal);
+            expect(cells.at(0).text()).toEqual(response.assigned.roles[0].principal);
             // See test in staffRolesSelect.spec.js for test asserting that the correct option is displayed
             done();
         });
@@ -230,7 +234,7 @@ describe('staffRoles.vue', () => {
             });
 
             wrapper.find('.btn-add').trigger('click');
-            expect(wrapper.vm.updated_staff_roles).toEqual(response.assigned.concat([user_role]));
+            expect(wrapper.vm.updated_staff_roles).toEqual(response.assigned.roles.concat([user_role]));
             done();
         });
     });
@@ -253,7 +257,7 @@ describe('staffRoles.vue', () => {
             wrapper.findAll('option').at(2).setSelected();
             wrapper.find('.btn-add').trigger('click');
 
-            expect(wrapper.vm.updated_staff_roles).toEqual(response.assigned);
+            expect(wrapper.vm.updated_staff_roles).toEqual(response.assigned.roles);
             expect(wrapper.vm.response_message).toEqual('User: test_user already exists. User not added.');
             done();
         });
@@ -262,7 +266,7 @@ describe('staffRoles.vue', () => {
     it("marks user for deletion if user had previously assigned role", (done) => {
         moxios.wait(() => {
             wrapper.find('.btn-remove').trigger('click');
-            expect(wrapper.vm.deleted_users).toEqual(response.assigned);
+            expect(wrapper.vm.deleted_users).toEqual(response.assigned.roles);
             done();
         });
     });
@@ -350,7 +354,7 @@ describe('staffRoles.vue', () => {
     it("does not prompt the user if 'Submit' is clicked and there are unsaved changes", (done) => {
         moxios.wait(() => {
             wrapper.setData({
-                deleted_users: response.assigned
+                deleted_users: response.assigned.roles
             });
             wrapper.find('#is-submitting').trigger('click');
             expect(global.confirm).toHaveBeenCalledTimes(0);
@@ -361,7 +365,7 @@ describe('staffRoles.vue', () => {
     it("prompts the user if 'Cancel' is clicked and there are unsaved changes", (done) => {
         moxios.wait(() => {
             wrapper.setData({
-                deleted_users: response.assigned
+                deleted_users: response.assigned.roles
             });
             wrapper.find('#is-canceling').trigger('click');
             expect(global.confirm).toHaveBeenCalled();
@@ -375,7 +379,7 @@ describe('staffRoles.vue', () => {
             expect(wrapper.vm.unsaved_changes).toBe(false);
 
             wrapper.setData({
-                deleted_users: response.assigned
+                deleted_users: response.assigned.roles
             });
             wrapper.vm.unsavedUpdates();
             expect(wrapper.vm.unsaved_changes).toBe(true);


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2442

* Adds API endpoint for getting patron access control details, in the form:
```
{
  'inherited': {
    'roles: [ { 'principal': 'someuser', 'role': 'somerole' } ],
    'embargo': 'date',
    'deleted': boolean
  },
  'assigned': {
    'roles: [ { 'principal': 'someuser', 'role': 'somerole' } ],
    'embargo': 'date',
    'deleted': boolean
  }
}
```
* Updates response and update request format for staff ACLs to be wrapped in an object with the 'roles' key to match the format of the patron response.
* Refactored API integration tests to move common needs into parent class