### PR TITLE
BXC-2471 - Destroy action cleans up external files

### DIFF
--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsHelper.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsHelper.java
@@ -47,7 +47,8 @@ public class DestroyObjectsHelper {
      * @param repoObj object to destroy
      * @param aclService acl service
      */
-    public static void assertCanDestroy(AgentPrincipals agent, RepositoryObject repoObj, AccessControlService aclService) {
+    public static void assertCanDestroy(AgentPrincipals agent, RepositoryObject repoObj,
+            AccessControlService aclService) {
         if (repoObj instanceof AdminUnit) {
             aclService.assertHasAccess("User does not have permission to destroy admin unit", repoObj.getPid(),
                     agent.getPrincipals(), Permission.destroyUnit);

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsHelper.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsHelper.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.persist.services.destroy;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+
+import edu.unc.lib.dl.acl.service.AccessControlService;
+import edu.unc.lib.dl.acl.util.AgentPrincipals;
+import edu.unc.lib.dl.acl.util.Permission;
+import edu.unc.lib.dl.exceptions.RepositoryException;
+import edu.unc.lib.dl.fcrepo4.AdminUnit;
+import edu.unc.lib.dl.fcrepo4.RepositoryObject;
+
+/**
+ * Helper for destroy operations
+ *
+ * @author bbpennel
+ *
+ */
+public class DestroyObjectsHelper {
+
+    private static final ObjectWriter MAPPER = new ObjectMapper().writerFor(DestroyObjectsRequest.class);
+
+    private DestroyObjectsHelper() {
+    }
+
+    /**
+     * Asserts that the provided agent has permission to destroy the indicated object.
+     *
+     * @param agent agent
+     * @param repoObj object to destroy
+     * @param aclService acl service
+     */
+    public static void assertCanDestroy(AgentPrincipals agent, RepositoryObject repoObj, AccessControlService aclService) {
+        if (repoObj instanceof AdminUnit) {
+            aclService.assertHasAccess("User does not have permission to destroy admin unit", repoObj.getPid(),
+                    agent.getPrincipals(), Permission.destroyUnit);
+        } else {
+            aclService.assertHasAccess("User does not have permission to destroy this object", repoObj.getPid(),
+                    agent.getPrincipals(), Permission.destroy);
+        }
+    }
+
+    public static String serializeDestroyRequest(DestroyObjectsRequest request) {
+        try {
+            return MAPPER.writeValueAsString(request);
+        } catch (IOException e) {
+            throw new RepositoryException("Failed to create destroy request", e);
+        }
+    }
+}

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsJob.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsJob.java
@@ -194,6 +194,10 @@ public class DestroyObjectsJob implements Runnable {
     }
 
     private void destroyBinaries() {
+        if (cleanupBinaryUris.isEmpty()) {
+            return;
+        }
+
         if (transferSession == null) {
             transferSession = transferService.getSession();
         }

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsRequest.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsRequest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.persist.services.destroy;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import edu.unc.lib.dl.acl.util.AccessGroupSet;
+import edu.unc.lib.dl.acl.util.AgentPrincipals;
+
+/**
+ * A request to destroy one or more objects.
+ *
+ * @author bbpennel
+ *
+ */
+public class DestroyObjectsRequest {
+
+    private String jobId;
+    private String[] ids;
+    private String username;
+    private AccessGroupSet principals;
+
+    public DestroyObjectsRequest() {
+    }
+
+    public DestroyObjectsRequest(String jobId, AgentPrincipals agent, String... ids) {
+        this.username = agent.getUsername();
+        this.principals = agent.getPrincipals();
+        this.ids = ids;
+        this.jobId = jobId;
+    }
+
+    @JsonIgnore
+    public AgentPrincipals getAgent() {
+        return new AgentPrincipals(username, principals);
+    }
+
+    public AccessGroupSet getPrincipals() {
+        return principals;
+    }
+
+    public void setPrincipals(AccessGroupSet principals) {
+        this.principals = principals;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String[] getIds() {
+        return ids;
+    }
+
+    public void setIds(String[] ids) {
+        this.ids = ids;
+    }
+
+    public String getJobId() {
+        return jobId;
+    }
+
+    public void setJobId(String jobId) {
+        this.jobId = jobId;
+    }
+}

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsService.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsService.java
@@ -15,26 +15,21 @@
  */
 package edu.unc.lib.dl.persist.services.destroy;
 
-import java.util.ArrayList;
-import java.util.List;
+import static edu.unc.lib.dl.persist.services.destroy.DestroyObjectsHelper.assertCanDestroy;
+import static edu.unc.lib.dl.persist.services.destroy.DestroyObjectsHelper.serializeDestroyRequest;
 
-import org.fcrepo.client.FcrepoClient;
+import java.util.UUID;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import edu.unc.lib.dl.acl.service.AccessControlService;
 import edu.unc.lib.dl.acl.util.AgentPrincipals;
-import edu.unc.lib.dl.acl.util.Permission;
-import edu.unc.lib.dl.fcrepo4.AdminUnit;
 import edu.unc.lib.dl.fcrepo4.PIDs;
 import edu.unc.lib.dl.fcrepo4.RepositoryObject;
-import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
 import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
-import edu.unc.lib.dl.fcrepo4.TransactionManager;
 import edu.unc.lib.dl.fedora.PID;
-import edu.unc.lib.dl.rdf.CdrAcl;
-import edu.unc.lib.dl.search.solr.service.ObjectPathFactory;
+import edu.unc.lib.dl.services.AbstractMessageSender;
 
 /**
  * Service that manages the destruction of objects in the repository and their replacement by tombstones
@@ -42,21 +37,12 @@ import edu.unc.lib.dl.search.solr.service.ObjectPathFactory;
  * @author harring
  *
  */
-public class DestroyObjectsService {
+public class DestroyObjectsService extends AbstractMessageSender {
 
     private static final Logger log = LoggerFactory.getLogger(DestroyObjectsService.class);
-    @Autowired
+
     private AccessControlService aclService;
-    @Autowired
-    private RepositoryObjectFactory repoObjFactory;
-    @Autowired
     private RepositoryObjectLoader repoObjLoader;
-    @Autowired
-    private TransactionManager txManager;
-    @Autowired
-    private ObjectPathFactory pathFactory;
-    @Autowired
-    private FcrepoClient fcrepoClient;
 
     /**
      * Checks whether the active user has permissions to destroy the listed objects,
@@ -64,88 +50,31 @@ public class DestroyObjectsService {
      *
      * @param agent security principals of the agent making request
      * @param ids list of objects to destroy
+     * @return the id of the destroy job created
      */
-    public void destroyObjects(AgentPrincipals agent, String... ids) {
-        List<PID> objsToDestroy = new ArrayList<>();
+    public String destroyObjects(AgentPrincipals agent, String... ids) {
+        if (ids.length == 0) {
+            throw new IllegalArgumentException("Must provide ids for one or more objects to destroy");
+        }
 
         for (String id : ids) {
             PID pid = PIDs.get(id);
             RepositoryObject obj = repoObjLoader.getRepositoryObject(pid);
-            if (obj instanceof AdminUnit) {
-                aclService.assertHasAccess("User does not have permission to destroy admin unit", pid,
-                        agent.getPrincipals(), Permission.destroyUnit);
-            } else {
-                aclService.assertHasAccess("User does not have permission to destroy this object", pid,
-                        agent.getPrincipals(), Permission.destroy);
-            }
-            if (obj.getResource().hasProperty(CdrAcl.markedForDeletion)) {
-                objsToDestroy.add(pid);
-            }
+            assertCanDestroy(agent, obj, aclService);
         }
-        if (!objsToDestroy.isEmpty()) {
-            DestroyObjectsJob job = initializeJob(objsToDestroy);
-            log.info("Destroy job for {} objects started by {}", objsToDestroy.size(), agent.getUsernameUri());
-            job.run();
-        } else {
-            log.info("Destroy job submitted by {} provided no eligable candidates, skipping", agent.getUsernameUri());
-        }
+        String jobId = UUID.randomUUID().toString();
+        DestroyObjectsRequest request = new DestroyObjectsRequest(jobId, agent, ids);
+        sendMessage(serializeDestroyRequest(request));
+
+        log.info("Destroy job for {} objects started by {}", ids.length, agent.getUsernameUri());
+        return jobId;
     }
 
-    private DestroyObjectsJob initializeJob(List<PID> objsToDestroy) {
-        DestroyObjectsJob job = new DestroyObjectsJob(objsToDestroy);
-        job.setFcrepoClient(fcrepoClient);
-        job.setPathFactory(pathFactory);
-        job.setRepoObjFactory(repoObjFactory);
-        job.setRepoObjLoader(repoObjLoader);
-        job.setTransactionManager(txManager);
-
-        return job;
-    }
-
-    /**
-     * @param aclService the aclService to set
-     */
     public void setAclService(AccessControlService aclService) {
         this.aclService = aclService;
     }
 
-    /**
-     * @param repoObjLoader the object loader to set
-     */
     public void setRepositoryObjectLoader(RepositoryObjectLoader repoObjLoader) {
         this.repoObjLoader = repoObjLoader;
     }
-
-    /**
-     *
-     * @param repoObjFactory the repository object factory to set
-     */
-    public void setRepositoryObjectFactory(RepositoryObjectFactory repoObjFactory) {
-        this.repoObjFactory = repoObjFactory;
-    }
-
-    /**
-     *
-     * @param txManager the transaction manager to set
-     */
-    public void setTransactionManager(TransactionManager txManager) {
-        this.txManager = txManager;
-    }
-
-    /**
-     *
-     * @param pathFactory the path factory to set
-     */
-    public void setPathFactory(ObjectPathFactory pathFactory) {
-        this.pathFactory = pathFactory;
-    }
-
-    /**
-     *
-     * @param fcrepoClient the fcrepo client to set
-     */
-    public void setFcrepoClient(FcrepoClient fcrepoClient) {
-        this.fcrepoClient = fcrepoClient;
-    }
-
 }

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/storage/StorageLocationManagerImpl.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/storage/StorageLocationManagerImpl.java
@@ -164,8 +164,9 @@ public class StorageLocationManagerImpl implements StorageLocationManager {
 
     @Override
     public StorageLocation getStorageLocationForUri(URI uri) {
+        URI normalizedUri = uri.normalize();
         return storageLocations.stream()
-                .filter(sl -> sl.isValidUri(uri))
+                .filter(sl -> sl.isValidUri(normalizedUri))
                 .findFirst()
                 .orElseThrow(() -> new UnknownStorageLocationException(
                         "No configured storage locations matched " + uri));

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/BinaryTransferSession.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/BinaryTransferSession.java
@@ -90,6 +90,14 @@ public interface BinaryTransferSession extends AutoCloseable {
     URI transferVersion(PID binPid, InputStream sourceStream);
 
     /**
+     * Delete a binary from a preservation storage location. If the binary cannot
+     * be deleted, then a BinaryTransferException will be thrown.
+     *
+     * @param fileUri uri of the binary to delete.
+     */
+    void delete(URI fileUri);
+
+    /**
      * Closes the binary session. If there are any failures, they will be RuntimeExceptions.
      */
     @Override

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/BinaryTransferSessionImpl.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/BinaryTransferSessionImpl.java
@@ -136,4 +136,9 @@ public class BinaryTransferSessionImpl implements BinaryTransferSession {
 
         return streamClient;
     }
+
+    @Override
+    public void delete(URI fileUri) {
+        getStreamClient().delete(fileUri);
+    }
 }

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/StreamToFSTransferClient.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/StreamToFSTransferClient.java
@@ -94,4 +94,14 @@ public class StreamToFSTransferClient implements StreamTransferClient {
     public void shutdown() {
         // No finalization needed at this time
     }
+
+    @Override
+    public void delete(URI fileUri) {
+        try {
+            Files.delete(Paths.get(fileUri));
+        } catch (IOException e) {
+            throw new BinaryTransferException("Failed to delete file from destination "
+                    + destination.getId(), e);
+        }
+    }
 }

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/StreamTransferClient.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/StreamTransferClient.java
@@ -59,6 +59,13 @@ public interface StreamTransferClient {
     URI transferVersion(PID binPid, InputStream sourceStream);
 
     /**
+     * Delete a binary in a preservation location.
+     *
+     * @param fileUri uri of the file to delete
+     */
+    void delete(URI fileUri);
+
+    /**
      * Shut down this transfer client.
      */
     void shutdown();

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/storage/HashedFilesystemStorageLocationTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/storage/HashedFilesystemStorageLocationTest.java
@@ -67,7 +67,7 @@ public class HashedFilesystemStorageLocationTest {
 
     @Test
     public void baseFieldWithNoScheme() {
-        String expectedBase = "file:///path/to/my/stuff/";
+        String expectedBase = "file:/path/to/my/stuff/";
         String assignedBase = "/path/to/my/stuff/";
         loc.setBase(assignedBase);
 

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/storage/HashedFilesystemStorageLocationTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/storage/HashedFilesystemStorageLocationTest.java
@@ -49,7 +49,7 @@ public class HashedFilesystemStorageLocationTest {
 
     @Test
     public void baseFieldWithFileScheme() {
-        String assignedBase = "file:///path/to/my/stuff/";
+        String assignedBase = "file:/path/to/my/stuff/";
         loc.setBase(assignedBase);
 
         assertEquals(assignedBase, loc.getBase());
@@ -57,8 +57,18 @@ public class HashedFilesystemStorageLocationTest {
     }
 
     @Test
+    public void baseFieldWithTripleSlashes() {
+        String assignedBase = "file:///path/to/my/stuff/";
+        String expectedBase = "file:/path/to/my/stuff/";
+        loc.setBase(assignedBase);
+
+        assertEquals(expectedBase, loc.getBase());
+        assertEquals(URI.create(expectedBase), loc.getBaseUri());
+    }
+
+    @Test
     public void baseFieldWithFileSchemeWithoutTrailingSlash() {
-        String assignedBase = "file:///path/to/my/stuff";
+        String assignedBase = "file:/path/to/my/stuff";
         loc.setBase(assignedBase);
 
         assertEquals(assignedBase + "/", loc.getBase());
@@ -83,7 +93,7 @@ public class HashedFilesystemStorageLocationTest {
 
     @Test
     public void getStorageUriForPidWithoutComponent() {
-        String assignedBase = "file:///location/path/";
+        String assignedBase = "file:/location/path/";
 
         loc.setId("loc1");
         loc.setBase(assignedBase);
@@ -96,7 +106,7 @@ public class HashedFilesystemStorageLocationTest {
 
     @Test
     public void getStorageUriForPidWithComponent() {
-        String assignedBase = "file:///location/path/";
+        String assignedBase = "file:/location/path/";
         String component = "/datafs/original_data";
 
         loc.setId("loc1");
@@ -110,7 +120,7 @@ public class HashedFilesystemStorageLocationTest {
 
     @Test
     public void isValidUriInLocation() {
-        String assignedBase = "file:///location/path/";
+        String assignedBase = "file:/location/path/";
         String subpath = "ab/cd/ef/gh/abcdefgh";
         URI targetUri = URI.create(assignedBase + subpath);
 

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/transfer/BinaryTransferSessionImplTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/transfer/BinaryTransferSessionImplTest.java
@@ -191,4 +191,19 @@ public class BinaryTransferSessionImplTest extends AbstractBinaryTransferTest {
             session.transferVersion(binPid, sourceFile.toUri());
         }
     }
+
+    @Test
+    public void deleteBinaryFSToFS() throws Exception {
+        when(ingestSource.getStorageType()).thenReturn(FILESYSTEM);
+        when(storageLoc.getStorageType()).thenReturn(FILESYSTEM);
+
+        Files.createDirectories(binDestPath.getParent());
+        createFile(binDestPath, "some stuff");
+        Path sourceFile = createSourceFile();
+
+        try (BinaryTransferSessionImpl session = new BinaryTransferSessionImpl(sourceManager, storageLoc)) {
+            session.delete(sourceFile.toUri());
+        }
+        assertFalse("File must be deleted", Files.exists(sourceFile));
+    }
 }

--- a/persistence/src/test/resources/acl-config.properties
+++ b/persistence/src/test/resources/acl-config.properties
@@ -1,0 +1,7 @@
+cdr.acl.globalRoles.administrator=adminGroup
+
+cache.contentPath.maxSize=500
+cache.contentPath.timeToLive=5000
+
+cache.objectAcls.maxSize=100
+cache.objectAcls.timeToLive=5000

--- a/persistence/src/test/resources/spring-test/acl-service-context.xml
+++ b/persistence/src/test/resources/spring-test/acl-service-context.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2008 The University of North Carolina at Chapel Hill
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd">
+    
+    <bean id="objectAclFactory" class="edu.unc.lib.dl.acl.fcrepo4.ObjectAclFactory"
+            init-method="init">
+        <property name="cacheMaxSize" value="0" />
+        <property name="cacheTimeToLive" value="0" />
+        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
+    </bean>
+    
+    <bean id="contentPathFactory" class="edu.unc.lib.dl.fedora.ContentPathFactory"
+            init-method="init">
+        <property name="cacheMaxSize" value="0" />
+        <property name="cacheTimeToLive" value="0" />
+        <property name="queryService" ref="sparqlQueryService" />
+    </bean>
+    
+    <bean id="inheritedPermissionEvaluator" class="edu.unc.lib.dl.acl.fcrepo4.InheritedPermissionEvaluator">
+        <property name="pathFactory" ref="contentPathFactory" />
+        <property name="objectAclFactory" ref="objectAclFactory" />
+    </bean>
+
+    <bean id="aclGlobalProperties"
+        class="org.springframework.beans.factory.config.PropertiesFactoryBean">
+        <property name="locations">
+            <list>
+                <value>classpath:acl-config.properties</value>
+            </list>
+        </property>
+    </bean>
+    
+    <bean id="globalPermissionEvaluator" class="edu.unc.lib.dl.acl.fcrepo4.GlobalPermissionEvaluator">
+        <constructor-arg ref="aclGlobalProperties" />
+    </bean>
+    
+    <bean id="aclService" class="edu.unc.lib.dl.acl.fcrepo4.AccessControlServiceImpl">
+        <property name="globalPermissionEvaluator" ref="globalPermissionEvaluator" />
+        <property name="permissionEvaluator" ref="inheritedPermissionEvaluator" />
+    </bean>
+    
+    <bean id="inheritedAclFactory" class="edu.unc.lib.dl.acl.fcrepo4.InheritedAclFactory">
+        <property name="objectAclFactory" ref="objectAclFactory" />
+        <property name="pathFactory" ref="contentPathFactory" />
+    </bean>
+</beans>

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/destroy/DestroyObjectsProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/destroy/DestroyObjectsProcessor.java
@@ -35,6 +35,7 @@ import edu.unc.lib.dl.persist.services.destroy.DestroyObjectsRequest;
 import edu.unc.lib.dl.persist.services.storage.StorageLocationManager;
 import edu.unc.lib.dl.persist.services.transfer.BinaryTransferService;
 import edu.unc.lib.dl.search.solr.service.ObjectPathFactory;
+import edu.unc.lib.dl.services.IndexingMessageSender;
 
 /**
  * Processor which handles messages requesting the destruction of objects.
@@ -57,6 +58,7 @@ public class DestroyObjectsProcessor implements Processor {
     private InheritedAclFactory inheritedAclFactory;
     private StorageLocationManager locManager;
     private BinaryTransferService transferService;
+    private IndexingMessageSender indexingMessageSender;
 
     @Override
     public void process(Exchange exchange) throws Exception {
@@ -79,6 +81,7 @@ public class DestroyObjectsProcessor implements Processor {
         job.setInheritedAclFactory(inheritedAclFactory);
         job.setBinaryTransferService(transferService);
         job.setStorageLocationManager(locManager);
+        job.setIndexingMessageSender(indexingMessageSender);
         return job;
     }
 
@@ -116,5 +119,9 @@ public class DestroyObjectsProcessor implements Processor {
 
     public void setBinaryTransferService(BinaryTransferService transferService) {
         this.transferService = transferService;
+    }
+
+    public void setIndexingMessageSender(IndexingMessageSender indexingMessageSender) {
+        this.indexingMessageSender = indexingMessageSender;
     }
 }

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/destroy/DestroyObjectsProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/destroy/DestroyObjectsProcessor.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.services.camel.destroy;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+import org.fcrepo.client.FcrepoClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+
+import edu.unc.lib.dl.acl.fcrepo4.InheritedAclFactory;
+import edu.unc.lib.dl.acl.service.AccessControlService;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
+import edu.unc.lib.dl.fcrepo4.TransactionManager;
+import edu.unc.lib.dl.persist.services.destroy.DestroyObjectsJob;
+import edu.unc.lib.dl.persist.services.destroy.DestroyObjectsRequest;
+import edu.unc.lib.dl.search.solr.service.ObjectPathFactory;
+
+/**
+ * Processor which handles messages requesting the destruction of objects.
+ *
+ * @author bbpennel
+ *
+ */
+public class DestroyObjectsProcessor implements Processor {
+
+    final Logger log = LoggerFactory.getLogger(DestroyObjectsProcessor.class);
+
+    private static final ObjectReader MAPPER = new ObjectMapper().readerFor(DestroyObjectsRequest.class);
+
+    private AccessControlService aclService;
+    private RepositoryObjectFactory repoObjFactory;
+    private RepositoryObjectLoader repoObjLoader;
+    private TransactionManager txManager;
+    private ObjectPathFactory pathFactory;
+    private FcrepoClient fcrepoClient;
+    private InheritedAclFactory inheritedAclFactory;
+
+    @Override
+    public void process(Exchange exchange) throws Exception {
+        log.debug("Processing xml import request");
+        final Message in = exchange.getIn();
+
+        DestroyObjectsRequest request = MAPPER.readValue((String) in.getBody());
+        DestroyObjectsJob job = createJob(request);
+        job.run();
+    }
+
+    private DestroyObjectsJob createJob(DestroyObjectsRequest request) {
+        DestroyObjectsJob job = new DestroyObjectsJob(request);
+        job.setFcrepoClient(fcrepoClient);
+        job.setPathFactory(pathFactory);
+        job.setRepoObjFactory(repoObjFactory);
+        job.setRepoObjLoader(repoObjLoader);
+        job.setTransactionManager(txManager);
+        job.setAclService(aclService);
+        job.setInheritedAclFactory(inheritedAclFactory);
+        return job;
+    }
+
+    public void setAclService(AccessControlService aclService) {
+        this.aclService = aclService;
+    }
+
+    public void setRepositoryObjectFactory(RepositoryObjectFactory repoObjFactory) {
+        this.repoObjFactory = repoObjFactory;
+    }
+
+    public void setRepositoryObjectLoader(RepositoryObjectLoader repoObjLoader) {
+        this.repoObjLoader = repoObjLoader;
+    }
+
+    public void setTransactionManager(TransactionManager txManager) {
+        this.txManager = txManager;
+    }
+
+    public void setObjectPathFactory(ObjectPathFactory pathFactory) {
+        this.pathFactory = pathFactory;
+    }
+
+    public void setFcrepoClient(FcrepoClient fcrepoClient) {
+        this.fcrepoClient = fcrepoClient;
+    }
+
+    public void setInheritedAclFactory(InheritedAclFactory inheritedAclFactory) {
+        this.inheritedAclFactory = inheritedAclFactory;
+    }
+}

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/destroy/DestroyObjectsProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/destroy/DestroyObjectsProcessor.java
@@ -32,6 +32,8 @@ import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
 import edu.unc.lib.dl.fcrepo4.TransactionManager;
 import edu.unc.lib.dl.persist.services.destroy.DestroyObjectsJob;
 import edu.unc.lib.dl.persist.services.destroy.DestroyObjectsRequest;
+import edu.unc.lib.dl.persist.services.storage.StorageLocationManager;
+import edu.unc.lib.dl.persist.services.transfer.BinaryTransferService;
 import edu.unc.lib.dl.search.solr.service.ObjectPathFactory;
 
 /**
@@ -53,6 +55,8 @@ public class DestroyObjectsProcessor implements Processor {
     private ObjectPathFactory pathFactory;
     private FcrepoClient fcrepoClient;
     private InheritedAclFactory inheritedAclFactory;
+    private StorageLocationManager locManager;
+    private BinaryTransferService transferService;
 
     @Override
     public void process(Exchange exchange) throws Exception {
@@ -73,6 +77,8 @@ public class DestroyObjectsProcessor implements Processor {
         job.setTransactionManager(txManager);
         job.setAclService(aclService);
         job.setInheritedAclFactory(inheritedAclFactory);
+        job.setBinaryTransferService(transferService);
+        job.setStorageLocationManager(locManager);
         return job;
     }
 
@@ -102,5 +108,13 @@ public class DestroyObjectsProcessor implements Processor {
 
     public void setInheritedAclFactory(InheritedAclFactory inheritedAclFactory) {
         this.inheritedAclFactory = inheritedAclFactory;
+    }
+
+    public void setStorageLocationManager(StorageLocationManager locManager) {
+        this.locManager = locManager;
+    }
+
+    public void setBinaryTransferService(BinaryTransferService transferService) {
+        this.transferService = transferService;
     }
 }

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/destroy/DestroyObjectsRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/destroy/DestroyObjectsRouter.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.services.camel.destroy;
+
+import static org.apache.camel.LoggingLevel.DEBUG;
+
+import org.apache.camel.BeanInject;
+import org.apache.camel.builder.RouteBuilder;
+
+/**
+ * Route to execute requests to destroy repository objects
+ *
+ * @author bbpennel
+ *
+ */
+public class DestroyObjectsRouter extends RouteBuilder {
+
+    @BeanInject(value = "destroyObjectsProcessor")
+    private DestroyObjectsProcessor destroyObjectsProcessor;
+
+    @Override
+    public void configure() throws Exception {
+        from("{{cdr.destroy.stream.camel}}")
+            .routeId("CdrDestroyObjects")
+            .log(DEBUG, "Received destroy objects message")
+            .bean(destroyObjectsProcessor);
+    }
+}

--- a/services-camel/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel/src/main/webapp/WEB-INF/service-context.xml
@@ -219,6 +219,7 @@
         <property name="inheritedAclFactory" ref="inheritedAclFactory" />
         <property name="storageLocationManager" ref="storageLocationManager" />
         <property name="binaryTransferService" ref="binaryTransferService" />
+        <property name="indexingMessageSender" ref="indexingMessageSender" />
     </bean>
     
     <bean id="fcrepo" class="org.fcrepo.camel.FcrepoComponent">

--- a/services-camel/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel/src/main/webapp/WEB-INF/service-context.xml
@@ -209,11 +209,25 @@
     <bean id="indexingMessageProcessor" class="edu.unc.lib.dl.services.camel.triplesReindexing.IndexingMessageProcessor">
     </bean>
     
+    <bean id="destroyObjectsProcessor" class="edu.unc.lib.dl.services.camel.destroy.DestroyObjectsProcessor">
+        <property name="aclService" ref="aclService" />
+        <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="transactionManager" ref="transactionManager" />
+        <property name="objectPathFactory" ref="objectPathFactory" />
+        <property name="fcrepoClient" ref="fcrepoClient" />
+        <property name="inheritedAclFactory" ref="inheritedAclFactory" />
+    </bean>
+    
     <bean id="fcrepo" class="org.fcrepo.camel.FcrepoComponent">
         <property name="authUsername" value="${fcrepo.auth.user}"/>
         <property name="authPassword" value="${fcrepo.auth.password}"/>
         <property name="authHost" value="${fcrepo.auth.host}"/>
         <property name="baseUrl" value="${fcrepo.baseUrl}"/>
+    </bean>
+    
+    <bean id="transactionManager" class="edu.unc.lib.dl.fcrepo4.TransactionManager">
+        <property name="client" ref="fcrepoClient" />
     </bean>
     
     <!-- XML Import dependencies -->
@@ -349,5 +363,9 @@
     
     <camel:camelContext id="CdrImportXML">
         <camel:package>edu.unc.lib.dl.services.camel.importxml</camel:package>
+    </camel:camelContext>
+    
+    <camel:camelContext id="CdrDestroyObjects">
+        <camel:package>edu.unc.lib.dl.services.camel.destroy</camel:package>
     </camel:camelContext>
 </beans>

--- a/services-camel/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel/src/main/webapp/WEB-INF/service-context.xml
@@ -214,9 +214,11 @@
         <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
         <property name="transactionManager" ref="transactionManager" />
-        <property name="objectPathFactory" ref="objectPathFactory" />
+        <property name="objectPathFactory" ref="pathFactory" />
         <property name="fcrepoClient" ref="fcrepoClient" />
         <property name="inheritedAclFactory" ref="inheritedAclFactory" />
+        <property name="storageLocationManager" ref="storageLocationManager" />
+        <property name="binaryTransferService" ref="binaryTransferService" />
     </bean>
     
     <bean id="fcrepo" class="org.fcrepo.camel.FcrepoComponent">

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/destroy/DestroyObjectsRouterTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/destroy/DestroyObjectsRouterTest.java
@@ -1,0 +1,143 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.services.camel.destroy;
+
+import static edu.unc.lib.dl.persist.services.destroy.DestroyObjectsHelper.serializeDestroyRequest;
+import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.UUID;
+
+import org.apache.camel.BeanInject;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.AdviceWithRouteBuilder;
+import org.apache.camel.test.spring.CamelSpringTestSupport;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.vocabulary.RDF;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.springframework.context.support.AbstractApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import edu.unc.lib.dl.acl.fcrepo4.InheritedAclFactory;
+import edu.unc.lib.dl.acl.util.AccessGroupSet;
+import edu.unc.lib.dl.acl.util.AgentPrincipals;
+import edu.unc.lib.dl.fcrepo4.FedoraTransaction;
+import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
+import edu.unc.lib.dl.fcrepo4.TransactionManager;
+import edu.unc.lib.dl.fcrepo4.WorkObject;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.persist.services.destroy.DestroyObjectsRequest;
+import edu.unc.lib.dl.rdf.Cdr;
+import edu.unc.lib.dl.search.solr.model.ObjectPath;
+import edu.unc.lib.dl.search.solr.service.ObjectPathFactory;
+
+/**
+ * @author bbpennel
+ *
+ */
+public class DestroyObjectsRouterTest extends CamelSpringTestSupport {
+    private static final String DESTROY_ROUTE = "CdrDestroyObjects";
+
+    private static final String USER_NAME = "user";
+    private static final String USER_GROUPS = "edu:lib:staff_grp";
+
+    @Produce(uri = "direct:start")
+    protected ProducerTemplate template;
+
+    private AgentPrincipals agent;
+
+    @BeanInject(value = "repositoryObjectLoader")
+    private RepositoryObjectLoader repoObjLoader;
+    @BeanInject(value = "repositoryObjectFactory")
+    private RepositoryObjectFactory repoObjFactory;
+    @BeanInject(value = "inheritedAclFactory")
+    private InheritedAclFactory inheritedAclFactory;
+    @BeanInject(value = "objectPathFactory")
+    private ObjectPathFactory objectPathFactory;
+
+    @BeanInject(value = "transactionManager")
+    private TransactionManager txManager;
+
+    @Mock
+    private WorkObject workObj;
+    @Mock
+    private FedoraTransaction tx;
+    @Mock
+    private ObjectPath objPath;
+
+    @Before
+    public void setup() {
+        initMocks(this);
+        AccessGroupSet testPrincipals = new AccessGroupSet(USER_GROUPS);
+        agent = new AgentPrincipals(USER_NAME, testPrincipals);
+
+        when(txManager.startTransaction()).thenReturn(tx);
+    }
+
+    @Override
+    protected AbstractApplicationContext createApplicationContext() {
+        return new ClassPathXmlApplicationContext("/service-context.xml", "/destroy-objects-context.xml");
+    }
+
+    @Test
+    public void destroyObject() throws Exception {
+        createContext(DESTROY_ROUTE);
+
+        String id = UUID.randomUUID().toString();
+        PID pid = PIDs.get(id);
+        when(repoObjLoader.getRepositoryObject(pid)).thenReturn(workObj);
+        Model model = createDefaultModel();
+        Resource resc = model.getResource(pid.getRepositoryPath());
+        resc.addProperty(RDF.type, Cdr.Work);
+        when(workObj.getResource()).thenReturn(resc);
+        when(workObj.getPid()).thenReturn(pid);
+        when(workObj.getUri()).thenReturn(pid.getRepositoryUri());
+
+        when(objectPathFactory.getPath(pid)).thenReturn(objPath);
+        when(objPath.toNamePath()).thenReturn("/path/to/stuff");
+        when(objPath.toIdPath()).thenReturn(id);
+
+        when(inheritedAclFactory.isMarkedForDeletion(pid)).thenReturn(true);
+
+        String jobId = UUID.randomUUID().toString();
+        DestroyObjectsRequest request = new DestroyObjectsRequest(jobId, agent, id);
+        template.sendBodyAndHeaders(serializeDestroyRequest(request), null);
+
+        verify(repoObjFactory).createOrTransformObject(eq(pid.getRepositoryUri()), any(Model.class));
+    }
+
+    private void createContext(String routeName) throws Exception {
+        context.getRouteDefinition(routeName).adviceWith(context, new AdviceWithRouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                replaceFromWith("direct:start");
+                mockEndpointsAndSkip("*");
+            }
+        });
+
+        context.start();
+    }
+}

--- a/services-camel/src/test/resources/config.properties
+++ b/services-camel/src/test/resources/config.properties
@@ -48,6 +48,9 @@ cdr.solrupdate.stream.camel=direct-vm:index.start
 cdr.triplesupdate.stream=direct-vm:index.start
 cdr.triplesupdate.stream.camel=direct-vm:index.start
 
+cdr.destroy.stream=direct-vm:index.start
+cdr.destroy.stream.camel=direct-vm:index.start
+
 # The camel URI for handling reindexing events.
 triplestore.reindex.stream=activemq:queue:triplestore.reindex
 reindexing.stream=activemq:queue:reindexing

--- a/services-camel/src/test/resources/destroy-objects-context.xml
+++ b/services-camel/src/test/resources/destroy-objects-context.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:c="http://www.springframework.org/schema/c"
+    xmlns:p="http://www.springframework.org/schema/p" xmlns:context="http://www.springframework.org/schema/context"
+    xmlns:util="http://www.springframework.org/schema/util"
+    xmlns:camel="http://camel.apache.org/schema/spring"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
+        http://www.springframework.org/schema/util 
+        http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.3.xsd
+        http://camel.apache.org/schema/spring
+        http://camel.apache.org/schema/spring/camel-spring.xsd">
+    
+    <bean id="destroyObjectsProcessor" class="edu.unc.lib.dl.services.camel.destroy.DestroyObjectsProcessor">
+        <property name="aclService" ref="aclService" />
+        <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="transactionManager" ref="transactionManager" />
+        <property name="objectPathFactory" ref="objectPathFactory" />
+        <property name="fcrepoClient" ref="fcrepoClient" />
+        <property name="inheritedAclFactory" ref="inheritedAclFactory" />
+    </bean>
+    
+    <bean id="aclService" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.acl.service.AccessControlService" />
+    </bean>
+    
+    <bean id="repositoryObjectFactory" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory" />
+    </bean>
+    
+    <bean id="inheritedAclFactory" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.acl.fcrepo4.InheritedAclFactory" />
+    </bean>
+    
+    <bean id="repositoryObjectLoader" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader" />
+    </bean>
+    
+    <bean id="transactionManager" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.fcrepo4.TransactionManager" />
+    </bean>
+    
+    <bean id="objectPathFactory" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.search.solr.service.ObjectPathFactory" />
+    </bean>
+    
+    <bean id="fcrepoClient" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="org.fcrepo.client.FcrepoClient" />
+    </bean>
+
+    <camel:camelContext id="cdrDestroyObjects">
+        <camel:package>edu.unc.lib.dl.services.camel.destroy</camel:package>
+    </camel:camelContext>
+    
+</beans>

--- a/services-camel/src/test/resources/destroy-objects-context.xml
+++ b/services-camel/src/test/resources/destroy-objects-context.xml
@@ -21,6 +21,7 @@
         <property name="objectPathFactory" ref="objectPathFactory" />
         <property name="fcrepoClient" ref="fcrepoClient" />
         <property name="inheritedAclFactory" ref="inheritedAclFactory" />
+        <property name="indexingMessageSender" ref="indexingMessageSender" />
     </bean>
     
     <bean id="aclService" class="org.mockito.Mockito" factory-method="mock">
@@ -45,6 +46,10 @@
     
     <bean id="objectPathFactory" class="org.mockito.Mockito" factory-method="mock">
         <constructor-arg value="edu.unc.lib.dl.search.solr.service.ObjectPathFactory" />
+    </bean>
+    
+    <bean id="indexingMessageSender" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.services.IndexingMessageSender" />
     </bean>
     
     <bean id="fcrepoClient" class="org.mockito.Mockito" factory-method="mock">

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/modify/DestroyObjectsController.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/modify/DestroyObjectsController.java
@@ -15,6 +15,8 @@
  */
 package edu.unc.lib.dl.cdr.services.rest.modify;
 
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -25,8 +27,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
@@ -46,13 +47,17 @@ public class DestroyObjectsController {
     @Autowired
     private DestroyObjectsService service;
 
-    @RequestMapping(value = "edit/destroy", method = RequestMethod.POST)
+    @PostMapping(value = "/edit/destroy")
     @ResponseBody
     public ResponseEntity<Object> destroyBatch(@RequestParam("ids") String ids) {
+        if (isEmpty(ids)) {
+            throw new IllegalArgumentException("Must provide one or more ids");
+        }
+
         return destroy(ids.split("\n"));
     }
 
-    @RequestMapping(value = "edit/destroy/{id}", method = RequestMethod.POST)
+    @PostMapping(value = "/edit/destroy/{id}")
     @ResponseBody
     public ResponseEntity<Object> destroyObject(@PathVariable("id") String id) {
         return destroy(id);
@@ -68,7 +73,8 @@ public class DestroyObjectsController {
         }
 
         AgentPrincipals agent = AgentPrincipals.createFromThread();
-        service.destroyObjects(agent, ids);
+        String jobId = service.destroyObjects(agent, ids);
+        result.put("job", jobId);
         log.info("{} initiated destruction of {} objects from the repository", agent.getUsername(), ids.length);
 
         result.put("timestamp", System.currentTimeMillis());

--- a/services/src/main/webapp/WEB-INF/service-context.xml
+++ b/services/src/main/webapp/WEB-INF/service-context.xml
@@ -93,11 +93,18 @@
         <property name="operationMetrics" ref="activityMetricsClient" />
     </bean>
     
+    <bean id="destroyObjectsJmsTemplate" class="org.springframework.jms.core.JmsTemplate">
+        <property name="connectionFactory" ref="jmsFactory" />
+        <property name="defaultDestinationName" value="${cdr.destroy.stream}" />
+        <property name="pubSubDomain" value="false" />
+    </bean>
+    
     <bean id="destroyObjectsService"
         class="edu.unc.lib.dl.persist.services.destroy.DestroyObjectsService">
         <property name="aclService" ref="aclService" />
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
-        </bean>
+        <property name="jmsTemplate" ref="destroyObjectsJmsTemplate" />
+    </bean>
     
     <bean id="jmsTemplate" class="org.springframework.jms.core.JmsTemplate">
         <property name="connectionFactory" ref="jmsFactory" />

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/RetrievePatronRolesIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/RetrievePatronRolesIT.java
@@ -69,6 +69,7 @@ import edu.unc.lib.dl.test.AclModelBuilder;
 @ContextHierarchy({
    @ContextConfiguration("/spring-test/test-fedora-container.xml"),
    @ContextConfiguration("/spring-test/cdr-client-container.xml"),
+   @ContextConfiguration("/spring-test/acl-service-context.xml"),
    @ContextConfiguration("/access-control-retrieval-it-servlet.xml")
 })
 public class RetrievePatronRolesIT extends AbstractAPIIT {

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/RetrieveStaffRolesIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/RetrieveStaffRolesIT.java
@@ -64,6 +64,7 @@ import edu.unc.lib.dl.test.AclModelBuilder;
 @ContextHierarchy({
     @ContextConfiguration("/spring-test/test-fedora-container.xml"),
     @ContextConfiguration("/spring-test/cdr-client-container.xml"),
+    @ContextConfiguration("/spring-test/acl-service-context.xml"),
     @ContextConfiguration("/access-control-retrieval-it-servlet.xml")
 })
 public class RetrieveStaffRolesIT extends AbstractAPIIT {

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/DestroyObjectsIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/DestroyObjectsIT.java
@@ -1,0 +1,189 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.cdr.services.rest.modify;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.net.URI;
+import java.util.Map;
+
+import org.apache.jena.rdf.model.Model;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.core.MessageCreator;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.unc.lib.dl.acl.util.AccessGroupSet;
+import edu.unc.lib.dl.acl.util.GroupsThreadStore;
+import edu.unc.lib.dl.fcrepo4.AdminUnit;
+import edu.unc.lib.dl.fcrepo4.CollectionObject;
+import edu.unc.lib.dl.test.AclModelBuilder;
+
+/**
+ * @author bbpennel
+ *
+ */
+@ContextHierarchy({
+    @ContextConfiguration("/spring-test/test-fedora-container.xml"),
+    @ContextConfiguration("/spring-test/cdr-client-container.xml"),
+    @ContextConfiguration("/spring-test/acl-service-context.xml"),
+    @ContextConfiguration("/destroy-objects-it-servlet.xml")
+})
+public class DestroyObjectsIT extends AbstractAPIIT {
+    private static final String USER_NAME = "user";
+    private static final String USER_GROUPS = "edu:lib:staff_grp";
+    private static final String ADMIN_GROUP = "adminGroup";
+
+    private AdminUnit adminUnit;
+    private CollectionObject collObj;
+
+    @Autowired
+    private JmsTemplate jmsTemplate;
+
+    @Before
+    public void setup() throws Exception {
+        reset(jmsTemplate);
+
+        AccessGroupSet testPrincipals = new AccessGroupSet(USER_GROUPS);
+
+        GroupsThreadStore.storeUsername(USER_NAME);
+        GroupsThreadStore.storeGroups(testPrincipals);
+
+        setupContentRoot();
+    }
+
+    @Test
+    public void destroySingle() throws Exception {
+        createCollectionInUnit(new AclModelBuilder("Unit with owner")
+                    .addUnitOwner(USER_GROUPS)
+                    .model);
+
+        treeIndexer.indexAll(baseAddress);
+
+        MvcResult result = mvc.perform(post("/edit/destroy/" + collObj.getPid().getId()))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+
+        assertResponseSuccess(result);
+
+        verify(jmsTemplate).send(any(MessageCreator.class));
+    }
+
+    @Test
+    public void destroyUnitAsManagerForbidden() throws Exception {
+        createCollectionInUnit(new AclModelBuilder("Unit with manager")
+                .addCanManage(USER_GROUPS)
+                .model);
+
+        treeIndexer.indexAll(baseAddress);
+
+        mvc.perform(post(URI.create("/edit/destroy/" + adminUnit.getPid().getId())))
+                .andExpect(status().isForbidden())
+                .andReturn();
+
+        verify(jmsTemplate, never()).send(any(MessageCreator.class));
+    }
+
+    @Test
+    public void destroyUnitAsAdmin() throws Exception {
+        AccessGroupSet testPrincipals = new AccessGroupSet(ADMIN_GROUP);
+        GroupsThreadStore.storeGroups(testPrincipals);
+
+        createCollectionInUnit(null);
+
+        treeIndexer.indexAll(baseAddress);
+
+        mvc.perform(post(URI.create("/edit/destroy/" + adminUnit.getPid().getId())))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+
+        verify(jmsTemplate).send(any(MessageCreator.class));
+    }
+
+    @Test
+    public void destroyMultiple() throws Exception {
+        createCollectionInUnit(new AclModelBuilder("Unit with owner")
+                .addUnitOwner(USER_GROUPS)
+                .model);
+        CollectionObject collObj2 = repositoryObjectFactory.createCollectionObject(null);
+        adminUnit.addMember(collObj2);
+
+        treeIndexer.indexAll(baseAddress);
+
+        String ids = collObj.getPid().getId() + "\n" + collObj2.getPid().getId();
+
+        MvcResult result = mvc.perform(post("/edit/destroy")
+                .param("ids", ids))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+
+        assertResponseSuccess(result);
+
+        verify(jmsTemplate).send(any(MessageCreator.class));
+    }
+
+    @Test
+    public void destroyMultipleNoPermission() throws Exception {
+        createCollectionInUnit(null);
+        CollectionObject collObj2 = repositoryObjectFactory.createCollectionObject(null);
+        adminUnit.addMember(collObj2);
+
+        treeIndexer.indexAll(baseAddress);
+
+        String ids = collObj.getPid().getId() + "\n" + collObj2.getPid().getId();
+
+        mvc.perform(post("/edit/destroy")
+                .param("ids", ids))
+                .andExpect(status().isForbidden())
+                .andReturn();
+
+        verify(jmsTemplate, never()).send(any(MessageCreator.class));
+    }
+
+    @Test
+    public void destroyNone() throws Exception {
+        mvc.perform(post("/edit/destroy")
+                .param("ids", ""))
+                .andExpect(status().isBadRequest())
+                .andReturn();
+
+        verify(jmsTemplate, never()).send(any(MessageCreator.class));
+    }
+
+    private void assertResponseSuccess(MvcResult mvcResult) throws Exception {
+        Map<String, Object> resp = getMapFromResponse(mvcResult);
+        assertTrue("Missing job id", resp.containsKey("job"));
+        assertEquals("destroy", resp.get("action"));
+    }
+
+    private void createCollectionInUnit(Model unitModel) {
+        adminUnit = repositoryObjectFactory.createAdminUnit(unitModel);
+        contentRoot.addMember(adminUnit);
+        collObj = repositoryObjectFactory.createCollectionObject(null);
+        adminUnit.addMember(collObj);
+    }
+}

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/UpdatePatronAccessIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/UpdatePatronAccessIT.java
@@ -67,6 +67,7 @@ import edu.unc.lib.dl.test.AclModelBuilder;
 @ContextHierarchy({
     @ContextConfiguration("/spring-test/test-fedora-container.xml"),
     @ContextConfiguration("/spring-test/cdr-client-container.xml"),
+    @ContextConfiguration("/spring-test/acl-service-context.xml"),
     @ContextConfiguration("/update-patron-it-servlet.xml")
 })
 public class UpdatePatronAccessIT extends AbstractAPIIT {

--- a/services/src/test/resources/access-control-retrieval-it-servlet.xml
+++ b/services/src/test/resources/access-control-retrieval-it-servlet.xml
@@ -32,44 +32,6 @@
 
     <context:component-scan resource-pattern="**/AccessControlRetrievalController*" base-package="edu.unc.lib.dl.cdr.services.rest"/>
     
-    <!-- Access Retrieval App beans -->
-    <bean id="inheritedPermissionEvaluator" class="edu.unc.lib.dl.acl.fcrepo4.InheritedPermissionEvaluator">
-        <property name="pathFactory" ref="contentPathFactory" />
-        <property name="objectAclFactory" ref="objectAclFactory" />
-    </bean>
-
-    <bean id="aclGlobalProperties"
-        class="org.springframework.beans.factory.config.PropertiesFactoryBean">
-        <property name="locations">
-            <list>
-                <value>classpath:acl-config.properties</value>
-            </list>
-        </property>
-    </bean>
-    
-    <bean id="globalPermissionEvaluator" class="edu.unc.lib.dl.acl.fcrepo4.GlobalPermissionEvaluator">
-        <constructor-arg ref="aclGlobalProperties" />
-    </bean>
-    
-    <bean id="aclService" class="edu.unc.lib.dl.acl.fcrepo4.AccessControlServiceImpl">
-        <property name="globalPermissionEvaluator" ref="globalPermissionEvaluator" />
-        <property name="permissionEvaluator" ref="inheritedPermissionEvaluator" />
-    </bean>
-    
-    <bean id="objectAclFactory" class="edu.unc.lib.dl.acl.fcrepo4.ObjectAclFactory"
-            init-method="init">
-        <property name="cacheMaxSize" value="500" />
-        <property name="cacheTimeToLive" value="5000" />
-        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
-    </bean>
-    
-     <bean id="contentPathFactory" class="edu.unc.lib.dl.fedora.ContentPathFactory"
-            init-method="init">
-        <property name="cacheMaxSize" value="100" />
-        <property name="cacheTimeToLive" value="5000" />
-        <property name="queryService" ref="sparqlQueryService" />
-    </bean>
-    
     <bean id="inheritedAclFactory" class="edu.unc.lib.dl.acl.fcrepo4.InheritedAclFactory">
         <property name="objectAclFactory" ref="objectAclFactory" />
         <property name="pathFactory" ref="contentPathFactory" />

--- a/services/src/test/resources/destroy-objects-it-servlet.xml
+++ b/services/src/test/resources/destroy-objects-it-servlet.xml
@@ -30,17 +30,11 @@
         
     <mvc:annotation-driven/>
 
-    <context:component-scan resource-pattern="**/ImportXMLController*" base-package="edu.unc.lib.dl.cdr.services.rest.modify"/>
+    <context:component-scan resource-pattern="**/DestroyObjectsController*" base-package="edu.unc.lib.dl.cdr.services.rest.modify"/>
     
-    <bean id="xmlImportService" class="edu.unc.lib.dl.persist.services.importxml.ImportXMLService">
+    <bean id="destroyObjectsService" class="edu.unc.lib.dl.persist.services.destroy.DestroyObjectsService">
+        <property name="aclService" ref="aclService" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
         <property name="jmsTemplate" ref="jmsTemplate"/>
-    </bean>
-    
-    <bean id="dataDir" class="java.lang.String">
-        <constructor-arg value="src/test/resources/temp"/>
-    </bean>
-    
-    <bean id="aclService" class="org.mockito.Mockito" factory-method="mock">
-        <constructor-arg value="edu.unc.lib.dl.acl.fcrepo4.AccessControlServiceImpl" />
     </bean>
 </beans>

--- a/services/src/test/resources/spring-test/acl-service-context.xml
+++ b/services/src/test/resources/spring-test/acl-service-context.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2008 The University of North Carolina at Chapel Hill
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd">
+    
+    <bean id="objectAclFactory" class="edu.unc.lib.dl.acl.fcrepo4.ObjectAclFactory"
+            init-method="init">
+        <property name="cacheMaxSize" value="0" />
+        <property name="cacheTimeToLive" value="0" />
+        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
+    </bean>
+    
+    <bean id="contentPathFactory" class="edu.unc.lib.dl.fedora.ContentPathFactory"
+            init-method="init">
+        <property name="cacheMaxSize" value="0" />
+        <property name="cacheTimeToLive" value="0" />
+        <property name="queryService" ref="sparqlQueryService" />
+    </bean>
+    
+    <bean id="inheritedPermissionEvaluator" class="edu.unc.lib.dl.acl.fcrepo4.InheritedPermissionEvaluator">
+        <property name="pathFactory" ref="contentPathFactory" />
+        <property name="objectAclFactory" ref="objectAclFactory" />
+    </bean>
+
+    <bean id="aclGlobalProperties"
+        class="org.springframework.beans.factory.config.PropertiesFactoryBean">
+        <property name="locations">
+            <list>
+                <value>classpath:acl-config.properties</value>
+            </list>
+        </property>
+    </bean>
+    
+    <bean id="globalPermissionEvaluator" class="edu.unc.lib.dl.acl.fcrepo4.GlobalPermissionEvaluator">
+        <constructor-arg ref="aclGlobalProperties" />
+    </bean>
+    
+    <bean id="aclService" class="edu.unc.lib.dl.acl.fcrepo4.AccessControlServiceImpl">
+        <property name="globalPermissionEvaluator" ref="globalPermissionEvaluator" />
+        <property name="permissionEvaluator" ref="inheritedPermissionEvaluator" />
+    </bean>
+</beans>

--- a/services/src/test/resources/update-patron-it-servlet.xml
+++ b/services/src/test/resources/update-patron-it-servlet.xml
@@ -39,42 +39,4 @@
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
         <property name="transactionManager" ref="transactionManager" />
     </bean>
-    
-    <!-- Access Retrieval App beans -->
-    <bean id="inheritedPermissionEvaluator" class="edu.unc.lib.dl.acl.fcrepo4.InheritedPermissionEvaluator">
-        <property name="pathFactory" ref="contentPathFactory" />
-        <property name="objectAclFactory" ref="objectAclFactory" />
-    </bean>
-
-    <bean id="aclGlobalProperties"
-        class="org.springframework.beans.factory.config.PropertiesFactoryBean">
-        <property name="locations">
-            <list>
-                <value>classpath:acl-config.properties</value>
-            </list>
-        </property>
-    </bean>
-    
-    <bean id="globalPermissionEvaluator" class="edu.unc.lib.dl.acl.fcrepo4.GlobalPermissionEvaluator">
-        <constructor-arg ref="aclGlobalProperties" />
-    </bean>
-    
-    <bean id="aclService" class="edu.unc.lib.dl.acl.fcrepo4.AccessControlServiceImpl">
-        <property name="globalPermissionEvaluator" ref="globalPermissionEvaluator" />
-        <property name="permissionEvaluator" ref="inheritedPermissionEvaluator" />
-    </bean>
-    
-    <bean id="objectAclFactory" class="edu.unc.lib.dl.acl.fcrepo4.ObjectAclFactory"
-            init-method="init">
-        <property name="cacheMaxSize" value="500" />
-        <property name="cacheTimeToLive" value="5000" />
-        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
-    </bean>
-    
-    <bean id="contentPathFactory" class="edu.unc.lib.dl.fedora.ContentPathFactory"
-            init-method="init">
-        <property name="cacheMaxSize" value="200" />
-        <property name="cacheTimeToLive" value="200" />
-        <property name="queryService" ref="sparqlQueryService" />
-    </bean>
 </beans>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2471

* Destroy action deletes original file from external binary location
* Destroy action triggers clearing of destroyed records from search index
* Destroy execution moved to asynchronous job in services-camel
* Adds transfer client method for deleting external binary
* Normalizes file uris from file:/// to file:/ since fedora is doing this internally
* Fills in tests for destroy operations