### PR TITLE
Fix Premis updating

### DIFF
--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectFactory.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectFactory.java
@@ -15,6 +15,7 @@
  */
 package edu.unc.lib.dl.fcrepo4;
 
+import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.FCR_METADATA;
 import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.METADATA_CONTAINER;
 import static edu.unc.lib.dl.util.RDFModelUtil.TURTLE_MIMETYPE;
 import static org.fcrepo.client.ExternalContentHandling.PROXY;
@@ -347,7 +348,12 @@ public class RepositoryObjectFactory {
             updateBinaryDescription(pid, describedBy, model);
         }
 
-        return new BinaryObject(PIDs.get(resultUri), storageUri, repoObjDriver, this);
+        String resultUriString = resultUri.toString();
+        if (resultUriString.endsWith(FCR_METADATA)) {
+            resultUriString = resultUriString.replace("/" + FCR_METADATA, "");
+        }
+
+        return new BinaryObject(PIDs.get(resultUriString), storageUri, repoObjDriver, this);
     }
 
     private void updateBinaryDescription(PID binPid, URI describedBy, Model model) {

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/persist/api/storage/StorageType.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/persist/api/storage/StorageType.java
@@ -20,7 +20,8 @@ package edu.unc.lib.dl.persist.api.storage;
  *
  */
 public enum StorageType {
-    FILESYSTEM("filesystem");
+    FILESYSTEM("filesystem"),
+    POSIX_FS("posix");
 
     private final String id;
 

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/storage/HashedPosixStorageLocation.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/storage/HashedPosixStorageLocation.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.persist.services.storage;
+
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import edu.unc.lib.dl.persist.api.storage.StorageType;
+
+/**
+ * A hashed posix filesystem based storage location, which allows setting of file permissions.
+ *
+ * @author bbpennel
+ */
+public class HashedPosixStorageLocation extends HashedFilesystemStorageLocation {
+    public static final String TYPE_NAME = "hashed_posix";
+
+    private final static Pattern PERMS_PATTERN = Pattern.compile("[0-2][0-7][0-7][0-7]");
+    private static final Map<Integer, PosixFilePermission> PERM_MAPPING = new HashMap<>();
+    static {
+        PERM_MAPPING.put(0001, PosixFilePermission.OTHERS_EXECUTE);
+        PERM_MAPPING.put(0002, PosixFilePermission.OTHERS_WRITE);
+        PERM_MAPPING.put(0004, PosixFilePermission.OTHERS_READ);
+        PERM_MAPPING.put(0010, PosixFilePermission.GROUP_EXECUTE);
+        PERM_MAPPING.put(0020, PosixFilePermission.GROUP_WRITE);
+        PERM_MAPPING.put(0040, PosixFilePermission.GROUP_READ);
+        PERM_MAPPING.put(0100, PosixFilePermission.OWNER_EXECUTE);
+        PERM_MAPPING.put(0200, PosixFilePermission.OWNER_WRITE);
+        PERM_MAPPING.put(0400, PosixFilePermission.OWNER_READ);
+    }
+
+    private Set<PosixFilePermission> permissions;
+
+    public void setPermissions(String perms) {
+        if (!PERMS_PATTERN.matcher(perms).matches()) {
+            throw new IllegalArgumentException("Invalid permissions value " + perms);
+        }
+        // Build list of individual permissions by masking the input octal mode
+        int mode = Integer.parseInt(perms, 8);
+        permissions = new HashSet<>();
+        for (int mask: PERM_MAPPING.keySet()) {
+            if (mask == (mode & mask)) {
+                permissions.add(PERM_MAPPING.get(mask));
+            }
+        }
+    }
+
+    /**
+     * Get the set of posix file permissions to use for files created in this location
+     *
+     * @return set of permissions, or null if no permissions were defined
+     */
+    public Set<PosixFilePermission> getPermissions() {
+        return permissions;
+    }
+
+    @Override
+    public StorageType getStorageType() {
+        return StorageType.POSIX_FS;
+    }
+}

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/storage/StorageLocationManagerImpl.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/storage/StorageLocationManagerImpl.java
@@ -81,7 +81,8 @@ public class StorageLocationManagerImpl implements StorageLocationManager {
         InputStream configStream = new FileInputStream(new File(configPath));
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerSubtypes(
-                new NamedType(HashedFilesystemStorageLocation.class, HashedFilesystemStorageLocation.TYPE_NAME));
+                new NamedType(HashedFilesystemStorageLocation.class, HashedFilesystemStorageLocation.TYPE_NAME),
+                new NamedType(HashedPosixStorageLocation.class, HashedPosixStorageLocation.TYPE_NAME));
         storageLocations = mapper.readValue(configStream,
                 new TypeReference<List<StorageLocation>>() {});
         idToStorageLocation = storageLocations.stream()

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/BinaryTransferSessionImpl.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/BinaryTransferSessionImpl.java
@@ -16,6 +16,7 @@
 package edu.unc.lib.dl.persist.services.transfer;
 
 import static edu.unc.lib.dl.persist.api.storage.StorageType.FILESYSTEM;
+import static edu.unc.lib.dl.persist.api.storage.StorageType.POSIX_FS;
 import static org.springframework.util.Assert.notNull;
 
 import java.io.InputStream;
@@ -101,6 +102,8 @@ public class BinaryTransferSessionImpl implements BinaryTransferSession {
         BinaryTransferClient client = null;
         if (FILESYSTEM.equals(source.getStorageType()) && FILESYSTEM.equals(storageLocation.getStorageType())) {
             client = new FSToFSTransferClient(source, storageLocation);
+        } else if (FILESYSTEM.equals(source.getStorageType()) && POSIX_FS.equals(storageLocation.getStorageType())) {
+            client = new FSToPosixTransferClient(source, storageLocation);
         } else {
             throw new NotImplementedException("Transfer from " + source.getId() + " to " + storageLocation.getId()
                 + " is not currently supported.");
@@ -132,6 +135,8 @@ public class BinaryTransferSessionImpl implements BinaryTransferSession {
 
         if (FILESYSTEM.equals(storageLocation.getStorageType())) {
             streamClient = new StreamToFSTransferClient(storageLocation);
+        } else if (POSIX_FS.equals(storageLocation.getStorageType())) {
+            streamClient = new StreamToPosixTransferClient(storageLocation);
         } else {
             throw new NotImplementedException("Write stream to " + storageLocation.getId()
                 + " is not currently supported.");

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/FSToFSTransferClient.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/FSToFSTransferClient.java
@@ -45,7 +45,7 @@ import edu.unc.lib.dl.persist.api.transfer.BinaryTransferException;
 public class FSToFSTransferClient implements BinaryTransferClient {
 
     private IngestSource source;
-    private StorageLocation destination;
+    protected StorageLocation destination;
 
     private static final CopyOption[] COPY_NO_OVERWRITE = { COPY_ATTRIBUTES };
     private static final CopyOption[] COPY_ALLOW_OVERWRITE = { COPY_ATTRIBUTES, REPLACE_EXISTING };

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/FSToPosixTransferClient.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/FSToPosixTransferClient.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.persist.services.transfer;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.persist.api.ingest.IngestSource;
+import edu.unc.lib.dl.persist.api.storage.StorageLocation;
+import edu.unc.lib.dl.persist.api.transfer.BinaryTransferException;
+import edu.unc.lib.dl.persist.services.storage.HashedPosixStorageLocation;
+
+/**
+ * Client for transferring files from a filesystem ingest source to a
+ * posix filesystem storage location.
+ *
+ * @author bbpennel
+ */
+public class FSToPosixTransferClient extends FSToFSTransferClient {
+
+    /**
+     * @param source
+     * @param destination
+     */
+    public FSToPosixTransferClient(IngestSource source, StorageLocation destination) {
+        super(source, destination);
+    }
+
+    @Override
+    public URI transfer(PID binPid, URI sourceFileUri, boolean allowOverwrite) {
+        URI binUri = super.transfer(binPid, sourceFileUri, allowOverwrite);
+        HashedPosixStorageLocation posixLoc = (HashedPosixStorageLocation) destination;
+
+        if (posixLoc.getPermissions() != null) {
+            Path binPath = Paths.get(binUri);
+
+            try {
+                Files.setPosixFilePermissions(binPath, posixLoc.getPermissions());
+            } catch (IOException e) {
+                throw new BinaryTransferException("Failed to set permissions in destination "
+                        + destination.getId(), e);
+            }
+        }
+
+        return binUri;
+    }
+}

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/StreamToFSTransferClient.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/StreamToFSTransferClient.java
@@ -43,7 +43,7 @@ import edu.unc.lib.dl.persist.api.transfer.StreamTransferClient;
  */
 public class StreamToFSTransferClient implements StreamTransferClient {
 
-    private StorageLocation destination;
+    protected StorageLocation destination;
 
     /**
      * @param destination destination storage location
@@ -62,7 +62,7 @@ public class StreamToFSTransferClient implements StreamTransferClient {
         return writeStream(binPid, sourceStream, true);
     }
 
-    private URI writeStream(PID binPid, InputStream sourceStream, boolean allowOverwrite) {
+    protected URI writeStream(PID binPid, InputStream sourceStream, boolean allowOverwrite) {
         URI destUri = destination.getStorageUri(binPid);
         Path destPath = Paths.get(destUri);
 

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/StreamToPosixTransferClient.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/StreamToPosixTransferClient.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.persist.services.transfer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.persist.api.storage.StorageLocation;
+import edu.unc.lib.dl.persist.api.transfer.BinaryTransferException;
+import edu.unc.lib.dl.persist.services.storage.HashedPosixStorageLocation;
+
+/**
+ * Client for transferring content to a posix filesystem storage location from input streams
+ *
+ * @author bbpennel
+ */
+public class StreamToPosixTransferClient extends StreamToFSTransferClient {
+
+    /**
+     * @param destination
+     */
+    public StreamToPosixTransferClient(StorageLocation destination) {
+        super(destination);
+    }
+
+    @Override
+    protected URI writeStream(PID binPid, InputStream sourceStream, boolean allowOverwrite) {
+        URI binUri = super.writeStream(binPid, sourceStream, allowOverwrite);
+        HashedPosixStorageLocation posixLoc = (HashedPosixStorageLocation) destination;
+
+        if (posixLoc.getPermissions() != null) {
+            Path binPath = Paths.get(binUri);
+
+            try {
+                Files.setPosixFilePermissions(binPath, posixLoc.getPermissions());
+            } catch (IOException e) {
+                throw new BinaryTransferException("Failed to set permissions in destination "
+                        + destination.getId(), e);
+            }
+        }
+
+        return binUri;
+    }
+}

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/storage/HashedFilesystemStorageLocationTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/storage/HashedFilesystemStorageLocationTest.java
@@ -36,7 +36,7 @@ public class HashedFilesystemStorageLocationTest {
 
     private static final String TEST_UUID = "2e8f7551-ef3c-4387-8c3d-a38609927800";
 
-    private HashedFilesystemStorageLocation loc;
+    protected HashedFilesystemStorageLocation loc;
 
     @Before
     public void setup() {

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/storage/HashedPosixStorageLocationTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/storage/HashedPosixStorageLocationTest.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.persist.services.storage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import edu.unc.lib.dl.persist.api.storage.StorageType;
+
+/**
+ * @author bbpennel
+ */
+public class HashedPosixStorageLocationTest extends HashedFilesystemStorageLocationTest {
+
+    private HashedPosixStorageLocation posixLoc;
+
+    @Override
+    @Before
+    public void setup() {
+        posixLoc = new HashedPosixStorageLocation();
+        loc = posixLoc;
+    }
+
+    @Override
+    @Test
+    public void getStorageType() {
+        assertEquals(StorageType.POSIX_FS, loc.getStorageType());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void setPermissionsInvalidFormat() {
+        posixLoc.setPermissions("what");
+    }
+
+    @Test
+    public void getPermissionsNoPermissions() {
+        assertNull(posixLoc.getPermissions());
+    }
+
+    @Test
+    public void getPermissionsWithOctal() {
+        posixLoc.setPermissions("0644");
+        Set<PosixFilePermission> perms = posixLoc.getPermissions();
+        assertEquals(4, perms.size());
+        assertTrue(perms.contains(PosixFilePermission.OWNER_WRITE));
+        assertTrue(perms.contains(PosixFilePermission.OWNER_READ));
+        assertTrue(perms.contains(PosixFilePermission.GROUP_READ));
+        assertTrue(perms.contains(PosixFilePermission.OTHERS_READ));
+    }
+}

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/transfer/FSToFSTransferClientTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/transfer/FSToFSTransferClientTest.java
@@ -46,22 +46,22 @@ import edu.unc.lib.dl.persist.api.transfer.BinaryTransferException;
  */
 public class FSToFSTransferClientTest {
 
-    private static final String TEST_UUID = "a168cf29-a2a9-4da8-9b8d-025855b180d5";
-    private static final String FILE_CONTENT = "File content";
+    protected static final String TEST_UUID = "a168cf29-a2a9-4da8-9b8d-025855b180d5";
+    protected static final String FILE_CONTENT = "File content";
 
-    private FSToFSTransferClient client;
+    protected FSToFSTransferClient client;
 
     @Rule
     public final TemporaryFolder tmpFolder = new TemporaryFolder();
-    private Path sourcePath;
-    private Path storagePath;
+    protected Path sourcePath;
+    protected Path storagePath;
     @Mock
-    private IngestSource ingestSource;
+    protected IngestSource ingestSource;
     @Mock
     private StorageLocation storageLoc;
 
-    private PID binPid;
-    private Path binDestPath;
+    protected PID binPid;
+    protected Path binDestPath;
 
     @Before
     public void setup() throws Exception {
@@ -174,7 +174,7 @@ public class FSToFSTransferClientTest {
         client.shutdown();
     }
 
-    private Path createSourceFile() throws Exception {
+    protected Path createSourceFile() throws Exception {
         return createFile(sourcePath.resolve("file.txt"), FILE_CONTENT);
     }
 
@@ -183,7 +183,7 @@ public class FSToFSTransferClientTest {
         return filePath;
     }
 
-    private void assertIsSourceFile(Path path) throws Exception {
+    protected void assertIsSourceFile(Path path) throws Exception {
         assertTrue("Source file was not present at " + path, path.toFile().exists());
         assertEquals(FILE_CONTENT, FileUtils.readFileToString(path.toFile(), "UTF-8"));
     }

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/transfer/FSToPosixTransferClientTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/transfer/FSToPosixTransferClientTest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.persist.services.transfer;
+
+import static edu.unc.lib.dl.model.DatastreamPids.getOriginalFilePid;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.persist.services.storage.HashedPosixStorageLocation;
+
+/**
+ * @author bbpennel
+ */
+public class FSToPosixTransferClientTest extends FSToFSTransferClientTest {
+
+    @Mock
+    private HashedPosixStorageLocation storageLoc;
+
+    private FSToPosixTransferClient posixClient;
+
+    @Override
+    @Before
+    public void setup() throws Exception {
+        initMocks(this);
+        tmpFolder.create();
+        sourcePath = tmpFolder.newFolder("source").toPath();
+        storagePath = tmpFolder.newFolder("storage").toPath();
+
+        this.posixClient = new FSToPosixTransferClient(ingestSource, storageLoc);
+        this.client = posixClient;
+
+        binPid = getOriginalFilePid(PIDs.get(TEST_UUID));
+        binDestPath = storagePath.resolve(binPid.getComponentId());
+
+        when(storageLoc.getStorageUri(binPid)).thenReturn(binDestPath.toUri());
+        when(storageLoc.getPermissions()).thenReturn(null);
+    }
+
+    @Test
+    public void transfer_NewFile_WithPermissions() throws Exception {
+        when(storageLoc.getPermissions()).thenReturn(new HashSet<>(asList(
+                PosixFilePermission.OWNER_READ,
+                PosixFilePermission.OWNER_WRITE)));
+
+        Path sourceFile = createSourceFile();
+
+        URI binUri = client.transfer(binPid, sourceFile.toUri());
+        Path binPath = Paths.get(binUri);
+
+        assertIsSourceFile(binPath);
+
+        Set<PosixFilePermission> perms = Files.getPosixFilePermissions(binPath);
+        assertEquals(2, perms.size());
+        assertTrue(perms.contains(PosixFilePermission.OWNER_READ));
+        assertTrue(perms.contains(PosixFilePermission.OWNER_WRITE));
+    }
+}

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/transfer/StreamToFSTransferClientTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/transfer/StreamToFSTransferClientTest.java
@@ -47,20 +47,20 @@ import edu.unc.lib.dl.persist.api.transfer.BinaryTransferException;
  */
 public class StreamToFSTransferClientTest {
 
-    private static final String TEST_UUID = "a168cf29-a2a9-4da8-9b8d-025855b180d5";
-    private static final String ORIGINAL_CONTENT = "Some original stuff";
-    private static final String STREAM_CONTENT = "Stream content";
+    protected static final String TEST_UUID = "a168cf29-a2a9-4da8-9b8d-025855b180d5";
+    protected static final String ORIGINAL_CONTENT = "Some original stuff";
+    protected static final String STREAM_CONTENT = "Stream content";
 
-    private StreamToFSTransferClient client;
+    protected StreamToFSTransferClient client;
 
     @Rule
     public final TemporaryFolder tmpFolder = new TemporaryFolder();
-    private Path storagePath;
+    protected Path storagePath;
     @Mock
     private StorageLocation storageLoc;
 
-    private PID binPid;
-    private Path binDestPath;
+    protected PID binPid;
+    protected Path binDestPath;
 
     @Before
     public void setup() throws Exception {
@@ -139,12 +139,12 @@ public class StreamToFSTransferClientTest {
         }
     }
 
-    private void assertContent(Path path, String content) throws Exception {
+    protected void assertContent(Path path, String content) throws Exception {
         assertTrue("Source content was not present at " + path, path.toFile().exists());
         assertEquals(content, FileUtils.readFileToString(path.toFile(), "UTF-8"));
     }
 
-    private InputStream toStream(String content) {
+    protected InputStream toStream(String content) {
         return new ByteArrayInputStream(content.getBytes());
     }
 }

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/transfer/StreamToPosixTransferClientTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/transfer/StreamToPosixTransferClientTest.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.persist.services.transfer;
+
+import static edu.unc.lib.dl.model.DatastreamPids.getOriginalFilePid;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.persist.services.storage.HashedPosixStorageLocation;
+
+/**
+ * @author bbpennel
+ */
+public class StreamToPosixTransferClientTest extends StreamToFSTransferClientTest {
+
+    private StreamToPosixTransferClient posixClient;
+
+    @Mock
+    private HashedPosixStorageLocation storageLoc;
+
+    @Override
+    @Before
+    public void setup() throws Exception {
+        initMocks(this);
+        tmpFolder.create();
+        storagePath = tmpFolder.newFolder("storage").toPath();
+
+        this.posixClient = new StreamToPosixTransferClient(storageLoc);
+        this.client = posixClient;
+
+        binPid = getOriginalFilePid(PIDs.get(TEST_UUID));
+        binDestPath = storagePath.resolve(binPid.getComponentId());
+
+        when(storageLoc.getStorageUri(binPid)).thenReturn(binDestPath.toUri());
+        when(storageLoc.getPermissions()).thenReturn(null);
+    }
+
+    @Test
+    public void transfer_NewFile_WithPermissions() throws Exception {
+        when(storageLoc.getPermissions()).thenReturn(new HashSet<>(asList(
+                PosixFilePermission.OWNER_READ,
+                PosixFilePermission.OWNER_WRITE)));
+
+        InputStream sourceStream = toStream(STREAM_CONTENT);
+
+        URI binUri = client.transfer(binPid, sourceStream);
+
+        assertContent(binDestPath, STREAM_CONTENT);
+
+        Set<PosixFilePermission> perms = Files.getPosixFilePermissions(Paths.get(binUri));
+        assertEquals(2, perms.size());
+        assertTrue(perms.contains(PosixFilePermission.OWNER_READ));
+        assertTrue(perms.contains(PosixFilePermission.OWNER_WRITE));
+    }
+}


### PR DESCRIPTION
Resolves two separate issues that were causing premis updates to fail on dcr-test after the first modification

* Forces setting of size for premis log external binary as fedora was retrieving the incorrect size, only within this environment. There is a bug ticket to potentially try to investigate this further in the future.
* Adds support for posix based storage location that allows file permissions to be set on updated/created files.