### PR TITLE
Specify deploy type for Vue JS builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,27 @@ build-all: build-admin build-access
 build-admin:
 	# Build vue permissions application files
 	npm --prefix static/js/admin/vue-permissions-editor install
+
+ifeq ($(DEPLOY_TYPE), prod)
 	npm --prefix static/js/admin/vue-permissions-editor run build
+else
+	npm --prefix static/js/admin/vue-permissions-editor run build-dev
+endif
 
 	cat /dev/null > static/js/vue-permissions.js
+
+ifeq ($(DEPLOY_TYPE), prod)
 	cat static/js/admin/vue-permissions-editor/dist/js/chunk-vendors*.js > static/js/vue-permissions.js
+endif
+
 	# Add new line so app*.js doesn't get commented out
 	echo >> static/js/vue-permissions.js
+
+ifeq ($(DEPLOY_TYPE), prod)
 	cat static/js/admin/vue-permissions-editor/dist/js/app*.js >> static/js/vue-permissions.js
+else
+	cat static/js/admin/vue-permissions-editor/dist/app.js >> static/js/vue-permissions.js
+endif
 
 	cat static/js/lib/jquery.min.js > static/js/cdr-admin.js
 	echo "define('jquery-ui', ['jquery'], function ($$) {" >> static/js/cdr-admin.js
@@ -26,7 +40,7 @@ build-admin:
 		>> static/js/cdr-admin.js
 
 	sass static/css/sass/cdr_vue_modal_styles.scss  static/css/cdr_vue_modal_styles.css --style "expanded"
-	
+
 	cat static/css/reset.css \
 		static/css/cdr_common.css \
 		static/css/admin/jquery-ui.css \
@@ -39,9 +53,12 @@ build-admin:
 		static/css/admin/fontawesome/all.min.css \
 		static/css/structure_browse.css \
 		static/css/cdr_vue_modal_styles.css \
-		static/js/admin/vue-permissions-editor/dist/css/app*.css \
 		> static/css/cdr_admin.css
-	
+
+ifeq ($(DEPLOY_TYPE), prod)
+	cat static/js/admin/vue-permissions-editor/dist/css/app*.css >> static/css/cdr_admin.css
+endif
+
 ifneq ($(VERSION), "")
 	for i in static/js/admin/*.js; do \
 		sed "s/\(urlArgs *: *\)\".*\"/\1\"v=$(VERSION)\"/" $$i > $$i.temp; \
@@ -52,7 +69,12 @@ endif
 build-access:
 	# Build vue application(s) files
 	npm --prefix static/js/vue-cdr-access install
+
+ifeq ($(DEPLOY_TYPE), prod)
 	npm --prefix static/js/vue-cdr-access run build
+else
+	npm --prefix static/js/vue-cdr-access run build-dev
+endif
 
 	# Make sure file is empty
 	cat /dev/null > static/css/sass/cdr-ui.scss
@@ -67,16 +89,25 @@ build-access:
 	echo "});" >> static/js/cdr-access.js
 
 	cat /dev/null > static/js/vue-access.js
-	cat static/js/vue-cdr-access/dist/js/chunk-vendors*.js > static/js/vue-access.js
+
+ifeq ($(DEPLOY_TYPE), prod)
+	cat static/js/vue-cdr-access/dist/js/chunk-vendors*.js >> static/js/vue-access.js
+endif
+
 	# Add new line so app*.js doesn't get commented out
 	echo >> static/js/vue-access.js
+
+ifeq ($(DEPLOY_TYPE), prod)
 	cat static/js/vue-cdr-access/dist/js/app*.js >> static/js/vue-access.js
+else
+	cat static/js/vue-cdr-access/dist/app.js >> static/js/vue-access.js
+endif
 
 	cat \
 		static/js/public/src/*.js \
 		static/js/vue-access.js \
 		>> static/js/cdr-access.js
-		
+
 	cat static/css/reset.css \
 		static/css/cdr_common.css \
 		static/css/cdrui_styles.css \
@@ -84,9 +115,11 @@ build-access:
 		static/css/structure_browse.css \
 		static/css/cdr-ui.css \
 		static/css/cdr_vue_modal_styles.css \
-		static/js/vue-cdr-access/dist/css/app*.css \
 		> static/css/cdr_access.css
 
+ifeq ($(DEPLOY_TYPE), prod)
+	cat static/js/vue-cdr-access/dist/css/app*.css >> static/css/cdr_access.css
+endif
 SUSPEND = "n"
 
 run-access:

--- a/pom.xml
+++ b/pom.xml
@@ -360,25 +360,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>${exec-maven-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <configuration>
-                            <executable>make</executable>
-                            <commandlineArgs>VERSION=${cdr.version}</commandlineArgs>
-                        </configuration>
-                        <id>static-build</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <inherited>false</inherited>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven.surefire.version}</version>

--- a/static/js/admin/vue-permissions-editor/package.json
+++ b/static/js/admin/vue-permissions-editor/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
+    "build-dev": "vue-cli-service build --mode development",
     "test:unit": "vue-cli-service test:unit"
   },
   "dependencies": {

--- a/static/js/vue-cdr-access/package.json
+++ b/static/js/vue-cdr-access/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
+    "build-dev": "vue-cli-service build --mode development",
     "test:unit": "vue-cli-service test:unit"
   },
   "dependencies": {


### PR DESCRIPTION
Add build type, so Vue debug extensions work in development, but are excluded in production environment.
Depends on https://gitlab.lib.unc.edu/cdr/boxc-ansible/merge_requests/23
https://jira.lib.unc.edu/browse/BXC-2500