### PR TITLE
Maven repository fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "oai4solr"]
 	url = https://github.com/UNC-Libraries/oai4solr.git
-	branch = dynamic-set
+	branch = 7.x-1.0
 	path = oai4solr
 [submodule "clamavj"]
 	url = https://github.com/UNC-Libraries/clamavj.git

--- a/pom.xml
+++ b/pom.xml
@@ -493,94 +493,38 @@
             </plugin>
         </plugins>
     </build>
-
+    
     <repositories>
         <repository>
-            <id>maven-central-repository</id>
-            <name>Maven Central Repository</name>
-            <url>http://repo1.maven.org/maven2/</url>
-        </repository>
-        <repository>
-            <id>aduna</id>
-            <name>Aduna software</name>
-            <url>http://repo.aduna-software.org/maven2/releases</url>
+            <id>maven.restlet.org</id>
+            <name>maven.restlet.org</name>
+            <url>https://maven.restlet.talend.com/</url>
+        </repository> 
+    </repositories>
+    
+    <pluginRepositories>
+        <pluginRepository>
+            <id>sonatype-nexus-snapshots</id>
+            <name>Sonatype Nexus Snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
             <releases>
                 <enabled>false</enabled>
             </releases>
             <snapshots>
-                <enabled>false</enabled>
+                <enabled>true</enabled>
             </snapshots>
-        </repository>
-        <repository>
-            <id>java-net-maven2-repository</id>
-            <name>Java.net Maven 2 Repository</name>
-            <url>http://download.java.net/maven/2</url>
-        </repository>
-        <repository>
-            <id>maven-restlet</id>
-            <name>Public online Restlet repository</name>
-            <url>http://maven.restlet.org</url>
-        </repository>
-        <repository>
-            <id>renci-snapshots</id>
-            <name>RENCI Maven repository</name>
-            <url>http://ci-dev.renci.org/nexus/content/repositories/snapshots/</url>
-        </repository>
-        <repository>
-            <id>renci-releases</id>
-            <name>RENCI Maven repository</name>
-            <url>http://ci-dev.renci.org/nexus/content/repositories/releases/</url>
-        </repository>
-        <repository>
-            <id>jboss</id>
-            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+        </pluginRepository>
+    
+        <pluginRepository>
+            <id>sonatype-nexus-staging</id>
+            <name>Nexus Release Repository</name>
+            <url>https://oss.sonatype.org/content/repositories/releases</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
-        </repository>
-        <repository>
-            <id>duraspace-releases</id>
-            <name>DuraSpace Releases Maven Repository</name>
-            <url>http://m2.duraspace.org/content/repositories/releases</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>duraspace-thirdparty</id>
-            <name>Duraspace Thirdparty Maven Repository</name>
-            <url>http://m2.duraspace.org/content/repositories/thirdparty</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>duraspace-snapshots</id>
-            <name>DuraSpace Snapshots Maven Repository</name>
-            <url>http://m2.duraspace.org/content/repositories/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>java-net-maven2-repository</id>
-            <name>Java.net Maven 2 Repository</name>
-            <url>http://download.java.net/maven/2</url>
         </pluginRepository>
     </pluginRepositories>
 

--- a/static/js/vue-cdr-access/tests/unit/worksOnly.spec.js
+++ b/static/js/vue-cdr-access/tests/unit/worksOnly.spec.js
@@ -50,12 +50,12 @@ describe('worksOnly.vue', () => {
         expect(wrapper.vm.$router.currentRoute.query.types).toEqual('Work');
     });
 
-    it("updates route to only show works if button is unchecked for a gallery view", () => {
+    it("updates route to only show works and folders if button is unchecked for a gallery view", () => {
         wrapper.vm.$router.currentRoute.query.browse_type='gallery-display';
         wrapper.setData({ works_only: true });
         record_input.trigger('click');
 
-        expect(wrapper.vm.$router.currentRoute.query.types).toEqual('Work');
+        expect(wrapper.vm.$router.currentRoute.query.types).toEqual('Work,Folder');
     });
 
     it("updates route to only show works if button is checked for a list view", () => {


### PR DESCRIPTION
Maven central seems to have suddenly stopped working with http and the restlet repo appears to have moved. Needed to update the oai4solr plugin