### PR TITLE
BXC-2576/2590/2591 - Deposit bug fixes

### DIFF
--- a/deposit/src/main/java/edu/unc/lib/deposit/normalize/DirectoryToBagJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/normalize/DirectoryToBagJob.java
@@ -16,6 +16,7 @@
 package edu.unc.lib.deposit.normalize;
 
 import java.io.File;
+import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
@@ -57,8 +58,9 @@ public class DirectoryToBagJob extends AbstractFileServerToBagJob {
         Bag depositBag = model.createBag(getDepositPID().getURI().toString());
 
         Map<String, String> status = getDepositStatus();
-        String sourcePath = status.get(DepositField.sourceUri.name());
-        File sourceFile = new File(sourcePath);
+        URI sourceUri = URI.create(status.get(DepositField.sourceUri.name()));
+        Path sourcePath = Paths.get(sourceUri);
+        File sourceFile = sourcePath.toFile();
 
         // List all files and directories in the deposit, excluding the base directory
         Collection<File> fileListings =
@@ -82,7 +84,7 @@ public class DirectoryToBagJob extends AbstractFileServerToBagJob {
 
             Boolean isDir = file.isDirectory();
 
-            Path filePath = sourceFile.toPath().getParent().relativize(file.toPath());
+            Path filePath = sourcePath.getParent().relativize(file.toPath());
             String filePathString = filePath.toString();
             String filename = filePath.getFileName().toString();
 

--- a/deposit/src/main/java/edu/unc/lib/deposit/work/DepositEmailHandler.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/work/DepositEmailHandler.java
@@ -261,7 +261,7 @@ public class DepositEmailHandler {
 
             String uri = depositPID.getURI();
             this.dataset.begin(ReadWrite.READ);
-            Model model = this.dataset.getNamedModel(uri).begin();
+            Model model = this.dataset.getNamedModel(uri);
 
             String depositPid = depositPID.getURI();
             Bag depositBag = model.getBag(depositPid);

--- a/deposit/src/main/java/edu/unc/lib/deposit/work/DepositSupervisor.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/work/DepositSupervisor.java
@@ -35,6 +35,7 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 
 import org.apache.jena.query.Dataset;
+import org.apache.jena.query.ReadWrite;
 import org.apache.jena.rdf.model.Bag;
 import org.apache.jena.rdf.model.Model;
 import org.slf4j.Logger;
@@ -772,7 +773,8 @@ public class DepositSupervisor implements WorkerListener {
         Map<String, String> depositStatus = depositStatusFactory.get(depositUUID);
         PID depositPid = PIDs.get(DEPOSIT_RECORD_BASE, depositUUID);
         try {
-            Model model = dataset.getNamedModel(depositPid.getRepositoryPath()).begin();
+            dataset.begin(ReadWrite.READ);
+            Model model = dataset.getNamedModel(depositPid.getRepositoryPath());
 
             Bag depositBag = model.getBag(depositPid.getRepositoryPath());
 

--- a/deposit/src/test/java/edu/unc/lib/deposit/normalize/DirectoryToBagJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/normalize/DirectoryToBagJobTest.java
@@ -85,7 +85,7 @@ public class DirectoryToBagJobTest extends AbstractNormalizationJobTest {
 
     @Test
     public void testConversion() throws Exception {
-        status.put(DepositField.sourceUri.name(), depositDirectory.getAbsolutePath());
+        status.put(DepositField.sourceUri.name(), depositDirectory.toURI().toString());
         status.put(DepositField.fileName.name(), "Test File");
         status.put(DepositField.mediaId.name(), "789");
         status.put(DepositField.accessionNumber.name(), "123456");

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/FSToPosixTransferClient.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/FSToPosixTransferClient.java
@@ -15,16 +15,19 @@
  */
 package edu.unc.lib.dl.persist.services.transfer;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import org.slf4j.Logger;
+
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.persist.api.ingest.IngestSource;
 import edu.unc.lib.dl.persist.api.storage.StorageLocation;
-import edu.unc.lib.dl.persist.api.transfer.BinaryTransferException;
 import edu.unc.lib.dl.persist.services.storage.HashedPosixStorageLocation;
 
 /**
@@ -34,6 +37,7 @@ import edu.unc.lib.dl.persist.services.storage.HashedPosixStorageLocation;
  * @author bbpennel
  */
 public class FSToPosixTransferClient extends FSToFSTransferClient {
+    private static final Logger log = getLogger(FSToPosixTransferClient.class);
 
     /**
      * @param source
@@ -54,8 +58,7 @@ public class FSToPosixTransferClient extends FSToFSTransferClient {
             try {
                 Files.setPosixFilePermissions(binPath, posixLoc.getPermissions());
             } catch (IOException e) {
-                throw new BinaryTransferException("Failed to set permissions in destination "
-                        + destination.getId(), e);
+                log.debug("Failed to set permissions in destination {}", destination.getId());
             }
         }
 

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/modify/IngestSourceController.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/modify/IngestSourceController.java
@@ -16,7 +16,7 @@
 package edu.unc.lib.dl.cdr.services.rest.modify;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.net.URI;
 import java.nio.file.Paths;
@@ -74,7 +74,7 @@ public class IngestSourceController {
     @Autowired
     private DepositSubmissionService depositService;
 
-    @GetMapping(value = "/edit/ingestSources/list/{pid}", produces = APPLICATION_JSON_UTF8_VALUE)
+    @GetMapping(value = "/edit/ingestSources/list/{pid}", produces = APPLICATION_JSON_VALUE)
     @ResponseBody
     public ResponseEntity<Object> listIngestSources(@PathVariable("pid") String pid) {
         PID destination = PIDs.get(pid);
@@ -97,7 +97,7 @@ public class IngestSourceController {
         }
     }
 
-    @PostMapping(value = "/edit/ingestSources/ingest/{pid}", produces = APPLICATION_JSON_UTF8_VALUE)
+    @PostMapping(value = "/edit/ingestSources/ingest/{pid}", produces = APPLICATION_JSON_VALUE)
     @ResponseBody
     public ResponseEntity<Object> ingestFromSource(@PathVariable("pid") String pid,
             @RequestBody List<IngestPackageDetails> packages) {
@@ -114,7 +114,6 @@ public class IngestSourceController {
         results.put("destination", pid);
 
         List<String> depositIds = new ArrayList<>();
-        List<URI> candidateUris = new ArrayList<>();
 
         // Validate the packages requested for deposit
         for (IngestPackageDetails packageDetails : packages) {
@@ -140,8 +139,6 @@ public class IngestSourceController {
 
         // Build deposit entries and add to queue
         for (IngestPackageDetails packageDetails : packages) {
-            IngestSource source = sourceManager.getIngestSourceById(packageDetails.getSourceId());
-
             // Generate a filename if one was not provided
             String filename = packageDetails.getLabel();
             if (isBlank(filename)) {


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2576
https://jira.lib.unc.edu/browse/BXC-2590
https://jira.lib.unc.edu/browse/BXC-2591

* Downgrades failure when unable to set file permissions after moving a file into a POSIX storage location during ingest to a debug rather than a thrown exception.
* Fixes a transaction failure when sending emails after completing a migration deposit
* Fixes bug which caused all directory deposits to fail because they were not expecting uris