### PR TITLE
BXC-2536 - Use hashed paths for deposit metadata files

### DIFF
--- a/deposit/src/main/java/edu/unc/lib/deposit/normalize/AbstractFileServerToBagJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/normalize/AbstractFileServerToBagJob.java
@@ -236,9 +236,7 @@ public abstract class AbstractFileServerToBagJob extends AbstractDepositJob {
 
         // Persist the MODS file to disk if there were any fields added
         if (!mods.getChildren().isEmpty()) {
-            final File modsFolder = getDescriptionDir();
-            modsFolder.mkdirs();
-            File modsFile = new File(modsFolder, containerPID.getUUID() + ".xml");
+            File modsFile = getModsPath(containerPID, true).toFile();
             try (FileOutputStream fos = new FileOutputStream(modsFile)) {
                 new XMLOutputter(org.jdom2.output.Format.getPrettyFormat()).output(mods.getDocument(), fos);
             } catch (IOException e) {

--- a/deposit/src/main/java/edu/unc/lib/deposit/normalize/CDRMETS2N3BagJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/normalize/CDRMETS2N3BagJob.java
@@ -15,7 +15,6 @@
  */
 package edu.unc.lib.deposit.normalize;
 
-import java.io.File;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -76,13 +75,11 @@ public class CDRMETS2N3BagJob extends AbstractMETS2N3BagJob {
         extractor.addAccessControls(model);
         LOG.info("Extractor access controls added");
 
-        final File modsFolder = getDescriptionDir();
-        modsFolder.mkdir();
         extractor.saveDescriptions(new FilePathFunction() {
         @Override
             public String getPath(String piduri) {
-                String uuid = PIDs.get(piduri).getUUID();
-                return new File(modsFolder, uuid + ".xml").getAbsolutePath();
+                PID pid = PIDs.get(piduri);
+                return getModsPath(pid, true).toAbsolutePath().toString();
             }
         });
         LOG.info("MODS descriptions saved");

--- a/deposit/src/main/java/edu/unc/lib/deposit/normalize/NormalizeFileObjectsJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/normalize/NormalizeFileObjectsJob.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -130,14 +131,14 @@ public class NormalizeFileObjectsJob extends AbstractDepositJob {
     }
 
     private void transferDescription(PID filePid, PID workPid) {
-        File modsFile = new File(getDescriptionDir(), filePid.getUUID() + ".xml");
-        if (modsFile.exists()) {
-            File modsDest = new File(getDescriptionDir(), workPid.getUUID() + ".xml");
+        Path modsFile = getModsPath(filePid);
+        if (Files.exists(modsFile)) {
+            Path modsDest = getModsPath(workPid, true);
             try {
-                Files.move(modsFile.toPath(), modsDest.toPath());
+                Files.move(modsFile, modsDest);
             } catch (IOException e) {
                 failJob(e, "Failed to transfer description file {0} to work at {1}",
-                        modsFile.getAbsolutePath(), modsDest.getAbsolutePath());
+                        modsFile, modsDest);
             }
         }
     }

--- a/deposit/src/main/java/edu/unc/lib/deposit/normalize/VocabularyEnforcementJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/normalize/VocabularyEnforcementJob.java
@@ -84,7 +84,7 @@ public class VocabularyEnforcementJob extends AbstractDepositJob {
 
         for (String resourcePID : resourcePIDs) {
             PID pid = PIDs.get(resourcePID);
-            File modsFile = new File(getDescriptionDir(), pid.getUUID() + ".xml");
+            File modsFile = getModsPath(pid).toFile();
 
             // Check if the resource has a description
             if (modsFile.exists()) {

--- a/deposit/src/main/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJob.java
@@ -27,7 +27,6 @@ import java.io.File;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -147,7 +146,7 @@ public class TransferBinariesToStorageJob extends AbstractDepositJob {
     private void transferFitsExtract(PID objPid, Resource resc, BinaryTransferSession transferSession) {
         if (!resc.hasProperty(CdrDeposit.fitsStorageUri)) {
             PID fitsPid = getTechnicalMetadataPid(objPid);
-            URI stagingUri = Paths.get(getTechMdDirectory().getAbsolutePath(), objPid.getId() + ".xml").toUri();
+            URI stagingUri = getTechMdPath(objPid, false).toUri();
             URI storageUri = transferSession.transfer(fitsPid, stagingUri);
             resc.addLiteral(CdrDeposit.fitsStorageUri, storageUri.toString());
         }

--- a/deposit/src/main/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJob.java
@@ -25,6 +25,7 @@ import static java.util.stream.Collectors.toSet;
 
 import java.io.File;
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashSet;
@@ -133,7 +134,7 @@ public class TransferBinariesToStorageJob extends AbstractDepositJob {
         // add descStorageUri if doesn't already exist. It will exist in a resume scenario.
         if (!resc.hasProperty(CdrDeposit.descriptiveStorageUri)) {
             Path modsPath = getModsPath(objPid);
-            if (modsPath == null) {
+            if (!Files.exists(modsPath)) {
                 return;
             }
 

--- a/deposit/src/main/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJob.java
@@ -25,6 +25,7 @@ import static java.util.stream.Collectors.toSet;
 
 import java.io.File;
 import java.net.URI;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.List;
@@ -131,13 +132,13 @@ public class TransferBinariesToStorageJob extends AbstractDepositJob {
     private void transferModsFile(PID objPid, Resource resc, BinaryTransferSession transferSession) {
         // add descStorageUri if doesn't already exist. It will exist in a resume scenario.
         if (!resc.hasProperty(CdrDeposit.descriptiveStorageUri)) {
-            File modsFile = new File(getDescriptionDir(), objPid.getUUID() + ".xml");
-            if (!modsFile.exists()) {
+            Path modsPath = getModsPath(objPid);
+            if (modsPath == null) {
                 return;
             }
 
             PID originalPid = getMdDescriptivePid(objPid);
-            URI storageUri = transferSession.transferReplaceExisting(originalPid, modsFile.toURI());
+            URI storageUri = transferSession.transferReplaceExisting(originalPid, modsPath.toUri());
             resc.addLiteral(CdrDeposit.descriptiveStorageUri, storageUri.toString());
         }
     }

--- a/deposit/src/main/java/edu/unc/lib/deposit/work/AbstractDepositJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/work/AbstractDepositJob.java
@@ -315,6 +315,10 @@ public abstract class AbstractDepositJob implements Runnable {
         return getMetadataPath(eventsDirectory, pid, ".nt", true).toFile();
     }
 
+    public Path getTechMdPath(PID pid, boolean createDirs) {
+        return getMetadataPath(getTechMdDirectory(), pid, ".xml", createDirs);
+    }
+
     private Path getMetadataPath(File baseDir, PID pid, String extension, boolean createDirs) {
         Path mdBasePath = baseDir.toPath();
 

--- a/deposit/src/main/java/edu/unc/lib/deposit/work/AbstractDepositJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/work/AbstractDepositJob.java
@@ -15,12 +15,16 @@
  */
 package edu.unc.lib.deposit.work;
 
+import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.HASHED_PATH_DEPTH;
+import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.HASHED_PATH_SIZE;
+import static edu.unc.lib.dl.fcrepo4.RepositoryPaths.idToPath;
 import static edu.unc.lib.dl.util.DepositConstants.DESCRIPTION_DIR;
 import static edu.unc.lib.dl.util.DepositConstants.TECHMD_DIR;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.MessageFormat;
 import java.util.AbstractMap.SimpleEntry;
@@ -213,6 +217,27 @@ public abstract class AbstractDepositJob implements Runnable {
 
     public File getDescriptionDir() {
         return new File(getDepositDirectory(), DESCRIPTION_DIR);
+    }
+
+    /**
+     * Get the path to an existing MODS file for the given pid.
+     *
+     * @param pid
+     * @return
+     */
+    protected Path getModsPath(PID pid) {
+        Path descDir = getDescriptionDir().toPath();
+        Path modsPath = descDir.resolve(pid.getId() + ".xml");
+        if (Files.exists(modsPath)) {
+            return modsPath;
+        }
+        String hashing = idToPath(pid.getId(), HASHED_PATH_DEPTH, HASHED_PATH_SIZE);
+        Path hashedPath = modsPath.resolve(hashing).resolve(pid.getId() + ".xml");
+
+        if (Files.exists(hashedPath)) {
+            return hashedPath;
+        }
+        return null;
     }
 
     public File getDepositsDirectory() {

--- a/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJobIT.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJobIT.java
@@ -27,6 +27,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -515,13 +517,10 @@ public class IngestContentObjectsJobIT extends AbstractFedoraDepositJobIT {
 
     @Test
     public void addDescriptionTest() throws Exception {
-        File modsFolder = job.getDescriptionDir();
-        modsFolder.mkdir();
-
         PID folderPid = pidMinter.mintContentPid();
 
-        File modsFile = new File(modsFolder, folderPid.getUUID() + ".xml");
-        modsFile.createNewFile();
+        Path modsPath = job.getModsPath(folderPid, true);
+        Files.createFile(modsPath);
 
         String label = "testfolder";
 
@@ -533,7 +532,7 @@ public class IngestContentObjectsJobIT extends AbstractFedoraDepositJobIT {
         Bag folderBag = model.createBag(folderPid.getRepositoryPath());
         folderBag.addProperty(RDF.type, Cdr.Folder);
         folderBag.addProperty(CdrDeposit.label, label);
-        folderBag.addProperty(CdrDeposit.descriptiveStorageUri, modsFile.toPath().toUri().toString());
+        folderBag.addProperty(CdrDeposit.descriptiveStorageUri, modsPath.toUri().toString());
 
         depBag.add(folderBag);
 
@@ -588,12 +587,9 @@ public class IngestContentObjectsJobIT extends AbstractFedoraDepositJobIT {
 
     @Test
     public void addPremisEventsTest() throws Exception {
-        File premisEventsDir = job.getEventsDirectory();
-        premisEventsDir.mkdir();
-
         PID folderObjPid = pidMinter.mintContentPid();
 
-        File premisEventsFile = new File(premisEventsDir, folderObjPid.getUUID() + ".nt");
+        File premisEventsFile = job.getPremisFile(folderObjPid);
         premisEventsFile.createNewFile();
 
         String label = "testfolder";

--- a/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJobIT.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJobIT.java
@@ -17,7 +17,6 @@ package edu.unc.lib.deposit.fcrepo4;
 
 import static edu.unc.lib.dl.persist.services.storage.StorageLocationTestHelper.LOC1_ID;
 import static edu.unc.lib.dl.test.TestHelpers.setField;
-import static edu.unc.lib.dl.util.DepositConstants.TECHMD_DIR;
 import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -100,8 +99,6 @@ public class IngestContentObjectsJobIT extends AbstractFedoraDepositJobIT {
     private static final String FILE2_MIMETYPE = "text/plain";
     private static final long FILE2_SIZE = 4L;
 
-    private File techmdDir;
-
     @Autowired
     private AccessControlService aclService;
     @Autowired
@@ -149,9 +146,6 @@ public class IngestContentObjectsJobIT extends AbstractFedoraDepositJobIT {
         setupDestination();
 
         FileUtils.copyDirectory(new File("src/test/resources/examples"), depositDir);
-
-        techmdDir = new File(depositDir, TECHMD_DIR);
-        techmdDir.mkdir();
 
         // Create deposit record for this deposit to reference
         depositRecord = repoObjFactory.createDepositRecord(depositPid, null);
@@ -640,7 +634,7 @@ public class IngestContentObjectsJobIT extends AbstractFedoraDepositJobIT {
 
         PID folderObjPid = pidMinter.mintContentPid();
 
-        File premisEventsFile = new File(premisEventsDir, folderObjPid.getUUID() + ".xml");
+        File premisEventsFile = job.getPremisFile(folderObjPid);
         premisEventsFile.createNewFile();
 
         String label = "testfolder";
@@ -714,9 +708,9 @@ public class IngestContentObjectsJobIT extends AbstractFedoraDepositJobIT {
         parent.add(fileResc);
 
         // Create the accompanying fake premis report file
-        File fitsFile = new File(techmdDir, filePid.getUUID() + ".xml");
-        fitsFile.createNewFile();
-        fileResc.addProperty(CdrDeposit.fitsStorageUri, fitsFile.toPath().toUri().toString());
+        Path fitsPath = job.getTechMdPath(filePid, true);
+        Files.createFile(fitsPath);
+        fileResc.addProperty(CdrDeposit.fitsStorageUri, fitsPath.toUri().toString());
 
         return filePid;
     }

--- a/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJobTest.java
@@ -19,7 +19,6 @@ import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.AUTHENTICATED_PRI
 import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.PUBLIC_PRINC;
 import static edu.unc.lib.dl.persist.services.storage.StorageLocationTestHelper.LOC1_ID;
 import static edu.unc.lib.dl.test.TestHelpers.setField;
-import static edu.unc.lib.dl.util.DepositConstants.TECHMD_DIR;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyCollectionOf;
@@ -34,6 +33,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -158,7 +158,6 @@ public class IngestContentObjectsJobTest extends AbstractDepositJobTest {
     @Captor
     private ArgumentCaptor<Model> modelCaptor;
 
-    private File techmdDir;
     private Path storageLocPath;
 
     @Mock
@@ -195,9 +194,6 @@ public class IngestContentObjectsJobTest extends AbstractDepositJobTest {
         setupDestination();
 
         FileUtils.copyDirectory(new File("src/test/resources/examples"), depositDir);
-
-        techmdDir = new File(depositDir, TECHMD_DIR);
-        techmdDir.mkdir();
 
         storageLocPath = tmpFolder.newFolder("storageLoc").toPath();
 
@@ -654,9 +650,9 @@ public class IngestContentObjectsJobTest extends AbstractDepositJobTest {
         parent.add(fileResc);
 
         // Create the accompanying fake FITS report file
-        File fitsFile = new File(techmdDir, filePid.getUUID() + ".xml");
-        fitsFile.createNewFile();
-        fileResc.addProperty(CdrDeposit.fitsStorageUri, fitsFile.toPath().toUri().toString());
+        Path fitsPath = job.getTechMdPath(filePid, true);
+        Files.createFile(fitsPath);
+        fileResc.addProperty(CdrDeposit.fitsStorageUri, fitsPath.toUri().toString());
 
         return filePid;
     }

--- a/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/IngestDepositRecordJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/IngestDepositRecordJobTest.java
@@ -57,7 +57,6 @@ import edu.unc.lib.dl.persist.api.transfer.BinaryTransferService;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferSession;
 import edu.unc.lib.dl.rdf.Cdr;
 import edu.unc.lib.dl.rdf.CdrDeposit;
-import edu.unc.lib.dl.util.DepositConstants;
 import edu.unc.lib.dl.util.PackagingType;
 import edu.unc.lib.dl.util.RedisWorkerConstants.DepositField;
 
@@ -111,10 +110,6 @@ public class IngestDepositRecordJobTest extends AbstractDepositJobTest {
         depositDir.mkdir();
         FileUtils.copyDirectory(new File(packagePath), depositDir);
 
-        File eventsDir = new File(depositDir, DepositConstants.EVENTS_DIR);
-        eventsDir.mkdir();
-        FileUtils.writeStringToFile(new File(eventsDir, depositPid.getUUID() + ".nt"), "loggin", "UTF-8");
-
         Dataset dataset = TDBFactory.createDataset();
 
         job = new IngestDepositRecordJob();
@@ -129,6 +124,8 @@ public class IngestDepositRecordJobTest extends AbstractDepositJobTest {
         setField(job, "locationManager", storageLocationManager);
 
         job.init();
+
+        FileUtils.writeStringToFile(job.getPremisFile(depositPid), "loggin", "UTF-8");
 
         Model model = job.getWritableModel();
         model.read(new File(n3File).getAbsolutePath());

--- a/deposit/src/test/java/edu/unc/lib/deposit/normalize/BagIt2N3BagJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/normalize/BagIt2N3BagJobTest.java
@@ -128,7 +128,7 @@ public class BagIt2N3BagJobTest extends AbstractNormalizationJobTest {
                 sourceUri.toString() + "data/test/ipsum.txt");
 
         // Verify that the description file for the bag exists
-        File modsFile = new File(job.getDescriptionDir(), PIDs.get(bagFolder.getURI()).getUUID() + ".xml");
+        File modsFile = job.getModsPath(PIDs.get(bagFolder.getURI())).toFile();
         assertTrue(modsFile.exists());
 
         Set<String> cleanupSet = new HashSet<>();

--- a/deposit/src/test/java/edu/unc/lib/deposit/normalize/NormalizeFileObjectsJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/normalize/NormalizeFileObjectsJobTest.java
@@ -195,8 +195,7 @@ public class NormalizeFileObjectsJobTest extends AbstractDepositJobTest {
         Resource childResc = addFileObject(folderBag);
         PID childPid = PIDs.get(childResc.getURI());
 
-        job.getDescriptionDir().mkdir();
-        File childModsFile = new File(job.getDescriptionDir(), childPid.getUUID() + ".xml");
+        File childModsFile = job.getModsPath(childPid, true).toFile();
         childModsFile.createNewFile();
 
         job.closeModel();
@@ -209,7 +208,7 @@ public class NormalizeFileObjectsJobTest extends AbstractDepositJobTest {
 
         // Verify that the MODS file was renamed to match work uuid
         PID workPid = PIDs.get(workResc.getURI());
-        File workModsFile = new File(job.getDescriptionDir(), workPid.getUUID() + ".xml");
+        File workModsFile = job.getModsPath(workPid).toFile();
 
         assertTrue(workModsFile.exists());
         assertFalse(childModsFile.exists());

--- a/deposit/src/test/java/edu/unc/lib/deposit/validate/ExtractTechnicalMetadataJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/validate/ExtractTechnicalMetadataJobTest.java
@@ -30,6 +30,8 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.apache.commons.httpclient.HttpStatus;
@@ -262,8 +264,8 @@ public class ExtractTechnicalMetadataJobTest extends AbstractDepositJobTest {
 
         techmdDir.mkdir();
         PID skippedPid = addFileObject(depositBag, "/skipped/object.jpg", null, null);
-        File skippedFile = new File(techmdDir, skippedPid.getUUID() + ".xml");
-        skippedFile.createNewFile();
+        Path skippedPath = job.getTechMdPath(skippedPid, true);
+        Files.createFile(skippedPath);
 
         PID filePid = addFileObject(depositBag, IMAGE_FILEPATH, null, null);
 
@@ -309,7 +311,7 @@ public class ExtractTechnicalMetadataJobTest extends AbstractDepositJobTest {
         assertEquals("Incorrect number of reports in output dir",
                 numberReports, techmdDir.list().length);
 
-        File reportFile = new File(techmdDir, filePid.getUUID() + ".xml");
+        File reportFile = job.getTechMdPath(filePid, false).toFile();
         assertTrue("Report file not created", reportFile.exists());
 
         Document premisDoc = new SAXBuilder().build(new FileInputStream(reportFile));

--- a/deposit/src/test/java/edu/unc/lib/deposit/validate/ValidateDescriptionJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/validate/ValidateDescriptionJobTest.java
@@ -68,18 +68,16 @@ public class ValidateDescriptionJobTest extends AbstractDepositJobTest {
         setField(job, "jobStatusFactory", jobStatusFactory);
         job.setModsValidator(modsValidator);
         job.init();
-
-        job.getDescriptionDir().mkdir();
     }
 
     @Test
     public void testNoDescriptions() {
-        job.getDescriptionDir().delete();
         job.run();
     }
 
     @Test
     public void testNoFiles() {
+        job.getDescriptionDir().mkdir();
         job.run();
     }
 
@@ -154,12 +152,12 @@ public class ValidateDescriptionJobTest extends AbstractDepositJobTest {
 
     private PID makeDescriptionFile() throws IOException {
         PID pid = makePid();
-        File descriptFile = getDescriptionFile(pid);
+        File descriptFile = job.getModsPath(pid, true).toFile();
         Files.createFile(descriptFile.toPath());
         return pid;
     }
 
     private File getDescriptionFile(PID pid) {
-        return new File(job.getDescriptionDir(), pid.getUUID() + ".xml");
+        return job.getModsPath(pid).toFile();
     }
 }


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2536

* PREMIS, MODS and FITS metadata files are now stored to and retrieved from hashed directories during deposit.
* Consolidated path generation for these files into common helper methods