### PR TITLE
Assign a storage location to newly created containers

### DIFF
--- a/services/src/main/webapp/WEB-INF/service-context.xml
+++ b/services/src/main/webapp/WEB-INF/service-context.xml
@@ -219,6 +219,7 @@
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
         <property name="transactionManager" ref="transactionManager" />
         <property name="operationsMessageSender" ref="operationsMessageSender" />
+        <property name="storageLocationManager" ref="storageLocationManager" />
     </bean>
     
     <bean id="editLabelService" class="edu.unc.lib.dl.persist.services.edit.EditLabelService">

--- a/services/src/test/resources/add-container-it-servlet.xml
+++ b/services/src/test/resources/add-container-it-servlet.xml
@@ -39,6 +39,7 @@
         <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
         <property name="transactionManager" ref="transactionManager" />
         <property name="operationsMessageSender" ref="operationsMessageSender" />
+        <property name="storageLocationManager" ref="storageLocationManager" />
     </bean>
 
     <bean id="patronService" class="edu.unc.lib.dl.persist.services.acl.PatronAccessAssignmentService">


### PR DESCRIPTION
Fixes a bug that was preventing containers from being created due to trying to look up their storage location before they were fully ingested.