### PR TITLE
BXC-2541 - Submit Migration Deposits

### DIFF
--- a/deposit/src/main/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJob.java
@@ -328,6 +328,7 @@ public class IngestContentObjectsJob extends AbstractDepositJob {
      */
     private FileObject addFileToWork(WorkObject work, Resource childResc)
             throws DepositException {
+        log.debug("Adding file {} to work {}", childResc, work.getPid());
         PID childPid = PIDs.get(childResc.getURI());
 
         URI storageUri = URI.create(getPropertyValue(childResc, CdrDeposit.storageUri));

--- a/metadata/src/main/java/edu/unc/lib/dl/util/DepositMethod.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/util/DepositMethod.java
@@ -21,9 +21,13 @@ package edu.unc.lib.dl.util;
  *
  */
 public enum DepositMethod {
-    Unspecified("Unspecified Method"), WebForm("CDR Web Form"), SWORD13(
-            "SWORD 1.3"), SWORD20("SWORD 2.0"), CDRAPI1("CDR API 1.0"), CDRCollector(
-            "CDR Collector 1.0");
+    Unspecified("Unspecified Method"),
+    WebForm("CDR Web Form"),
+    SWORD13("SWORD 1.3"),
+    SWORD20("SWORD 2.0"),
+    CDRAPI1("CDR API 1.0"),
+    CDRCollector("CDR Collector 1.0"),
+    BXC3_TO_5_MIGRATION_UTIL("BXC3 To BXC5 Migration Utility");
 
     private String label;
 

--- a/metadata/src/main/java/edu/unc/lib/dl/util/PackagingType.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/util/PackagingType.java
@@ -30,8 +30,7 @@ public enum PackagingType {
     ATOM("http://purl.org/net/sword/terms/Atom"),
     BAG_WITH_N3("http://cdr.unc.edu/BAGIT/profiles/N3"),
     BAGIT("http://purl.org/net/sword/package/BagIt"),
-    DIRECTORY("http://cdr.unc.edu/DirectoryIngest"),
-    PRECONSTRUCTED_DEPOSIT("http://cdr.unc.edu/package/PreconstructedDeposit");
+    DIRECTORY("http://cdr.unc.edu/DirectoryIngest");
 
     private String uri;
 

--- a/metadata/src/main/java/edu/unc/lib/dl/util/PackagingType.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/util/PackagingType.java
@@ -30,7 +30,8 @@ public enum PackagingType {
     ATOM("http://purl.org/net/sword/terms/Atom"),
     BAG_WITH_N3("http://cdr.unc.edu/BAGIT/profiles/N3"),
     BAGIT("http://purl.org/net/sword/package/BagIt"),
-    DIRECTORY("http://cdr.unc.edu/DirectoryIngest");
+    DIRECTORY("http://cdr.unc.edu/DirectoryIngest"),
+    PRECONSTRUCTED_DEPOSIT("http://cdr.unc.edu/package/PreconstructedDeposit");
 
     private String uri;
 

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/BannerUtility.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/BannerUtility.java
@@ -16,14 +16,12 @@
 package edu.unc.lib.dcr.migration;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.commons.io.FileUtils.readFileToString;
 import static org.slf4j.LoggerFactory.getLogger;
 
-import java.io.File;
 import java.io.IOException;
-import java.net.URISyntaxException;
-import java.net.URL;
+import java.io.InputStream;
 
+import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 
 /**
@@ -52,11 +50,10 @@ public class BannerUtility {
     }
 
     private static String loadFile(String rescPath) {
-        URL fileUrl = BannerUtility.class.getResource("/classes/" + rescPath);
+        InputStream stream = BannerUtility.class.getResourceAsStream("/" + rescPath);
         try {
-            File file = new File(fileUrl.toURI());
-            return readFileToString(file, UTF_8);
-        } catch (IOException | URISyntaxException e) {
+            return IOUtils.toString(stream, UTF_8);
+        } catch (IOException e) {
             log.error("Failed to load banner", e);
             return "";
         }

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/MigrationCLI.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/MigrationCLI.java
@@ -57,6 +57,27 @@ public class MigrationCLI implements Callable<Integer> {
             description = "Path where deposit directories will be stored. Defaults to home dir.")
     protected Path depositBaseDir;
 
+    @Option(names = {"-u", "--username"},
+            defaultValue = "${sys:user.name}",
+            description = "User performing this action. Defaults to current user.")
+    protected String username;
+
+    @Option(names = {"--groups"},
+            defaultValue = "unc:app:lib:cdr:migrationGroup",
+            description = "Groups used for permissions evaluations. Defaults to the migration group.")
+    protected String groups;
+
+    @Option(names = {"--redis-host"},
+            defaultValue = "localhost",
+            description = "Host name for redis. Default localhost.")
+    protected String redisHost;
+
+    @Option(names = {"--redis-port"},
+            defaultValue = "6379",
+            description = "Port for redis. Default 6379.")
+    protected int redisPort;
+>>>>>>> Add command for submitting deposit to deposit pipeline, and flag for immediately sending transformed deposits to pipeline
+
     private MigrationCLI() {
     }
 

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/MigrationCLI.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/MigrationCLI.java
@@ -37,7 +37,8 @@ import picocli.CommandLine.Option;
         TransformPremis.class,
         PathIndexCommand.class,
         TransformContentCommand.class,
-        ViewDepositModelCommand.class
+        ViewDepositModelCommand.class,
+        SubmitDepositCommand.class
     })
 public class MigrationCLI implements Callable<Integer> {
     private static final Logger output = getLogger(OUTPUT_LOGGER);

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/MigrationCLI.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/MigrationCLI.java
@@ -54,7 +54,7 @@ public class MigrationCLI implements Callable<Integer> {
     protected String tdbDir;
 
     @Option(names = {"--deposit-dir"},
-            defaultValue = "${sys:dcr.migration.index.url:-${sys:user.home}/bxc_deposits",
+            defaultValue = "${sys:dcr.deposit.dir:-${sys:user.home}/bxc_deposits",
             description = "Path where deposit directories will be stored. Defaults to home dir.")
     protected Path depositBaseDir;
 

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/MigrationCLI.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/MigrationCLI.java
@@ -77,7 +77,6 @@ public class MigrationCLI implements Callable<Integer> {
             defaultValue = "6379",
             description = "Port for redis. Default 6379.")
     protected int redisPort;
->>>>>>> Add command for submitting deposit to deposit pipeline, and flag for immediately sending transformed deposits to pipeline
 
     private MigrationCLI() {
     }

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/SubmitDepositCommand.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/SubmitDepositCommand.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dcr.migration;
+
+import static edu.unc.lib.dcr.migration.MigrationConstants.OUTPUT_LOGGER;
+import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.DEPOSIT_RECORD_BASE;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.util.concurrent.Callable;
+
+import org.slf4j.Logger;
+
+import edu.unc.lib.dcr.migration.deposit.DepositSubmissionService;
+import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fedora.PID;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.ParentCommand;
+
+/**
+ * Command for submitting existing deposits
+ *
+ * @author bbpennel
+ */
+@Command(name = "submit_deposit", aliases = {"sd"},
+        description = "Submit preconstructed deposits for ingest")
+public class SubmitDepositCommand implements Callable<Integer> {
+
+    private static final Logger output = getLogger(OUTPUT_LOGGER);
+
+    @ParentCommand
+    private MigrationCLI parentCommand;
+
+    @Parameters(index = "0",
+            description = "UUID of the deposit to submit")
+    private String depositId;
+
+    @Parameters(index = "1",
+            description = "UUID of the container into which the deposit will be ingest")
+    private String destinationId;
+
+    @Override
+    public Integer call() throws Exception {
+        output.info(BannerUtility.getBanner());
+
+        DepositSubmissionService depositService = new DepositSubmissionService(
+                parentCommand.redisHost, parentCommand.redisPort);
+
+        PID depositPid = PIDs.get(DEPOSIT_RECORD_BASE, depositId);
+        PID destinationPid = PIDs.get(destinationId);
+
+        output.info("Submitting {} for deposit to {}", depositPid.getQualifiedId(), destinationPid.getId());
+
+        int result = depositService.submitDeposit(parentCommand.username, parentCommand.groups,
+                depositPid, destinationPid);
+
+        output.info("Deposit submitted");
+
+        return result;
+    }
+}

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/TransformContentCommand.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/TransformContentCommand.java
@@ -92,8 +92,10 @@ public class TransformContentCommand implements Callable<Integer> {
         transformerManager.setPidMinter(pidMinter);
         transformerManager.setDirectoryManager(depositDirectoryManager);
 
-        ContentTransformationService transformService = new ContentTransformationService(startingId, topLevelAsUnit);
+        ContentTransformationService transformService = new ContentTransformationService(
+                depositPid, startingId, topLevelAsUnit);
         transformService.setTransformerManager(transformerManager);
+        transformService.setModelManager(depositModelManager);
 
         int result = transformService.perform();
 

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/TransformContentCommand.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/TransformContentCommand.java
@@ -62,6 +62,10 @@ public class TransformContentCommand implements Callable<Integer> {
             description = "Nest transformed logs in hashed subdirectories. Default: true")
     private boolean hashNesting = true;
 
+    @Option(names = {"-g", "--generate-ids"},
+            description = "Generate new ids for transformed objects, for testing.")
+    private boolean generateIds;
+
     @Option(names = {"--deposit-into"},
             description = "Submits the transformed content for deposit to the provided container UUID")
     private String depositInto;
@@ -91,6 +95,7 @@ public class TransformContentCommand implements Callable<Integer> {
         transformerManager.setTopLevelAsUnit(topLevelAsUnit);
         transformerManager.setPidMinter(pidMinter);
         transformerManager.setDirectoryManager(depositDirectoryManager);
+        transformerManager.setGenerateIds(generateIds);
 
         ContentTransformationService transformService = new ContentTransformationService(
                 depositPid, startingId, topLevelAsUnit);

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformer.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformer.java
@@ -297,17 +297,17 @@ public class ContentObjectTransformer extends RecursiveAction {
     }
 
     private void extractMods(Document foxml) {
-        log.info("Checking for MODS {}", pid);
+        log.info("Checking for MODS {}", originalPid);
         List<DatastreamVersion> modsVersions = listDatastreamVersions(foxml, MODS_DS);
         if (modsVersions == null || modsVersions.isEmpty()) {
-            log.debug("No MODS for {}" , pid);
+            log.debug("No MODS for {}" , originalPid);
             return;
         }
 
-        log.info("Found mods for {}", pid);
+        log.info("Found mods for {}", originalPid);
 
         DatastreamVersion current = modsVersions.get(modsVersions.size() - 1);
-        directoryManager.writeMods(pid, current.getBodyEl());
+        directoryManager.writeMods(newPid, current.getBodyEl());
     }
 
     private boolean isMarkedForDeletion(Resource resc) {

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformer.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformer.java
@@ -168,7 +168,7 @@ public class ContentObjectTransformer extends RecursiveAction {
     }
 
     private void populateContainerObject(Resource bxc3Resc, Resource resourceType, Model depositModel) {
-        Bag containerBag = depositModel.getBag(pid.getRepositoryPath());
+        Bag containerBag = depositModel.createBag(pid.getRepositoryPath());
         containerBag.addProperty(RDF.type, resourceType);
 
         List<PID> contained = listContained(bxc3Resc);
@@ -207,7 +207,7 @@ public class ContentObjectTransformer extends RecursiveAction {
             fileResc = depositModel.getResource(pid.getRepositoryPath());
         } else {
             // Use the pid of the current object to make a new work object
-            workBag = depositModel.getBag(pid.getRepositoryPath());
+            workBag = depositModel.createBag(pid.getRepositoryPath());
             workBag.addProperty(RDF.type, Cdr.Work);
 
             // Build a new resource for the file object

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformerManager.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformerManager.java
@@ -60,11 +60,14 @@ public class ContentObjectTransformerManager {
      *
      * @param originalPid
      * @param newPid
+     * @param parentPid
      * @param parentType
      * @return
      */
-    public ContentObjectTransformer createTransformer(PID originalPid, PID newPid, Resource parentType) {
-        ContentObjectTransformer transformer = new ContentObjectTransformer(originalPid, newPid, parentType);
+    public ContentObjectTransformer createTransformer(PID originalPid, PID newPid, PID parentPid,
+            Resource parentType) {
+        ContentObjectTransformer transformer = new ContentObjectTransformer(
+                originalPid, newPid, parentPid, parentType);
         transformer.setModelManager(modelManager);
         transformer.setPathIndex(pathIndex);
         transformer.setTopLevelAsUnit(topLevelAsUnit);

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformerManager.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformerManager.java
@@ -43,6 +43,7 @@ public class ContentObjectTransformerManager {
     private PathIndex pathIndex;
     private DepositModelManager modelManager;
     private boolean topLevelAsUnit;
+    private boolean generateIds;
     private RepositoryPIDMinter pidMinter;
     private DepositDirectoryManager directoryManager;
 
@@ -57,12 +58,13 @@ public class ContentObjectTransformerManager {
     /**
      * Construct a new content object transformer
      *
-     * @param pid
+     * @param originalPid
+     * @param newPid
      * @param parentType
      * @return
      */
-    public ContentObjectTransformer createTransformer(PID pid, Resource parentType) {
-        ContentObjectTransformer transformer = new ContentObjectTransformer(pid, parentType);
+    public ContentObjectTransformer createTransformer(PID originalPid, PID newPid, Resource parentType) {
+        ContentObjectTransformer transformer = new ContentObjectTransformer(originalPid, newPid, parentType);
         transformer.setModelManager(modelManager);
         transformer.setPathIndex(pathIndex);
         transformer.setTopLevelAsUnit(topLevelAsUnit);
@@ -99,6 +101,10 @@ public class ContentObjectTransformerManager {
         } while (true);
     }
 
+    public PID getTransformedPid(PID originalPid) {
+        return generateIds ? pidMinter.mintContentPid() : originalPid;
+    }
+
     public void setPathIndex(PathIndex pathIndex) {
         this.pathIndex = pathIndex;
     }
@@ -117,5 +123,9 @@ public class ContentObjectTransformerManager {
 
     public void setDirectoryManager(DepositDirectoryManager directoryManager) {
         this.directoryManager = directoryManager;
+    }
+
+    public void setGenerateIds(boolean generateIds) {
+        this.generateIds = generateIds;
     }
 }

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentTransformationService.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentTransformationService.java
@@ -48,14 +48,18 @@ public class ContentTransformationService {
      * @return result code
      */
     public int perform() {
+        // Determine transformed id of starting object
+        PID newPid = transformerManager.getTransformedPid(startingPid);
+
         // Populate the bag for the deposit itself
         Model depositObjModel = createDefaultModel();
         Bag depResc = depositObjModel.createBag(depositPid.getRepositoryPath());
-        depResc.add(createResource(startingPid.getRepositoryPath()));
+        depResc.add(createResource(newPid.getRepositoryPath()));
         modelManager.addTriples(depositObjModel);
 
         // Kick off transformation of the tree from the starting object
-        transformerManager.createTransformer(startingPid, null)
+
+        transformerManager.createTransformer(startingPid, newPid, null)
                 .fork();
 
         // Wait for all transformers to finish

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentTransformationService.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentTransformationService.java
@@ -16,9 +16,7 @@
 package edu.unc.lib.dcr.migration.content;
 
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
-import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 
-import org.apache.jena.rdf.model.Bag;
 import org.apache.jena.rdf.model.Model;
 
 import edu.unc.lib.dcr.migration.deposit.DepositModelManager;
@@ -53,12 +51,11 @@ public class ContentTransformationService {
 
         // Populate the bag for the deposit itself
         Model depositObjModel = createDefaultModel();
-        Bag depResc = depositObjModel.createBag(depositPid.getRepositoryPath());
-        depResc.add(createResource(newPid.getRepositoryPath()));
+        depositObjModel.createBag(depositPid.getRepositoryPath());
         modelManager.addTriples(depositObjModel);
 
         // Kick off transformation of the tree from the starting object
-        transformerManager.createTransformer(startingPid, newPid, null)
+        transformerManager.createTransformer(startingPid, newPid, depositPid, null)
                 .fork();
 
         // Wait for all transformers to finish

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentTransformationService.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentTransformationService.java
@@ -58,7 +58,6 @@ public class ContentTransformationService {
         modelManager.addTriples(depositObjModel);
 
         // Kick off transformation of the tree from the starting object
-
         transformerManager.createTransformer(startingPid, newPid, null)
                 .fork();
 

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/deposit/DepositModelManager.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/deposit/DepositModelManager.java
@@ -25,7 +25,9 @@ import java.nio.file.Paths;
 
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.ReadWrite;
+import org.apache.jena.rdf.model.Bag;
 import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,8 +88,28 @@ public class DepositModelManager {
      * @param model
      */
     public synchronized void addTriples(Model model) {
+        addTriples(model, null, null);
+    }
+
+    /**
+     * Add triples from the provided model to the deposit model, inserting the
+     * new resource as the child of the provided parent
+     *
+     * @param model
+     * @param newPid
+     * @param parentPid
+     */
+    public synchronized void addTriples(Model model, PID newPid, PID parentPid) {
         Model depositModel = getWriteModel();
         try {
+            // Insert reference from parent to new resource
+            if (newPid != null && parentPid != null) {
+                Resource newResc = model.getResource(newPid.getRepositoryPath());
+                Bag parentBag = depositModel.getBag(parentPid.getRepositoryPath());
+
+                parentBag.add(newResc);
+            }
+
             log.debug("Adding triples to deposit model: {}", model);
             depositModel.add(model);
             dataset.commit();

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/deposit/DepositSubmissionService.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/deposit/DepositSubmissionService.java
@@ -16,7 +16,7 @@
 package edu.unc.lib.dcr.migration.deposit;
 
 import static edu.unc.lib.dl.util.DepositMethod.BXC3_TO_5_MIGRATION_UTIL;
-import static edu.unc.lib.dl.util.PackagingType.PRECONSTRUCTED_DEPOSIT;
+import static edu.unc.lib.dl.util.PackagingType.BAG_WITH_N3;
 
 import edu.unc.lib.dl.acl.util.AccessGroupSet;
 import edu.unc.lib.dl.acl.util.AgentPrincipals;
@@ -64,7 +64,7 @@ public class DepositSubmissionService {
     public int submitDeposit(String depositorName, String depositorGroup, PID depositPid, PID destination) {
         AgentPrincipals principals = new AgentPrincipals(depositorName, new AccessGroupSet(depositorGroup));
 
-        DepositData depositData = new DepositData(null, null, PRECONSTRUCTED_DEPOSIT,
+        DepositData depositData = new DepositData(null, null, BAG_WITH_N3,
                 BXC3_TO_5_MIGRATION_UTIL.getLabel(), principals);
         depositData.setDepositorEmail(depositorName + EMAIL_SUFFIX);
 

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/deposit/DepositSubmissionService.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/deposit/DepositSubmissionService.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dcr.migration.deposit;
+
+import static edu.unc.lib.dl.util.DepositMethod.BXC3_TO_5_MIGRATION_UTIL;
+import static edu.unc.lib.dl.util.PackagingType.PRECONSTRUCTED_DEPOSIT;
+
+import edu.unc.lib.dl.acl.util.AccessGroupSet;
+import edu.unc.lib.dl.acl.util.AgentPrincipals;
+import edu.unc.lib.dl.exceptions.RepositoryException;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.persist.api.ingest.DepositData;
+import edu.unc.lib.dl.persist.services.ingest.PreconstructedDepositHandler;
+import edu.unc.lib.dl.util.DepositException;
+import edu.unc.lib.dl.util.DepositStatusFactory;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
+
+/**
+ * Service which submits a preconstructed deposit for ingestion
+ *
+ * @author bbpennel
+ */
+public class DepositSubmissionService {
+
+    protected static final String EMAIL_SUFFIX = "@ad.unc.edu";
+
+    private DepositStatusFactory depositStatusFactory;
+
+    public DepositSubmissionService(String redisHost, int redisPort) {
+        JedisPoolConfig jedisPoolConfig = new JedisPoolConfig();
+        jedisPoolConfig.setMaxIdle(15);
+        jedisPoolConfig.setMaxTotal(25);
+        jedisPoolConfig.setMinIdle(2);
+
+        JedisPool jedisPool = new JedisPool(jedisPoolConfig, redisHost, redisPort);
+
+        depositStatusFactory = new DepositStatusFactory();
+        depositStatusFactory.setJedisPool(jedisPool);
+    }
+
+    /**
+     * Submits the deposit with the given pid for deposit into the specified destination.
+     *
+     * @param depositorName name of the user performing the deposit
+     * @param depositorGroup Group(s) the user belongs to
+     * @param depositPid pid of the deposit to submit
+     * @param destination pid of the destination object
+     * @return result code
+     */
+    public int submitDeposit(String depositorName, String depositorGroup, PID depositPid, PID destination) {
+        AgentPrincipals principals = new AgentPrincipals(depositorName, new AccessGroupSet(depositorGroup));
+
+        DepositData depositData = new DepositData(null, null, PRECONSTRUCTED_DEPOSIT,
+                BXC3_TO_5_MIGRATION_UTIL.getLabel(), principals);
+        depositData.setDepositorEmail(depositorName + EMAIL_SUFFIX);
+
+        PreconstructedDepositHandler depositHandler = new PreconstructedDepositHandler(depositPid);
+        depositHandler.setDepositStatusFactory(depositStatusFactory);
+        try {
+            depositHandler.doDeposit(destination, depositData);
+        } catch (DepositException e) {
+            throw new RepositoryException("Failed to submit deposit", e);
+        }
+
+        return 0;
+    }
+
+    public void setDepositStatusFactory(DepositStatusFactory depositStatusFactory) {
+        this.depositStatusFactory = depositStatusFactory;
+    }
+}

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/fcrepo3/DatastreamVersion.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/fcrepo3/DatastreamVersion.java
@@ -30,6 +30,7 @@ public class DatastreamVersion {
     private String created;
     private String size;
     private String mimeType;
+    private String altIds;
     private Element bodyEl;
 
     /**
@@ -43,13 +44,14 @@ public class DatastreamVersion {
      * @param mimeType
      */
     public DatastreamVersion(String md5, String dsName, String versionName, String created,
-            String size, String mimeType) {
+            String size, String mimeType, String altIds) {
         this.md5 = md5;
         this.dsName = dsName;
         this.versionName = versionName;
         this.created = created;
         this.size = size;
         this.mimeType = mimeType;
+        this.altIds = altIds;
     }
 
     /**
@@ -92,6 +94,14 @@ public class DatastreamVersion {
      */
     public String getMimeType() {
         return mimeType;
+    }
+
+    public String getAltIds() {
+        return altIds;
+    }
+
+    public void setAltIds(String altIds) {
+        this.altIds = altIds;
     }
 
     /**

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/fcrepo3/FoxmlDocumentHelpers.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/fcrepo3/FoxmlDocumentHelpers.java
@@ -155,8 +155,10 @@ public class FoxmlDocumentHelpers {
             String created = dsvEl.getAttributeValue("CREATED");
             Element digestEl = dsvEl.getChild("contentDigest", FOXML_NS);
             String md5 = digestEl == null ? null : digestEl.getAttributeValue("DIGEST");
+            String altIds = dsvEl.getAttributeValue("ALT_IDS");
 
-            DatastreamVersion dsVersion = new DatastreamVersion(md5, name, versionName, created, size, mimeType);
+            DatastreamVersion dsVersion = new DatastreamVersion(md5, name, versionName,
+                    created, size, mimeType, altIds);
 
             Element bodyEl = dsvEl.getChild("xmlContent", FOXML_NS);
             if (bodyEl != null) {

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/paths/PathIndex.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/paths/PathIndex.java
@@ -124,7 +124,11 @@ public class PathIndex {
                     }
                 }
             }
-            return Paths.get(highestMatch);
+            if (highestMatch == null) {
+                return null;
+            } else {
+                return Paths.get(highestMatch);
+            }
         } catch (SQLException e) {
             throw new RepositoryException("Failed to look up path for " + pid, e);
         }

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/paths/PathIndex.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/paths/PathIndex.java
@@ -36,6 +36,8 @@ import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 import org.h2.tools.DeleteDbFiles;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import edu.unc.lib.dl.exceptions.RepositoryException;
 import edu.unc.lib.dl.fedora.PID;
@@ -46,6 +48,8 @@ import edu.unc.lib.dl.fedora.PID;
  * @author bbpennel
  */
 public class PathIndex {
+
+    private static final Logger log = LoggerFactory.getLogger(PathIndex.class);
 
     public static final int OBJECT_TYPE = 0;
     public static final int ORIGINAL_TYPE = 1;
@@ -74,6 +78,7 @@ public class PathIndex {
      */
     public Connection getConnection() throws SQLException {
         if (connection == null || connection.isClosed()) {
+            log.info("Opening path index connection to {}", "jdbc:h2:" + databaseUrl);
             connection = DriverManager.getConnection("jdbc:h2:" + databaseUrl, "test", "test");
         }
         return connection;

--- a/migration-util/src/test/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformerTest.java
+++ b/migration-util/src/test/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformerTest.java
@@ -26,12 +26,14 @@ import static edu.unc.lib.dcr.migration.fcrepo3.ContentModelHelper.FedoraPropert
 import static edu.unc.lib.dcr.migration.fcrepo3.ContentModelHelper.Relationship.contains;
 import static edu.unc.lib.dcr.migration.fcrepo3.FoxmlDocumentBuilder.DEFAULT_CREATED_DATE;
 import static edu.unc.lib.dcr.migration.fcrepo3.FoxmlDocumentBuilder.DEFAULT_LAST_MODIFIED;
+import static edu.unc.lib.dcr.migration.fcrepo3.FoxmlDocumentHelpers.DC_DS;
 import static edu.unc.lib.dcr.migration.fcrepo3.FoxmlDocumentHelpers.MODS_DS;
 import static edu.unc.lib.dcr.migration.fcrepo3.FoxmlDocumentHelpers.ORIGINAL_DS;
 import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.MODS_V3_NS;
 import static edu.unc.lib.dl.xml.SecureXMLFactory.createSAXBuilder;
 import static java.nio.file.Files.newOutputStream;
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
+import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -93,7 +95,11 @@ public class ContentObjectTransformerTest {
 
     private PID depositPid;
 
-    private ContentObjectTransformerManager factory;
+    private PID startingPid;
+
+    private ContentObjectTransformerManager manager;
+
+    private ContentTransformationService service;
 
     private DepositModelManager modelManager;
 
@@ -115,38 +121,42 @@ public class ContentObjectTransformerTest {
 
         pidMinter = new RepositoryPIDMinter();
 
+        startingPid = pidMinter.mintContentPid();
+
         depositPid = pidMinter.mintDepositRecordPid();
         modelManager = new DepositModelManager(depositPid, tdbDir.toString());
         directoryManager = new DepositDirectoryManager(depositPid, depositBasePath, false);
 
-        factory = new ContentObjectTransformerManager();
-        factory.setPathIndex(pathIndex);
-        factory.setModelManager(modelManager);
-        factory.setPidMinter(pidMinter);
-        factory.setTopLevelAsUnit(true);
-        factory.setDirectoryManager(directoryManager);
+        manager = new ContentObjectTransformerManager();
+        manager.setPathIndex(pathIndex);
+        manager.setModelManager(modelManager);
+        manager.setPidMinter(pidMinter);
+        manager.setTopLevelAsUnit(true);
+        manager.setDirectoryManager(directoryManager);
+
+        service = new ContentTransformationService(depositPid, startingPid.getId(), true);
+        service.setModelManager(modelManager);
+        service.setTransformerManager(manager);
     }
 
     @Test
     public void transformFolderWithNoChildren() throws Exception {
-        PID folderPid = makePid();
+        Model model = createContainerModel(startingPid);
 
-        Model model = createContainerModel(folderPid);
-
-        Document foxml = new FoxmlDocumentBuilder(folderPid, "folder")
+        Document foxml = new FoxmlDocumentBuilder(startingPid, "folder")
                 .relsExtModel(model)
                 .build();
-        serializeFoxml(objectsPath, folderPid, foxml);
+        serializeFoxml(objectsPath, startingPid, foxml);
 
-        ContentObjectTransformer transformer = factory.createTransformer(folderPid, folderPid, Cdr.Folder);
-        transformer.invoke();
+        service.perform();
 
         Model depModel = modelManager.getReadModel();
-        Resource resc = depModel.getResource(folderPid.getRepositoryPath());
+        Resource resc = depModel.getResource(startingPid.getRepositoryPath());
 
         assertTrue(resc.hasProperty(RDF.type, Cdr.Folder));
         assertTrue(resc.hasProperty(CdrDeposit.lastModifiedTime, DEFAULT_LAST_MODIFIED));
         assertTrue(resc.hasProperty(CdrDeposit.createTime, DEFAULT_CREATED_DATE));
+        assertTrue(resc.hasProperty(CdrDeposit.label, "folder"));
     }
 
     @Test
@@ -165,27 +175,24 @@ public class ContentObjectTransformerTest {
         serializeFoxml(objectsPath, child2Pid, foxml2);
 
         // Create the parent's foxml
-        PID folderPid = makePid();
-        Model model = createContainerModel(folderPid);
-        addContains(model, folderPid, child1Pid);
-        addContains(model, folderPid, child2Pid);
-        Document foxml = new FoxmlDocumentBuilder(folderPid, "folder")
+        Model model = createContainerModel(startingPid);
+        addContains(model, startingPid, child1Pid);
+        addContains(model, startingPid, child2Pid);
+        Document foxml = new FoxmlDocumentBuilder(startingPid, "folder")
                 .relsExtModel(model)
                 .build();
-        serializeFoxml(objectsPath, folderPid, foxml);
+        serializeFoxml(objectsPath, startingPid, foxml);
 
-        ContentObjectTransformer transformer = factory.createTransformer(folderPid, folderPid, Cdr.Folder);
-        transformer.fork();
-
-        int result = factory.awaitTransformers();
+        int result = service.perform();
         assertEquals(0, result);
 
         Model depModel = modelManager.getReadModel();
-        Bag parentBag = depModel.getBag(folderPid.getRepositoryPath());
+        Bag parentBag = depModel.getBag(startingPid.getRepositoryPath());
 
         assertTrue(parentBag.hasProperty(RDF.type, Cdr.Folder));
         assertTrue(parentBag.hasProperty(CdrDeposit.lastModifiedTime, DEFAULT_LAST_MODIFIED));
         assertTrue(parentBag.hasProperty(CdrDeposit.createTime, DEFAULT_CREATED_DATE));
+        assertTrue(parentBag.hasProperty(CdrDeposit.label, "folder"));
 
         Resource child1Resc = depModel.getResource(child1Pid.getRepositoryPath());
         Resource child2Resc = depModel.getResource(child2Pid.getRepositoryPath());
@@ -195,13 +202,15 @@ public class ContentObjectTransformerTest {
         assertTrue(bagChildren.contains(child2Resc));
 
         assertTrue(child1Resc.hasProperty(RDF.type, Cdr.Folder));
+        assertTrue(child1Resc.hasProperty(CdrDeposit.label, "child1"));
         assertTrue(child2Resc.hasProperty(RDF.type, Cdr.Folder));
+        assertTrue(child2Resc.hasProperty(CdrDeposit.label, "child2"));
     }
 
     @Test
     public void transformFolderWithChildGenerateIds() throws Exception {
         // Enable id generation
-        factory.setGenerateIds(true);
+        manager.setGenerateIds(true);
 
         // Create the children objects' foxml
         PID child1Pid = makePid();
@@ -211,17 +220,12 @@ public class ContentObjectTransformerTest {
         serializeFoxml(objectsPath, child1Pid, foxml1);
 
         // Create the parent's foxml
-        PID folderPid = makePid();
-        Model model = createContainerModel(folderPid);
-        addContains(model, folderPid, child1Pid);
-        Document foxml = new FoxmlDocumentBuilder(folderPid, "folder")
+        Model model = createContainerModel(startingPid);
+        addContains(model, startingPid, child1Pid);
+        Document foxml = new FoxmlDocumentBuilder(startingPid, "folder")
                 .relsExtModel(model)
                 .build();
-        serializeFoxml(objectsPath, folderPid, foxml);
-
-        ContentTransformationService service = new ContentTransformationService(depositPid, folderPid.getId(), false);
-        service.setModelManager(modelManager);
-        service.setTransformerManager(factory);
+        serializeFoxml(objectsPath, startingPid, foxml);
 
         int result = service.perform();
         assertEquals(0, result);
@@ -233,7 +237,7 @@ public class ContentObjectTransformerTest {
 
         Bag parentBag = depModel.getBag(depChildren.get(0).asResource());
         assertTrue(parentBag.hasProperty(RDF.type, Cdr.Folder));
-        assertNotEquals(folderPid.getRepositoryPath(), parentBag.getURI());
+        assertNotEquals(startingPid.getRepositoryPath(), parentBag.getURI());
 
         List<RDFNode> bagChildren = parentBag.iterator().toList();
         assertEquals(1, bagChildren.size());
@@ -245,47 +249,45 @@ public class ContentObjectTransformerTest {
 
     @Test
     public void transformWorkWithNoChildren() throws Exception {
-        PID workPid = makePid();
+        Model model = createContainerModel(startingPid, AGGREGATE_WORK);
 
-        Model model = createContainerModel(workPid, AGGREGATE_WORK);
+        Document foxml = new FoxmlDocumentBuilder(startingPid, "work")
+                .relsExtModel(model)
+                .build();
+        serializeFoxml(objectsPath, startingPid, foxml);
 
-        Document foxml = new FoxmlDocumentBuilder(workPid, "work").relsExtModel(model).build();
-        serializeFoxml(objectsPath, workPid, foxml);
-
-        ContentObjectTransformer transformer = factory.createTransformer(workPid, workPid, Cdr.Folder);
-        transformer.invoke();
+        service.perform();
 
         Model depModel = modelManager.getReadModel();
-        Resource resc = depModel.getResource(workPid.getRepositoryPath());
+        Resource resc = depModel.getResource(startingPid.getRepositoryPath());
 
         assertTrue(resc.hasProperty(RDF.type, Cdr.Work));
         assertTrue(resc.hasProperty(CdrDeposit.lastModifiedTime, DEFAULT_LAST_MODIFIED));
         assertTrue(resc.hasProperty(CdrDeposit.createTime, DEFAULT_CREATED_DATE));
+        assertTrue(resc.hasProperty(CdrDeposit.label, "work"));
     }
 
     @Test
     public void transformWorkWithMods() throws Exception {
-        PID workPid = makePid();
+        Model model = createContainerModel(startingPid, AGGREGATE_WORK);
 
-        Model model = createContainerModel(workPid, AGGREGATE_WORK);
-
-        Document foxml = new FoxmlDocumentBuilder(workPid, "work")
+        Document foxml = new FoxmlDocumentBuilder(startingPid, "work")
                 .relsExtModel(model)
                 .withDatastreamVersion(makeModsDatastream("My Work"))
                 .build();
-        serializeFoxml(objectsPath, workPid, foxml);
+        serializeFoxml(objectsPath, startingPid, foxml);
 
-        ContentObjectTransformer transformer = factory.createTransformer(workPid, workPid, Cdr.Folder);
-        transformer.invoke();
+        service.perform();
 
         Model depModel = modelManager.getReadModel();
-        Resource resc = depModel.getResource(workPid.getRepositoryPath());
+        Resource resc = depModel.getResource(startingPid.getRepositoryPath());
 
         assertTrue(resc.hasProperty(RDF.type, Cdr.Work));
         assertTrue(resc.hasProperty(CdrDeposit.lastModifiedTime, DEFAULT_LAST_MODIFIED));
         assertTrue(resc.hasProperty(CdrDeposit.createTime, DEFAULT_CREATED_DATE));
+        assertTrue(resc.hasProperty(CdrDeposit.label, "work"));
 
-        assertMods(workPid, "My Work");
+        assertMods(startingPid, "My Work");
     }
 
     @Test
@@ -298,24 +300,20 @@ public class ContentObjectTransformerTest {
                 .build();
         serializeFoxml(objectsPath, child1Pid, foxml1);
 
-        PID workPid = makePid();
-        Model model = createContainerModel(workPid, AGGREGATE_WORK);
-        addContains(model, workPid, child1Pid);
-        addRelationship(model, workPid, defaultWebObject.getProperty(), child1Pid);
+        Model model = createContainerModel(startingPid, AGGREGATE_WORK);
+        addContains(model, startingPid, child1Pid);
+        addRelationship(model, startingPid, defaultWebObject.getProperty(), child1Pid);
 
-        Document foxml = new FoxmlDocumentBuilder(workPid, "work")
+        Document foxml = new FoxmlDocumentBuilder(startingPid, "work")
                 .relsExtModel(model)
                 .build();
-        serializeFoxml(objectsPath, workPid, foxml);
+        serializeFoxml(objectsPath, startingPid, foxml);
 
-        ContentObjectTransformer transformer = factory.createTransformer(workPid, workPid, Cdr.Folder);
-        transformer.fork();
-
-        int result = factory.awaitTransformers();
+        int result = service.perform();
         assertEquals(0, result);
 
         Model depModel = modelManager.getReadModel();
-        Bag workBag = depModel.getBag(workPid.getRepositoryPath());
+        Bag workBag = depModel.getBag(startingPid.getRepositoryPath());
         Resource child1Resc = depModel.getResource(child1Pid.getRepositoryPath());
 
         // Verify work properties
@@ -323,6 +321,7 @@ public class ContentObjectTransformerTest {
         assertTrue(workBag.hasProperty(CdrDeposit.lastModifiedTime, DEFAULT_LAST_MODIFIED));
         assertTrue(workBag.hasProperty(CdrDeposit.createTime, DEFAULT_CREATED_DATE));
         assertTrue(workBag.hasProperty(Cdr.primaryObject, child1Resc));
+        assertTrue(workBag.hasProperty(CdrDeposit.label, "work"));
 
         // Verify file properties
         List<RDFNode> bagChildren = workBag.iterator().toList();
@@ -335,11 +334,12 @@ public class ContentObjectTransformerTest {
         assertTrue(child1Resc.hasLiteral(CdrDeposit.lastModifiedTime, DEFAULT_CREATED_DATE));
         assertTrue(child1Resc.hasLiteral(CdrDeposit.size, DATA_FILE_SIZE));
         assertTrue(child1Resc.hasLiteral(CdrDeposit.stagingLocation, dataFilePath.toUri().toString()));
+        assertTrue(child1Resc.hasProperty(CdrDeposit.label, "file1"));
     }
 
     @Test
     public void transformWorkWithFileWithGeneratedIds() throws Exception {
-        factory.setGenerateIds(true);
+        manager.setGenerateIds(true);
 
         PID child1Pid = makePid();
         Document foxml1 = new FoxmlDocumentBuilder(child1Pid, "file1")
@@ -348,19 +348,14 @@ public class ContentObjectTransformerTest {
                 .build();
         serializeFoxml(objectsPath, child1Pid, foxml1);
 
-        PID workPid = makePid();
-        Model model = createContainerModel(workPid, AGGREGATE_WORK);
-        addContains(model, workPid, child1Pid);
-        addRelationship(model, workPid, defaultWebObject.getProperty(), child1Pid);
+        Model model = createContainerModel(startingPid, AGGREGATE_WORK);
+        addContains(model, startingPid, child1Pid);
+        addRelationship(model, startingPid, defaultWebObject.getProperty(), child1Pid);
 
-        Document foxml = new FoxmlDocumentBuilder(workPid, "work")
+        Document foxml = new FoxmlDocumentBuilder(startingPid, "work")
                 .relsExtModel(model)
                 .build();
-        serializeFoxml(objectsPath, workPid, foxml);
-
-        ContentTransformationService service = new ContentTransformationService(depositPid, workPid.getId(), false);
-        service.setModelManager(modelManager);
-        service.setTransformerManager(factory);
+        serializeFoxml(objectsPath, startingPid, foxml);
 
         int result = service.perform();
         assertEquals(0, result);
@@ -372,7 +367,7 @@ public class ContentObjectTransformerTest {
 
         Bag parentBag = depModel.getBag(depChildren.get(0).asResource());
         assertTrue(parentBag.hasProperty(RDF.type, Cdr.Work));
-        assertNotEquals(workPid.getRepositoryPath(), parentBag.getURI());
+        assertNotEquals(startingPid.getRepositoryPath(), parentBag.getURI());
 
         List<RDFNode> bagChildren = parentBag.iterator().toList();
         assertEquals(1, bagChildren.size());
@@ -383,28 +378,65 @@ public class ContentObjectTransformerTest {
     }
 
     @Test
+    public void transformWorkWithFileNoDcTitle() throws Exception {
+        PID child1Pid = makePid();
+        Path dataFilePath = mockDatastreamFile(child1Pid, ORIGINAL_DS, 0);
+        Document foxml1 = new FoxmlDocumentBuilder(child1Pid, "label.txt")
+                .relsExtModel(createFileModel(child1Pid))
+                .withDatastreamVersion(createDataFileVersion())
+                // remove dc datastream
+                .withDatastreamVersions(DC_DS, null)
+                .build();
+        serializeFoxml(objectsPath, child1Pid, foxml1);
+
+        Model model = createContainerModel(startingPid, AGGREGATE_WORK);
+        addContains(model, startingPid, child1Pid);
+        addRelationship(model, startingPid, defaultWebObject.getProperty(), child1Pid);
+
+        Document foxml = new FoxmlDocumentBuilder(startingPid, "work")
+                .relsExtModel(model)
+                .build();
+        serializeFoxml(objectsPath, startingPid, foxml);
+
+        int result = service.perform();
+        assertEquals(0, result);
+
+        Model depModel = modelManager.getReadModel();
+        Bag workBag = depModel.getBag(startingPid.getRepositoryPath());
+        Resource child1Resc = depModel.getResource(child1Pid.getRepositoryPath());
+
+        // Verify work properties
+        assertTrue(workBag.hasProperty(RDF.type, Cdr.Work));
+        assertTrue(workBag.hasProperty(CdrDeposit.label, "work"));
+
+        // Verify file properties
+        List<RDFNode> bagChildren = workBag.iterator().toList();
+        assertEquals(1, bagChildren.size());
+        assertTrue(bagChildren.contains(child1Resc));
+        assertTrue(child1Resc.hasProperty(RDF.type, Cdr.FileObject));
+        assertTrue(child1Resc.hasLiteral(CdrDeposit.stagingLocation, dataFilePath.toUri().toString()));
+        assertTrue(child1Resc.hasProperty(CdrDeposit.label, "label.txt"));
+    }
+
+    @Test
     public void transformStandaloneFile() throws Exception {
         // Give the object a separate created time from its data file
         String objectCreated = "2011-10-01T11:11:11.111Z";
-        PID originalPid = makePid();
-        Path dataFilePath = mockDatastreamFile(originalPid, ORIGINAL_DS, 0);
-        Document foxml1 = new FoxmlDocumentBuilder(originalPid, "file1")
-                .relsExtModel(createFileModel(originalPid))
+        Path dataFilePath = mockDatastreamFile(startingPid, ORIGINAL_DS, 0);
+        Document foxml1 = new FoxmlDocumentBuilder(startingPid, "file1")
+                .relsExtModel(createFileModel(startingPid))
                 .withDatastreamVersion(createDataFileVersion())
                 .createdDate(objectCreated)
                 .withDatastreamVersion(makeModsDatastream("My File"))
                 .build();
-        serializeFoxml(objectsPath, originalPid, foxml1);
+        serializeFoxml(objectsPath, startingPid, foxml1);
 
-        ContentObjectTransformer transformer = factory.createTransformer(originalPid, originalPid, Cdr.Folder);
-        transformer.fork();
-
-        int result = factory.awaitTransformers();
+        int result = service.perform();
         assertEquals(0, result);
 
         Model depModel = modelManager.getReadModel();
         // original pid should now refer to a newly generated work
-        Bag workBag = depModel.getBag(originalPid.getRepositoryPath());
+        Bag workBag = depModel.getBag(startingPid.getRepositoryPath());
         List<RDFNode> bagChildren = workBag.iterator().toList();
         assertEquals(1, bagChildren.size());
         Resource fileResc = (Resource) bagChildren.get(0);
@@ -415,6 +447,7 @@ public class ContentObjectTransformerTest {
         assertTrue("Generated work should have inherited the object creation time from the file",
                 workBag.hasProperty(CdrDeposit.createTime, objectCreated));
         assertTrue(workBag.hasProperty(Cdr.primaryObject, fileResc));
+        assertTrue(workBag.hasProperty(CdrDeposit.label, "file1"));
 
         // Verify file properties
         assertTrue(fileResc.hasProperty(RDF.type, Cdr.FileObject));
@@ -425,99 +458,118 @@ public class ContentObjectTransformerTest {
         assertTrue(fileResc.hasLiteral(CdrDeposit.lastModifiedTime, DEFAULT_CREATED_DATE));
         assertTrue(fileResc.hasLiteral(CdrDeposit.size, DATA_FILE_SIZE));
         assertTrue(fileResc.hasLiteral(CdrDeposit.stagingLocation, dataFilePath.toUri().toString()));
+        assertTrue(fileResc.hasProperty(CdrDeposit.label, "file1"));
 
         // Work should have the MODS
-        assertMods(originalPid, "My File");
+        assertMods(startingPid, "My File");
     }
 
     @Test
-    public void transformCollectionInUnit() throws Exception {
-        PID collPid = makePid();
-
-        Model model = createContainerModel(collPid, ContentModel.COLLECTION);
-
-        Document foxml = new FoxmlDocumentBuilder(collPid, "collection")
-                .relsExtModel(model)
+    public void transformStandaloneFileWithAltId() throws Exception {
+        // Give the object a separate created time from its data file
+        Path dataFilePath = mockDatastreamFile(startingPid, ORIGINAL_DS, 0);
+        DatastreamVersion dataVersion = createDataFileVersion();
+        dataVersion.setAltIds("irods://localhost:12345/test/path/to/test.txt");
+        Document foxml1 = new FoxmlDocumentBuilder(startingPid, "")
+                .relsExtModel(createFileModel(startingPid))
+                .withDatastreamVersion(dataVersion)
+                .withDatastreamVersions(DC_DS, null)
                 .build();
-        serializeFoxml(objectsPath, collPid, foxml);
+        serializeFoxml(objectsPath, startingPid, foxml1);
 
-        ContentObjectTransformer transformer = factory.createTransformer(collPid, collPid, Cdr.AdminUnit);
-        transformer.invoke();
+        int result = service.perform();
+        assertEquals(0, result);
 
         Model depModel = modelManager.getReadModel();
-        Resource resc = depModel.getResource(collPid.getRepositoryPath());
+        // original pid should now refer to a newly generated work
+        Bag workBag = depModel.getBag(startingPid.getRepositoryPath());
+        List<RDFNode> bagChildren = workBag.iterator().toList();
+        assertEquals(1, bagChildren.size());
+        Resource fileResc = (Resource) bagChildren.get(0);
 
-        assertTrue(resc.hasProperty(RDF.type, Cdr.Collection));
-        assertTrue(resc.hasProperty(CdrDeposit.lastModifiedTime, DEFAULT_LAST_MODIFIED));
-        assertTrue(resc.hasProperty(CdrDeposit.createTime, DEFAULT_CREATED_DATE));
+        // Verify work properties
+        assertTrue(workBag.hasProperty(RDF.type, Cdr.Work));
+        assertTrue(workBag.hasProperty(CdrDeposit.label, "test.txt"));
+
+        // Verify file properties
+        assertTrue(fileResc.hasProperty(RDF.type, Cdr.FileObject));
+        assertTrue(fileResc.hasProperty(CdrDeposit.label, "test.txt"));
+        assertTrue(fileResc.hasLiteral(CdrDeposit.stagingLocation, dataFilePath.toUri().toString()));
     }
 
     @Test
-    public void transformCollectionAtTopWithFlag() throws Exception {
-        factory.setTopLevelAsUnit(true);
+    public void transformNestedCollection() throws Exception {
+        // Create the children objects' foxml
+        PID child1Pid = makePid();
+        Document foxml1 = new FoxmlDocumentBuilder(child1Pid, "collection")
+                .relsExtModel(createContainerModel(child1Pid, ContentModel.COLLECTION))
+                .build();
+        serializeFoxml(objectsPath, child1Pid, foxml1);
 
-        PID collPid = makePid();
-
-        Model model = createContainerModel(collPid, ContentModel.COLLECTION);
-
-        Document foxml = new FoxmlDocumentBuilder(collPid, "top collection")
+        // Create the parent's foxml
+        Model model = createContainerModel(startingPid, ContentModel.COLLECTION);
+        addContains(model, startingPid, child1Pid);
+        Document foxml = new FoxmlDocumentBuilder(startingPid, "aspiring unit")
                 .relsExtModel(model)
                 .build();
-        serializeFoxml(objectsPath, collPid, foxml);
+        serializeFoxml(objectsPath, startingPid, foxml);
 
-        ContentObjectTransformer transformer = factory.createTransformer(collPid, collPid, null);
-        transformer.invoke();
+        service.perform();
 
         Model depModel = modelManager.getReadModel();
-        Resource resc = depModel.getResource(collPid.getRepositoryPath());
+        Resource unitResc = depModel.getResource(startingPid.getRepositoryPath());
 
-        assertTrue(resc.hasProperty(RDF.type, Cdr.AdminUnit));
-        assertTrue(resc.hasProperty(CdrDeposit.lastModifiedTime, DEFAULT_LAST_MODIFIED));
-        assertTrue(resc.hasProperty(CdrDeposit.createTime, DEFAULT_CREATED_DATE));
+        assertTrue(unitResc.hasProperty(RDF.type, Cdr.AdminUnit));
+        assertTrue(unitResc.hasProperty(CdrDeposit.lastModifiedTime, DEFAULT_LAST_MODIFIED));
+        assertTrue(unitResc.hasProperty(CdrDeposit.createTime, DEFAULT_CREATED_DATE));
+        assertTrue(unitResc.hasProperty(CdrDeposit.label, "aspiring unit"));
+
+        Resource collResc = depModel.getResource(child1Pid.getRepositoryPath());
+
+        assertTrue(collResc.hasProperty(RDF.type, Cdr.Collection));
+        assertTrue(collResc.hasProperty(CdrDeposit.lastModifiedTime, DEFAULT_LAST_MODIFIED));
+        assertTrue(collResc.hasProperty(CdrDeposit.createTime, DEFAULT_CREATED_DATE));
+        assertTrue(collResc.hasProperty(CdrDeposit.label, "collection"));
     }
 
     @Test
     public void transformCollectionAtTopWithFlagFalse() throws Exception {
-        factory.setTopLevelAsUnit(false);
+        manager.setTopLevelAsUnit(false);
 
-        PID collPid = makePid();
+        Model model = createContainerModel(startingPid, ContentModel.COLLECTION);
 
-        Model model = createContainerModel(collPid, ContentModel.COLLECTION);
-
-        Document foxml = new FoxmlDocumentBuilder(collPid, "top collection")
+        Document foxml = new FoxmlDocumentBuilder(startingPid, "top collection")
                 .relsExtModel(model)
                 .build();
-        serializeFoxml(objectsPath, collPid, foxml);
+        serializeFoxml(objectsPath, startingPid, foxml);
 
-        ContentObjectTransformer transformer = factory.createTransformer(collPid, collPid, null);
-        transformer.invoke();
+        service.perform();
 
         Model depModel = modelManager.getReadModel();
-        Resource resc = depModel.getResource(collPid.getRepositoryPath());
+        Resource resc = depModel.getResource(startingPid.getRepositoryPath());
 
         assertTrue(resc.hasProperty(RDF.type, Cdr.Collection));
         assertTrue(resc.hasProperty(CdrDeposit.lastModifiedTime, DEFAULT_LAST_MODIFIED));
         assertTrue(resc.hasProperty(CdrDeposit.createTime, DEFAULT_CREATED_DATE));
+        assertTrue(resc.hasProperty(CdrDeposit.label, "top collection"));
     }
 
     @Test
     public void transformNonTransformableType() throws Exception {
-        PID pid = makePid();
-
         Model model = createDefaultModel();
-        Resource resc = model.getResource(toBxc3Uri(pid));
+        Resource resc = model.getResource(toBxc3Uri(startingPid));
         resc.addProperty(hasModel.getProperty(), DEPOSIT_RECORD.getResource());
 
-        Document foxml = new FoxmlDocumentBuilder(pid, "collection")
+        Document foxml = new FoxmlDocumentBuilder(startingPid, "collection")
                 .relsExtModel(model)
                 .build();
-        serializeFoxml(objectsPath, pid, foxml);
+        serializeFoxml(objectsPath, startingPid, foxml);
 
-        ContentObjectTransformer transformer = factory.createTransformer(pid, pid, Cdr.AdminUnit);
-        transformer.invoke();
+        int result = service.perform();
+        assertEquals("Transformation should contain failure", 1, result);
 
         Model depModel = modelManager.getReadModel();
-        assertTrue(depModel.isEmpty());
+        assertDoesNotContainSubject(depModel, startingPid);
     }
 
     @Test
@@ -530,24 +582,19 @@ public class ContentObjectTransformerTest {
         serializeFoxml(objectsPath, child1Pid, foxml1);
 
         // Create the parent's foxml
-        PID folderPid = makePid();
-        Model model = createContainerModel(folderPid);
-        addContains(model, folderPid, child1Pid);
-        Document foxml = new FoxmlDocumentBuilder(folderPid, "folder")
+        Model model = createContainerModel(startingPid);
+        addContains(model, startingPid, child1Pid);
+        Document foxml = new FoxmlDocumentBuilder(startingPid, "folder")
                 .relsExtModel(model)
                 .state("Deleted")
                 .build();
-        serializeFoxml(objectsPath, folderPid, foxml);
+        serializeFoxml(objectsPath, startingPid, foxml);
 
-        ContentObjectTransformer transformer = factory.createTransformer(folderPid, folderPid, Cdr.Folder);
-        transformer.fork();
-
-        int result = factory.awaitTransformers();
+        int result = service.perform();
         assertEquals(0, result);
 
         Model depModel = modelManager.getReadModel();
-        assertTrue("No properties should be present, for either the parent or child",
-                depModel.isEmpty());
+        assertDoesNotContainSubject(depModel, startingPid);
     }
 
     @Test
@@ -562,23 +609,19 @@ public class ContentObjectTransformerTest {
         serializeFoxml(objectsPath, child2Pid, foxml2);
 
         // Create the parent's foxml
-        PID folderPid = makePid();
-        Model model = createContainerModel(folderPid);
-        addContains(model, folderPid, missingPid);
-        addContains(model, folderPid, child2Pid);
-        Document foxml = new FoxmlDocumentBuilder(folderPid, "folder")
+        Model model = createContainerModel(startingPid);
+        addContains(model, startingPid, missingPid);
+        addContains(model, startingPid, child2Pid);
+        Document foxml = new FoxmlDocumentBuilder(startingPid, "folder")
                 .relsExtModel(model)
                 .build();
-        serializeFoxml(objectsPath, folderPid, foxml);
+        serializeFoxml(objectsPath, startingPid, foxml);
 
-        ContentObjectTransformer transformer = factory.createTransformer(folderPid, folderPid, Cdr.Folder);
-        transformer.fork();
-
-        int result = factory.awaitTransformers();
+        int result = service.perform();
         assertEquals(0, result);
 
         Model depModel = modelManager.getReadModel();
-        Bag parentBag = depModel.getBag(folderPid.getRepositoryPath());
+        Bag parentBag = depModel.getBag(startingPid.getRepositoryPath());
 
         assertTrue(parentBag.hasProperty(RDF.type, Cdr.Folder));
         assertTrue(parentBag.hasProperty(CdrDeposit.lastModifiedTime, DEFAULT_LAST_MODIFIED));
@@ -628,8 +671,9 @@ public class ContentObjectTransformerTest {
         return createDataFileVersion(DATA_FILE_MD5, 0, DEFAULT_CREATED_DATE, DATA_FILE_SIZE, DATA_FILE_MIMETYPE);
     }
 
-    private DatastreamVersion createDataFileVersion(String md5, int version, String created, String size, String mimeType) {
-        return new DatastreamVersion(md5, ORIGINAL_DS, ORIGINAL_DS + "." + version, created, size, mimeType);
+    private DatastreamVersion createDataFileVersion(String md5, int version, String created,
+            String size, String mimeType) {
+        return new DatastreamVersion(md5, ORIGINAL_DS, ORIGINAL_DS + "." + version, created, size, mimeType, null);
     }
 
     private Path mockDatastreamFile(PID pid, String dsName, int version) {
@@ -648,7 +692,8 @@ public class ContentObjectTransformerTest {
                 .addContent(new Element("titleInfo", MODS_V3_NS)
                         .addContent(new Element("title", MODS_V3_NS)
                                 .setText(title))));
-        DatastreamVersion modsDs = new DatastreamVersion(null, MODS_DS, MODS_DS + ".0", DEFAULT_CREATED_DATE, "100", "text/xml");
+        DatastreamVersion modsDs = new DatastreamVersion(null, MODS_DS, MODS_DS + ".0", DEFAULT_CREATED_DATE,
+                "100", "text/xml", null);
         modsDs.setBodyEl(doc.getRootElement());
         return modsDs;
     }
@@ -669,5 +714,9 @@ public class ContentObjectTransformerTest {
                 .getChild("title", MODS_V3_NS)
                 .getText();
         assertEquals("MODS title did not match", expectedTitle, resultTitle);
+    }
+
+    private void assertDoesNotContainSubject(Model model, PID pid) {
+        assertFalse(model.listSubjects().toSet().contains(createResource(pid.getRepositoryPath())));
     }
 }

--- a/migration-util/src/test/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformerTest.java
+++ b/migration-util/src/test/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformerTest.java
@@ -275,7 +275,7 @@ public class ContentObjectTransformerTest {
                 .build();
         serializeFoxml(objectsPath, workPid, foxml);
 
-        ContentObjectTransformer transformer = factory.createTransformer(workPid, Cdr.Folder);
+        ContentObjectTransformer transformer = factory.createTransformer(workPid, workPid, Cdr.Folder);
         transformer.invoke();
 
         Model depModel = modelManager.getReadModel();

--- a/migration-util/src/test/java/edu/unc/lib/dcr/migration/deposit/DepositSubmissionServiceTest.java
+++ b/migration-util/src/test/java/edu/unc/lib/dcr/migration/deposit/DepositSubmissionServiceTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dcr.migration.deposit;
+
+import static edu.unc.lib.dcr.migration.deposit.DepositSubmissionService.EMAIL_SUFFIX;
+import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.USER_NAMESPACE;
+import static edu.unc.lib.dl.test.TestHelpers.setField;
+import static edu.unc.lib.dl.util.DepositMethod.BXC3_TO_5_MIGRATION_UTIL;
+import static edu.unc.lib.dl.util.PackagingType.PRECONSTRUCTED_DEPOSIT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+
+import edu.unc.lib.dl.acl.util.AccessGroupSet;
+import edu.unc.lib.dl.fcrepo4.RepositoryPIDMinter;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.util.DepositStatusFactory;
+import edu.unc.lib.dl.util.RedisWorkerConstants.DepositAction;
+import edu.unc.lib.dl.util.RedisWorkerConstants.DepositField;
+import edu.unc.lib.dl.util.RedisWorkerConstants.DepositState;
+import edu.unc.lib.dl.util.RedisWorkerConstants.Priority;
+
+/**
+ * @author bbpennel
+ */
+public class DepositSubmissionServiceTest {
+
+    private static final String DEPOSITOR = "testUser";
+    private static final String DEPOSITOR_GROUPS = "somegroup";
+
+    @Captor
+    private ArgumentCaptor<Map<String, String>> statusCaptor;
+
+    @Mock
+    private DepositStatusFactory statusFactory;
+
+    private RepositoryPIDMinter pidMinter;
+
+    private DepositSubmissionService service;
+
+    @Before
+    public void setup() throws Exception {
+        initMocks(this);
+
+        service = new DepositSubmissionService("localhost", 1);
+        setField(service, "depositStatusFactory", statusFactory);
+
+        pidMinter = new RepositoryPIDMinter();
+    }
+
+    @Test
+    public void submitDeposit() {
+        PID depositPid = pidMinter.mintDepositRecordPid();
+        PID destinationPid = pidMinter.mintContentPid();
+
+        int result = service.submitDeposit(DEPOSITOR, DEPOSITOR_GROUPS, depositPid, destinationPid);
+
+        assertEquals(0, result);
+
+        verify(statusFactory).save(eq(depositPid.getId()), statusCaptor.capture());
+
+        Map<String, String> status = statusCaptor.getValue();
+        verifyDepositFields(depositPid, destinationPid, status);
+    }
+
+    private void verifyDepositFields(PID depositPid, PID destinationPid,
+            Map<String, String> status) {
+        assertEquals(depositPid.getId(), status.get(DepositField.uuid.name()));
+        assertNotNull("Deposit submission time must be set", status.get(DepositField.submitTime.name()));
+        assertEquals(PRECONSTRUCTED_DEPOSIT.getUri(), status.get(DepositField.packagingType.name()));
+        assertEquals(BXC3_TO_5_MIGRATION_UTIL.getLabel(), status.get(DepositField.depositMethod.name()));
+        assertEquals(DEPOSITOR, status.get(DepositField.depositorName.name()));
+        assertEquals(DEPOSITOR + EMAIL_SUFFIX, status.get(DepositField.depositorEmail.name()));
+        assertEquals(destinationPid.getId(), status.get(DepositField.containerId.name()));
+        assertEquals(Priority.normal.name(), status.get(DepositField.priority.name()));
+
+        assertEquals(DepositState.unregistered.name(), status.get(DepositField.state.name()));
+        assertEquals(DepositAction.register.name(), status.get(DepositField.actionRequest.name()));
+        AccessGroupSet depositPrincipals = new AccessGroupSet(status.get(DepositField.permissionGroups.name()));
+        assertTrue("user principal must be set in deposit", depositPrincipals.contains(USER_NAMESPACE + DEPOSITOR));
+        assertTrue("group principal must be set in deposit", depositPrincipals.contains(DEPOSITOR_GROUPS));
+    }
+}

--- a/migration-util/src/test/java/edu/unc/lib/dcr/migration/deposit/DepositSubmissionServiceTest.java
+++ b/migration-util/src/test/java/edu/unc/lib/dcr/migration/deposit/DepositSubmissionServiceTest.java
@@ -19,7 +19,7 @@ import static edu.unc.lib.dcr.migration.deposit.DepositSubmissionService.EMAIL_S
 import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.USER_NAMESPACE;
 import static edu.unc.lib.dl.test.TestHelpers.setField;
 import static edu.unc.lib.dl.util.DepositMethod.BXC3_TO_5_MIGRATION_UTIL;
-import static edu.unc.lib.dl.util.PackagingType.PRECONSTRUCTED_DEPOSIT;
+import static edu.unc.lib.dl.util.PackagingType.BAG_WITH_N3;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -91,7 +91,7 @@ public class DepositSubmissionServiceTest {
             Map<String, String> status) {
         assertEquals(depositPid.getId(), status.get(DepositField.uuid.name()));
         assertNotNull("Deposit submission time must be set", status.get(DepositField.submitTime.name()));
-        assertEquals(PRECONSTRUCTED_DEPOSIT.getUri(), status.get(DepositField.packagingType.name()));
+        assertEquals(BAG_WITH_N3.getUri(), status.get(DepositField.packagingType.name()));
         assertEquals(BXC3_TO_5_MIGRATION_UTIL.getLabel(), status.get(DepositField.depositMethod.name()));
         assertEquals(DEPOSITOR, status.get(DepositField.depositorName.name()));
         assertEquals(DEPOSITOR + EMAIL_SUFFIX, status.get(DepositField.depositorEmail.name()));

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/ingest/PreconstructedDepositHandler.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/ingest/PreconstructedDepositHandler.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.persist.services.ingest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.persist.api.ingest.DepositData;
+import edu.unc.lib.dl.util.DepositException;
+import edu.unc.lib.dl.util.RedisWorkerConstants.DepositField;
+
+/**
+ * @author bbpennel
+ */
+public class PreconstructedDepositHandler extends AbstractDepositHandler {
+    private static Logger log = LoggerFactory.getLogger(PreconstructedDepositHandler.class);
+
+    private PID depositPID;
+
+    public PreconstructedDepositHandler(PID depositPID) {
+        this.depositPID = depositPID;
+    }
+
+    @Override
+    public PID doDeposit(PID destination, DepositData deposit) throws DepositException {
+        log.debug("Preparing to perform a Preconstructed deposit to {}",
+                destination.getQualifiedId());
+
+        Map<String, String> options = new HashMap<>();
+        options.put(DepositField.excludeDepositRecord.name(), "true");
+
+        registerDeposit(depositPID, destination, deposit, options);
+
+        return depositPID;
+    }
+
+}


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2541

This PR allows for content structures to be deposited into bxc, with the mods and filename info. There seem to be some indexing issues that generally required me to reindex the new collection after deposit completed which should be addressed separately.

Changes:
* Adds command for submitting deposits to the deposit pipeline
  * adds service and deposit handler for submitting these types of deposits
* Adds option for the transform content job to immediately submit the result for ingest
* Populates the root deposit record entry for transformed deposits, which is required by the deposit pipeline
* Adds flag for generating new PIDs for transformed objects, allowing test sets to be ingested multiple times
* Sets a label (which serves as a fallback title and filename) for objects, using the dc.title > fedora:label > preingest file path (ALT_IDS)
* If transformation can't identify what type of resource an object is, it now throws an exception
* Additional tests, and some refactoring of content transformation tests to work with deposit root/be more regular

Deposits can be tested on the dev vm. To do so:
1) transfer the sample collection files to `/opt/data/test_staging/` on the vm
2) place the built `dcr-migration-util.jar` on the vm (I have been running it from /vagrant/workspace/ which is the workspace dir in the ansible project). 
3) update stc_objects.txt and stc_datastreams.txt to contain paths located in `/opt/data/test_staging/`
**(The following are outline below)**
4) index the file lists with sudo
5) Shut down dcr-deposit
6) transform and submit the deposit
7) Start back up dcr-deposit

```
# shut down the deposit app
sudo service dcr-deposit stop

# Indexing (you'll need to make sure the paths in the files match their location on the vm)
sudo java -jar dcr-migration-util.jar path_index populate /vagrant/workspace/stc_objects.txt /vagrant/workspace/stc_datastreams.txt

# Transform and submit for deposit (you'll need an Admin Unit in the repo as a destination)
sudo java -Dfcrepo.baseUri=http://localhost:8181/fcrepo/rest/ -jar dcr-migration-util.jar --tdb-dir /opt/data/deposits/jena-tdb-dataset --groups "unc:app:lib:cdr:admin" transform_content c576ff4c-357f-4a26-b27c-06e0b6c3abb7 --deposit-into <pid of deposit destination> -g

# resume the deposit app
sudo service dcr-deposit start
```

This is a fair amount of setup, but it shouldn't need to be repeated often for the actual migration.