### PR TITLE
BXC-2532/2533 - Migrate access controls

### DIFF
--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/acl/fcrepo4/ContentObjectAccessRestrictionValidator.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/acl/fcrepo4/ContentObjectAccessRestrictionValidator.java
@@ -19,6 +19,7 @@ import static edu.unc.lib.dl.rdf.CdrAcl.canAccess;
 import static edu.unc.lib.dl.rdf.CdrAcl.canDescribe;
 import static edu.unc.lib.dl.rdf.CdrAcl.canIngest;
 import static edu.unc.lib.dl.rdf.CdrAcl.canManage;
+import static edu.unc.lib.dl.rdf.CdrAcl.canProcess;
 import static edu.unc.lib.dl.rdf.CdrAcl.canViewAccessCopies;
 import static edu.unc.lib.dl.rdf.CdrAcl.canViewMetadata;
 import static edu.unc.lib.dl.rdf.CdrAcl.canViewOriginals;
@@ -56,17 +57,34 @@ import edu.unc.lib.dl.rdf.CdrAcl;
 public class ContentObjectAccessRestrictionValidator {
 
     private static final Set<Property> collectionProperties = new HashSet<>(Arrays.asList(
-            canViewMetadata, canViewAccessCopies, canViewOriginals,
-            canAccess, canDescribe, canIngest, canManage, none,
-            embargoUntil, markedForDeletion));
+            canViewMetadata,
+            canViewAccessCopies,
+            canViewOriginals,
+            canAccess,
+            canDescribe,
+            canIngest,
+            canProcess,
+            canManage,
+            none,
+            embargoUntil,
+            markedForDeletion));
 
     private static final Set<Property> adminUnitProperties = new HashSet<>(Arrays.asList(
-            canAccess, canDescribe, canIngest, canManage, unitOwner,
+            canAccess,
+            canDescribe,
+            canIngest,
+            canProcess,
+            canManage,
+            unitOwner,
             markedForDeletion));
 
     private static final Set<Property> contentProperties = new HashSet<>(Arrays.asList(
-            canViewMetadata, canViewAccessCopies, canViewOriginals, none,
-            embargoUntil, markedForDeletion));
+            canViewMetadata,
+            canViewAccessCopies,
+            canViewOriginals,
+            none,
+            embargoUntil,
+            markedForDeletion));
 
     private final Set<Resource> validObjectTypes;
 

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/acl/fcrepo4/ContentObjectAccessRestrictionValidatorTest.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/acl/fcrepo4/ContentObjectAccessRestrictionValidatorTest.java
@@ -151,6 +151,7 @@ public class ContentObjectAccessRestrictionValidatorTest {
         model.add(resc, CdrAcl.canViewAccessCopies, PUBLIC_PRINC);
         model.add(resc, CdrAcl.canViewOriginals, AUTHENTICATED_PRINC);
         model.add(resc, CdrAcl.canIngest, STAFF_PRINC);
+        model.add(resc, CdrAcl.canProcess, "processor_grp");
         model.add(resc, CdrAcl.canManage, OWNER_PRINC);
 
         validator.validate(resc);

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ACLTransformationHelpers.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ACLTransformationHelpers.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dcr.migration.content;
+
+import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.AUTHENTICATED_PRINC;
+import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.PUBLIC_PRINC;
+import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.vocabulary.RDF;
+
+import edu.unc.lib.dcr.migration.fcrepo3.ContentModelHelper.Bxc3UserRole;
+import edu.unc.lib.dcr.migration.fcrepo3.ContentModelHelper.CDRProperty;
+import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.rdf.Cdr;
+import edu.unc.lib.dl.rdf.CdrAcl;
+
+/**
+ * Helper methods for transforming content object access control settings
+ * from bxc3 to box5 expectations
+ *
+ * @author bbpennel
+ */
+public class ACLTransformationHelpers {
+
+    public final static String BXC3_PUBLIC_GROUP = "public";
+    public final static String BXC3_AUTHENTICATED_GROUP = "authenticated";
+
+    private static final Map<PID, Model> unitPatronAccessCache = new HashMap<>();
+
+    /**
+     * Transforms the bxc3 patron access control settings into bxc5
+     *
+     * Patron access settings found on an admin unit will be applied to its children
+     * collections instead, but only if the children do not have locally defined
+     * settings for the same groups.
+     *
+     * @param bxc3Resc
+     * @param bxc5Resc
+     * @param parentPid bxc5 PID of the parent
+     */
+    public static void transformPatronAccess(Resource bxc3Resc, Resource bxc5Resc, PID parentPid) {
+        // For admin units, cache patron access settings so they can be used for children instead
+        Resource destResc;
+        if (bxc5Resc.hasProperty(RDF.type, Cdr.AdminUnit)) {
+            Model unitModel = createDefaultModel();
+            PID unitPid = PIDs.get(bxc5Resc.getURI());
+            destResc = unitModel.getResource(unitPid.getRepositoryPath());
+            unitPatronAccessCache.put(unitPid, unitModel);
+        } else {
+            destResc = bxc5Resc;
+        }
+
+        if (bxc3Resc.hasProperty(CDRProperty.embargoUntil.getProperty())) {
+            destResc.addLiteral(CdrAcl.embargoUntil,
+                    bxc3Resc.getProperty(CDRProperty.embargoUntil.getProperty()).getString());
+        }
+
+        Property[] patronRoles = calculatePatronRoles(bxc3Resc);
+        Property everyoneRole = patronRoles[0];
+        Property authRole = patronRoles[1];
+
+        if (everyoneRole != null) {
+            destResc.addLiteral(everyoneRole, PUBLIC_PRINC);
+        }
+        if (authRole != null) {
+            destResc.addLiteral(authRole, AUTHENTICATED_PRINC);
+        }
+
+        // Merge in access settings from parent if present in the cache
+        mergeParentPatronAcls(parentPid, destResc, everyoneRole, authRole);
+    }
+
+    private static Property[] calculatePatronRoles(Resource bxc3Resc) {
+        if (bxc3Resc.hasLiteral(CDRProperty.isPublished.getProperty(), "no")
+                || bxc3Resc.hasLiteral(CDRProperty.allowIndexing.getProperty(), "no")) {
+            return new Property[] { CdrAcl.none, CdrAcl.none };
+        }
+
+        Property everyoneRole = null;
+        Property authRole = null;
+
+        StmtIterator stmtIt = bxc3Resc.listProperties();
+        while (stmtIt.hasNext()) {
+            Statement stmt = stmtIt.next();
+            if (!stmt.getObject().isLiteral()) {
+                continue;
+            }
+
+            String objectVal = stmt.getObject().asLiteral().getLexicalForm();
+            if (BXC3_PUBLIC_GROUP.equals(objectVal)) {
+                everyoneRole = mostRestrictiveRole(everyoneRole, stmt.getPredicate());
+            } else if (BXC3_AUTHENTICATED_GROUP.equals(objectVal)) {
+                authRole = mostRestrictiveRole(authRole, stmt.getPredicate());
+            }
+        }
+
+        boolean inherit = true;
+        if (bxc3Resc.hasProperty(CDRProperty.inheritPermissions.getProperty())) {
+            Statement stmt = bxc3Resc.getProperty(CDRProperty.inheritPermissions.getProperty());
+            inherit = Boolean.parseBoolean(stmt.getString());
+        }
+
+        if (!inherit) {
+            if (everyoneRole == null) {
+                everyoneRole = CdrAcl.none;
+            }
+            if (authRole == null) {
+                authRole = everyoneRole;
+            }
+        }
+
+        return new Property[] { everyoneRole, authRole };
+    }
+
+    private static Property mostRestrictiveRole(Property existingRole, Property bxc3Role) {
+        // Role can't become more restrictive via role property
+        if (CdrAcl.canViewMetadata.equals(existingRole) || CdrAcl.none.equals(existingRole)) {
+            return existingRole;
+        }
+
+        if (!Bxc3UserRole.metadataPatron.equals(bxc3Role)
+                && !Bxc3UserRole.accessCopiesPatron.equals(bxc3Role)
+                && !Bxc3UserRole.patron.equals(bxc3Role)) {
+            return existingRole;
+        }
+
+        if (Bxc3UserRole.metadataPatron.equals(bxc3Role)) {
+            return CdrAcl.canViewMetadata;
+        }
+        if (Bxc3UserRole.accessCopiesPatron.equals(bxc3Role)) {
+            return CdrAcl.canViewAccessCopies;
+        }
+        if (Bxc3UserRole.patron.equals(bxc3Role)) {
+            if (CdrAcl.canViewAccessCopies.equals(existingRole)) {
+                return existingRole;
+            } else {
+                return CdrAcl.canViewOriginals;
+            }
+        }
+
+        return existingRole;
+    }
+
+    private static void mergeParentPatronAcls(PID parentPid, Resource destResc, Property everyoneRole, Property authRole) {
+        // Merge in access settings from parent if present in the cache
+        Model parentUnitModel = unitPatronAccessCache.get(parentPid);
+        if (parentUnitModel != null) {
+            Resource parentUnitResc = parentUnitModel.getResource(parentPid.getRepositoryPath());
+            if (!destResc.hasProperty(CdrAcl.embargoUntil) && parentUnitResc.hasProperty(CdrAcl.embargoUntil)) {
+                destResc.addLiteral(CdrAcl.embargoUntil,
+                        parentUnitResc.getProperty(CdrAcl.embargoUntil).getLiteral().getString());
+            }
+            if (everyoneRole == null) {
+                StmtIterator it = parentUnitModel.listStatements(parentUnitResc, null, PUBLIC_PRINC);
+                if (it.hasNext()) {
+                    Statement roleStmt = it.next();
+                    destResc.addLiteral(roleStmt.getPredicate(), PUBLIC_PRINC);
+                    it.close();
+                }
+            }
+            if (authRole == null) {
+                StmtIterator it = parentUnitModel.listStatements(parentUnitResc, null, AUTHENTICATED_PRINC);
+                if (it.hasNext()) {
+                    Statement roleStmt = it.next();
+                    destResc.addLiteral(roleStmt.getPredicate(), AUTHENTICATED_PRINC);
+                    it.close();
+                }
+            }
+        }
+    }
+}

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ACLTransformationHelpers.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ACLTransformationHelpers.java
@@ -237,10 +237,11 @@ public class ACLTransformationHelpers {
     /**
      * Map all values of bxc3 user role to a bxc5 role, unless the principal is invalid
      *
-     * @param bxc3Role
-     * @param bxc5Role
-     * @param bxc3Resc
-     * @param bxc5Resc
+     * @param bxc3Role bxc3 role to transform if present
+     * @param bxc5Role bxc5 role which will be generated if the bxc3 role is found
+     * @param bxc3Resc bxc3 resource
+     * @param bxc5Resc bxc5 resource
+     * @param principalsAssigned principals which have had roles assigned so far
      */
     private static void mapStaffRole(Bxc3UserRole bxc3Role, Property bxc5Role,
             Resource bxc3Resc, Resource bxc5Resc, Set<String> principalsAssigned) {

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ACLTransformationHelpers.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ACLTransformationHelpers.java
@@ -56,6 +56,9 @@ public class ACLTransformationHelpers {
 
     private static final Map<PID, Model> unitPatronAccessCache = new HashMap<>();
 
+    private ACLTransformationHelpers() {
+    }
+
     /**
      * Transforms the bxc3 patron access control settings into bxc5
      *
@@ -185,7 +188,8 @@ public class ACLTransformationHelpers {
         return existingRole;
     }
 
-    private static void mergeParentPatronAcls(PID parentPid, Resource destResc, Property everyoneRole, Property authRole) {
+    private static void mergeParentPatronAcls(PID parentPid, Resource destResc, Property everyoneRole,
+            Property authRole) {
         // Merge in access settings from parent if present in the cache
         Model parentUnitModel = unitPatronAccessCache.get(parentPid);
         if (parentUnitModel != null) {

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformer.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformer.java
@@ -160,7 +160,8 @@ public class ContentObjectTransformer extends RecursiveAction {
         populateTimestamps(bxc3Resc, depResc);
         populateOriginalDeposit(bxc3Resc, depResc);
 
-        // TODO set patron access
+        // set patron access
+        ACLTransformationHelpers.transformPatronAccess(bxc3Resc, depResc, parentPid);
 
         // TODO set title, based on dc title and/or label
 

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformer.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformer.java
@@ -226,7 +226,10 @@ public class ContentObjectTransformer extends RecursiveAction {
         // transform PREMIS and copy to deposit directory
         transformPremis(originalPid, newPid);
 
-        // TODO set staff access
+        // set staff access if a unit or collection
+        if (Cdr.AdminUnit.equals(resourceType) || Cdr.Collection.equals(resourceType)) {
+            ACLTransformationHelpers.transformStaffRoles(bxc3Resc, containerBag);
+        }
     }
 
     private void populateFileObject(Resource bxc3Resc, Model depositModel) {

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/fcrepo3/ContentModelHelper.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/fcrepo3/ContentModelHelper.java
@@ -209,4 +209,31 @@ public class ContentModelHelper {
             return property;
         }
     }
+
+    public enum Bxc3UserRole {
+        list("list"),
+        accessCopiesPatron("access-copies-patron"),
+        metadataPatron("metadata-patron"),
+        patron("patron"),
+        observer("observer"),
+        ingester("ingester"),
+        metadataEditor("metadata-editor"),
+        processor("processor"),
+        curator("curator"),
+        administrator("administrator");
+
+        private Property property;
+
+        Bxc3UserRole(String predicate) {
+            property = createProperty(JDOMNamespaceUtil.CDR_ROLE_NS.getURI() + predicate);
+        }
+
+        public Property getProperty() {
+            return property;
+        }
+
+        public boolean equals(Property property) {
+            return this.property.equals(property);
+        }
+    }
 }

--- a/migration-util/src/test/java/edu/unc/lib/dcr/migration/content/ACLTransformationHelpersTest.java
+++ b/migration-util/src/test/java/edu/unc/lib/dcr/migration/content/ACLTransformationHelpersTest.java
@@ -1,0 +1,363 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dcr.migration.content;
+
+import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.DEPOSIT_RECORD_BASE;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.vocabulary.RDF;
+import org.jgroups.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+
+import edu.unc.lib.dcr.migration.fcrepo3.ContentModelHelper.Bxc3UserRole;
+import edu.unc.lib.dcr.migration.fcrepo3.ContentModelHelper.CDRProperty;
+import edu.unc.lib.dcr.migration.fcrepo3.ContentModelHelper.ContentModel;
+import edu.unc.lib.dcr.migration.fcrepo3.ContentModelHelper.FedoraProperty;
+import edu.unc.lib.dl.acl.util.AccessPrincipalConstants;
+import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.rdf.Cdr;
+import edu.unc.lib.dl.rdf.CdrAcl;
+
+/**
+ * @author bbpennel
+ */
+public class ACLTransformationHelpersTest {
+
+    private final static String EMBARGO_END_DATE = "2040-01-01T00:00:00";
+
+    private PID pid;
+    private PID parentPid;
+
+    @Before
+    public void setup() {
+        pid = PIDs.get(UUID.randomUUID().toString());
+        parentPid = PIDs.get(UUID.randomUUID().toString());
+    }
+
+    @Test
+    public void transformPatronAccess_BothAssignedRole() throws Exception {
+        Resource bxc3Resc = buildBoxc3Resource(pid, ContentModel.CONTAINER);
+
+        addRoleForPublic(bxc3Resc, Bxc3UserRole.metadataPatron);
+        addRoleForAuthenticated(bxc3Resc, Bxc3UserRole.patron);
+
+        Resource bxc5Resc = buildBoxc5Resource(pid, Cdr.Folder);
+
+        ACLTransformationHelpers.transformPatronAccess(bxc3Resc, bxc5Resc, parentPid);
+
+        assertEveryoneHasRole(CdrAcl.canViewMetadata, bxc5Resc);
+        assertAuthenticatedHasRole(CdrAcl.canViewOriginals, bxc5Resc);
+    }
+
+    @Test
+    public void transformPatronAccess_MultipleRolesForEveryone() throws Exception {
+        Resource bxc3Resc = buildBoxc3Resource(pid, ContentModel.CONTAINER);
+
+        addRoleForPublic(bxc3Resc, Bxc3UserRole.accessCopiesPatron);
+        addRoleForPublic(bxc3Resc, Bxc3UserRole.metadataPatron);
+        addRoleForPublic(bxc3Resc, Bxc3UserRole.patron);
+
+        Resource bxc5Resc = buildBoxc5Resource(pid, Cdr.Folder);
+
+        ACLTransformationHelpers.transformPatronAccess(bxc3Resc, bxc5Resc, parentPid);
+
+        assertEveryoneHasRole(CdrAcl.canViewMetadata, bxc5Resc);
+    }
+
+    @Test
+    public void transformPatronAccess_NoRoles() throws Exception {
+        Resource bxc3Resc = buildBoxc3Resource(pid, ContentModel.CONTAINER);
+
+        Resource bxc5Resc = buildBoxc5Resource(pid, Cdr.Folder);
+
+        ACLTransformationHelpers.transformPatronAccess(bxc3Resc, bxc5Resc, parentPid);
+
+        assertNoRolesAssignedforEveryone(bxc5Resc);
+        assertNoRolesAssignedforAuthenticated(bxc5Resc);
+    }
+
+    @Test
+    public void transformPatronAccess_NoRoles_InheritFalse() throws Exception {
+        Resource bxc3Resc = buildBoxc3Resource(pid, ContentModel.CONTAINER);
+
+        setInheritFromParent(bxc3Resc, false);
+
+        Resource bxc5Resc = buildBoxc5Resource(pid, Cdr.Folder);
+
+        ACLTransformationHelpers.transformPatronAccess(bxc3Resc, bxc5Resc, parentPid);
+
+        assertEveryoneHasRole(CdrAcl.none, bxc5Resc);
+        assertAuthenticatedHasRole(CdrAcl.none, bxc5Resc);
+    }
+
+    @Test
+    public void transformPatronAccess_OnlyPublicRole_InheritFalse() throws Exception {
+        Resource bxc3Resc = buildBoxc3Resource(pid, ContentModel.CONTAINER);
+
+        addRoleForPublic(bxc3Resc, Bxc3UserRole.accessCopiesPatron);
+        setInheritFromParent(bxc3Resc, false);
+
+        Resource bxc5Resc = buildBoxc5Resource(pid, Cdr.Folder);
+
+        ACLTransformationHelpers.transformPatronAccess(bxc3Resc, bxc5Resc, parentPid);
+
+        assertEveryoneHasRole(CdrAcl.canViewAccessCopies, bxc5Resc);
+        assertAuthenticatedHasRole(CdrAcl.canViewAccessCopies, bxc5Resc);
+    }
+
+    @Test
+    public void transformPatronAccess_OnlyPublicRole_InheritTrue() throws Exception {
+        Resource bxc3Resc = buildBoxc3Resource(pid, ContentModel.CONTAINER);
+
+        addRoleForPublic(bxc3Resc, Bxc3UserRole.accessCopiesPatron);
+        setInheritFromParent(bxc3Resc, true);
+
+        Resource bxc5Resc = buildBoxc5Resource(pid, Cdr.Folder);
+
+        ACLTransformationHelpers.transformPatronAccess(bxc3Resc, bxc5Resc, parentPid);
+
+        assertEveryoneHasRole(CdrAcl.canViewAccessCopies, bxc5Resc);
+        assertNoRolesAssignedforAuthenticated(bxc5Resc);
+    }
+
+
+    @Test
+    public void transformPatronAccess_EveryoneRole_WithEmbargo() throws Exception {
+        Resource bxc3Resc = buildBoxc3Resource(pid, ContentModel.CONTAINER);
+
+        addRoleForPublic(bxc3Resc, Bxc3UserRole.accessCopiesPatron);
+        addEmbargo(bxc3Resc, EMBARGO_END_DATE);
+
+        Resource bxc5Resc = buildBoxc5Resource(pid, Cdr.Folder);
+
+        ACLTransformationHelpers.transformPatronAccess(bxc3Resc, bxc5Resc, parentPid);
+
+        assertEveryoneHasRole(CdrAcl.canViewAccessCopies, bxc5Resc);
+        assertHasEmbargo(EMBARGO_END_DATE, bxc5Resc);
+    }
+
+    @Test
+    public void transformPatronAccess_Unpublished() throws Exception {
+        Resource bxc3Resc = buildBoxc3Resource(pid, ContentModel.CONTAINER);
+
+        addRoleForPublic(bxc3Resc, Bxc3UserRole.accessCopiesPatron);
+        addRoleForAuthenticated(bxc3Resc, Bxc3UserRole.patron);
+        setPublicationStatus(bxc3Resc, false);
+
+        Resource bxc5Resc = buildBoxc5Resource(pid, Cdr.Folder);
+
+        ACLTransformationHelpers.transformPatronAccess(bxc3Resc, bxc5Resc, parentPid);
+
+        assertEveryoneHasRole(CdrAcl.none, bxc5Resc);
+        assertAuthenticatedHasRole(CdrAcl.none, bxc5Resc);
+    }
+
+    @Test
+    public void transformPatronAccess_Published() throws Exception {
+        Resource bxc3Resc = buildBoxc3Resource(pid, ContentModel.CONTAINER);
+
+        addRoleForPublic(bxc3Resc, Bxc3UserRole.accessCopiesPatron);
+        addRoleForAuthenticated(bxc3Resc, Bxc3UserRole.patron);
+        setPublicationStatus(bxc3Resc, true);
+
+        Resource bxc5Resc = buildBoxc5Resource(pid, Cdr.Folder);
+
+        ACLTransformationHelpers.transformPatronAccess(bxc3Resc, bxc5Resc, parentPid);
+
+        assertEveryoneHasRole(CdrAcl.canViewAccessCopies, bxc5Resc);
+        assertAuthenticatedHasRole(CdrAcl.canViewOriginals, bxc5Resc);
+    }
+
+    @Test
+    public void transformPatronAccess_DisallowIndexing() throws Exception {
+        Resource bxc3Resc = buildBoxc3Resource(pid, ContentModel.CONTAINER);
+
+        addRoleForPublic(bxc3Resc, Bxc3UserRole.accessCopiesPatron);
+        addRoleForAuthenticated(bxc3Resc, Bxc3UserRole.patron);
+        setAllowIndexing(bxc3Resc, false);
+
+        Resource bxc5Resc = buildBoxc5Resource(pid, Cdr.Folder);
+
+        ACLTransformationHelpers.transformPatronAccess(bxc3Resc, bxc5Resc, parentPid);
+
+        assertEveryoneHasRole(CdrAcl.none, bxc5Resc);
+        assertAuthenticatedHasRole(CdrAcl.none, bxc5Resc);
+    }
+
+    @Test
+    public void transformPatronAccess_CollectionInUnit_UnitWithEmbargoAndRoles() throws Exception {
+        PID depositPid = PIDs.get(DEPOSIT_RECORD_BASE, UUID.randomUUID().toString());
+
+        // First try to transform the unit
+        Resource unitBxc3Resc = buildBoxc3Resource(parentPid, ContentModel.COLLECTION);
+
+        addRoleForPublic(unitBxc3Resc, Bxc3UserRole.accessCopiesPatron);
+        addRoleForAuthenticated(unitBxc3Resc, Bxc3UserRole.patron);
+        addEmbargo(unitBxc3Resc, EMBARGO_END_DATE);
+
+        Resource unitBxc5Resc = buildBoxc5Resource(parentPid, Cdr.AdminUnit);
+
+        ACLTransformationHelpers.transformPatronAccess(unitBxc3Resc, unitBxc5Resc, depositPid);
+
+        // Unit must not have any patron ACLs set
+        assertNoRolesAssignedforEveryone(unitBxc5Resc);
+        assertNoRolesAssignedforAuthenticated(unitBxc5Resc);
+        assertFalse(unitBxc5Resc.hasProperty(CdrAcl.embargoUntil));
+
+        // now transform the child collection, which adds no additional acls
+        Resource bxc3Resc = buildBoxc3Resource(pid, ContentModel.COLLECTION);
+        Resource bxc5Resc = buildBoxc5Resource(pid, Cdr.Collection);
+
+        ACLTransformationHelpers.transformPatronAccess(bxc3Resc, bxc5Resc, parentPid);
+
+        // Collection should have inherited all of the ACLs from the unit
+        assertEveryoneHasRole(CdrAcl.canViewAccessCopies, bxc5Resc);
+        assertAuthenticatedHasRole(CdrAcl.canViewOriginals, bxc5Resc);
+        assertHasEmbargo(EMBARGO_END_DATE, bxc5Resc);
+    }
+
+    @Test
+    public void transformPatronAccess_CollectionInUnit_BothWithEmbargoAndRoles() throws Exception {
+        PID depositPid = PIDs.get(DEPOSIT_RECORD_BASE, UUID.randomUUID().toString());
+
+        // First try to transform the unit
+        Resource unitBxc3Resc = buildBoxc3Resource(parentPid, ContentModel.COLLECTION);
+
+        addRoleForPublic(unitBxc3Resc, Bxc3UserRole.metadataPatron);
+        addRoleForAuthenticated(unitBxc3Resc, Bxc3UserRole.accessCopiesPatron);
+        addEmbargo(unitBxc3Resc, EMBARGO_END_DATE);
+
+        Resource unitBxc5Resc = buildBoxc5Resource(parentPid, Cdr.AdminUnit);
+
+        ACLTransformationHelpers.transformPatronAccess(unitBxc3Resc, unitBxc5Resc, depositPid);
+
+        // Unit must not have any patron ACLs set
+        assertNoRolesAssignedforEveryone(unitBxc5Resc);
+        assertNoRolesAssignedforAuthenticated(unitBxc5Resc);
+        assertFalse(unitBxc5Resc.hasProperty(CdrAcl.embargoUntil));
+
+        // now transform the child collection, which has its own ACLs
+        Resource bxc3Resc = buildBoxc3Resource(pid, ContentModel.COLLECTION);
+
+        addRoleForPublic(bxc3Resc, Bxc3UserRole.accessCopiesPatron);
+        addEmbargo(bxc3Resc, "2045-01-01T00:00:00");
+
+        Resource bxc5Resc = buildBoxc5Resource(pid, Cdr.Collection);
+
+        ACLTransformationHelpers.transformPatronAccess(bxc3Resc, bxc5Resc, parentPid);
+
+        // Collection ACLs, when present, should win
+        assertEveryoneHasRole(CdrAcl.canViewAccessCopies, bxc5Resc);
+        assertAuthenticatedHasRole(CdrAcl.canViewAccessCopies, bxc5Resc);
+        assertHasEmbargo("2045-01-01T00:00:00", bxc5Resc);
+    }
+
+    @Test
+    public void transformPatronAccess_DifferentBxc5Pid() throws Exception {
+        PID bxc5Pid = PIDs.get(UUID.randomUUID().toString());
+
+        Resource bxc3Resc = buildBoxc3Resource(pid, ContentModel.CONTAINER);
+
+        addRoleForPublic(bxc3Resc, Bxc3UserRole.metadataPatron);
+        addRoleForAuthenticated(bxc3Resc, Bxc3UserRole.patron);
+        addEmbargo(bxc3Resc, EMBARGO_END_DATE);
+
+        Resource bxc5Resc = buildBoxc5Resource(bxc5Pid, Cdr.Folder);
+
+        ACLTransformationHelpers.transformPatronAccess(bxc3Resc, bxc5Resc, parentPid);
+
+        assertEveryoneHasRole(CdrAcl.canViewMetadata, bxc5Resc);
+        assertAuthenticatedHasRole(CdrAcl.canViewOriginals, bxc5Resc);
+        assertHasEmbargo(EMBARGO_END_DATE, bxc5Resc);
+    }
+
+    private Resource buildBoxc3Resource(PID pid, ContentModel contentModel) {
+        Model bxc3Model = ModelFactory.createDefaultModel();
+        Resource bxc3Resc = bxc3Model.getResource(pid.getRepositoryPath());
+        bxc3Resc.addProperty(FedoraProperty.hasModel.getProperty(), contentModel.getResource());
+
+        return bxc3Resc;
+    }
+
+    private void addRoleForPublic(Resource bxc3Resc, Bxc3UserRole role) {
+        bxc3Resc.addLiteral(role.getProperty(), ACLTransformationHelpers.BXC3_PUBLIC_GROUP);
+    }
+
+    private void addRoleForAuthenticated(Resource bxc3Resc, Bxc3UserRole role) {
+        bxc3Resc.addLiteral(role.getProperty(), ACLTransformationHelpers.BXC3_AUTHENTICATED_GROUP);
+    }
+
+    private void setInheritFromParent(Resource bxc3Resc, boolean inherit) {
+        bxc3Resc.addLiteral(CDRProperty.inheritPermissions.getProperty(), Boolean.toString(inherit));
+    }
+
+    private void addEmbargo(Resource bxc3Resc, String embargoEndDate) {
+        bxc3Resc.addLiteral(CDRProperty.embargoUntil.getProperty(), embargoEndDate);
+    }
+
+    private void setPublicationStatus(Resource bxc3Resc, boolean isPublished) {
+        bxc3Resc.addLiteral(CDRProperty.isPublished.getProperty(), isPublished ? "yes" : "no");
+    }
+
+    private void setAllowIndexing(Resource bxc3Resc, boolean allow) {
+        bxc3Resc.addLiteral(CDRProperty.allowIndexing.getProperty(), allow ? "yes" : "no");
+    }
+
+    private Resource buildBoxc5Resource(PID pid, Resource resourceType) {
+        Model bxc5Model = ModelFactory.createDefaultModel();
+        Resource bxc5Resc = bxc5Model.getResource(pid.getRepositoryPath());
+        bxc5Resc.addProperty(RDF.type, resourceType);
+
+        return bxc5Resc;
+    }
+
+    private void assertEveryoneHasRole(Property role, Resource bxc5Resc) {
+        assertTrue("Everyone group did not have the expected role " + role + " for resource " + bxc5Resc.getURI(),
+                bxc5Resc.hasLiteral(role, AccessPrincipalConstants.PUBLIC_PRINC));
+    }
+
+    private void assertAuthenticatedHasRole(Property role, Resource bxc5Resc) {
+        assertTrue("Authenticated group did not have the expected role " + role + " for resource " + bxc5Resc.getURI(),
+                bxc5Resc.hasLiteral(role, AccessPrincipalConstants.AUTHENTICATED_PRINC));
+    }
+
+    private void assertNoRolesAssignedforEveryone(Resource bxc5Resc) {
+        List<Statement> roles = bxc5Resc.getModel().listStatements(
+                bxc5Resc, null, AccessPrincipalConstants.PUBLIC_PRINC).toList();
+        assertTrue("Expected no roles for everyone group on " + bxc5Resc.getURI(), roles.isEmpty());
+    }
+
+    private void assertNoRolesAssignedforAuthenticated(Resource bxc5Resc) {
+        List<Statement> roles = bxc5Resc.getModel().listStatements(
+                bxc5Resc, null, AccessPrincipalConstants.AUTHENTICATED_PRINC).toList();
+        assertTrue("Expected no roles for authenticated group on " + bxc5Resc.getURI(), roles.isEmpty());
+    }
+
+    private void assertHasEmbargo(String embargoEndDate, Resource bxc5Resc) {
+        assertTrue("Resource " + bxc5Resc.getURI() + " did not have expected embargo with end date " + embargoEndDate,
+                bxc5Resc.hasLiteral(CdrAcl.embargoUntil, embargoEndDate));
+    }
+}


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2532
https://jira.lib.unc.edu/browse/BXC-2533

See the Permissions Migration section of https://confluence.lib.unc.edu/display/RAT/Data+Migration+Planning for details.

* Migrates patron access controls for all content object types
  * transforms non-role assignment settings (like publication status, inheritance flag) into role assignments.
  * unit patron access assignments are moved to their child collections
* Migrates staff access controls
* Allows the canProcess role to be assigned during ingest.