### PR TITLE
BXC-2390 - Links between apps and Header fixes

### DIFF
--- a/access/src/main/webapp/WEB-INF/jsp/common/footer.jsp
+++ b/access/src/main/webapp/WEB-INF/jsp/common/footer.jsp
@@ -21,7 +21,7 @@
 
 <footer>
     <p class="footer-menu container">
-        <a href="${pageContext.request.contextPath}/">Home</a> |
+        <a href="${accessBaseUrl}">Home</a> |
         <a href="collections">Browse Collections</a> |
         <a href="aboutRepository">About</a> |
         <a href="${contactUrl}">Contact Us</a> |

--- a/access/src/main/webapp/WEB-INF/jsp/common/header.jsp
+++ b/access/src/main/webapp/WEB-INF/jsp/common/header.jsp
@@ -45,18 +45,7 @@
                     <a href="aboutRepository" class="navbar-item">What's Here?</a>
                     <a href="${contactUrl}" class="navbar-item">Contact Us</a>
                     <c:if test="${sessionScope.accessLevel != null && sessionScope.accessLevel.viewAdmin}">
-                        <c:choose>
-                            <c:when test="${not empty resultResponse && not empty resultResponse.selectedContainer}">
-                                <c:set var="jumpToAdmin" value="list/${resultResponse.selectedContainer.id}" />
-                            </c:when>
-                            <c:when test="${not empty briefObject && briefObject.resourceType == 'File'}">
-                                <c:set var="jumpToAdmin" value="list/${briefObject.ancestorPathFacet.searchKey}" />
-                            </c:when>
-                            <c:when test="${not empty briefObject}">
-                                <c:set var="jumpToAdmin" value="list/${briefObject.id}" />
-                            </c:when>
-                        </c:choose>
-                        <a href="${adminBaseUrl}/${jumpToAdmin}" class="navbar-item" target="_blank">Admin</a>
+                        <a href="${adminBaseUrl}" class="navbar-item" target="_blank">Admin</a>
                     </c:if>
                 </div>
                 <div class="navbar-end">

--- a/access/src/main/webapp/WEB-INF/jsp/common/header.jsp
+++ b/access/src/main/webapp/WEB-INF/jsp/common/header.jsp
@@ -40,7 +40,6 @@
             </div>
             <div id="navbar" class="menu navbar-menu">
                 <div class="navbar-start">
-                    <a href="${pageContext.request.contextPath}/" class="navbar-item">Home</a>
                     <a href="collections" class="navbar-item">Browse Collections</a>
                     <a href="aboutRepository" class="navbar-item">What's Here?</a>
                     <a href="${contactUrl}" class="navbar-item">Contact Us</a>

--- a/access/src/main/webapp/WEB-INF/jsp/common/headerSmall.jsp
+++ b/access/src/main/webapp/WEB-INF/jsp/common/headerSmall.jsp
@@ -19,6 +19,7 @@
 <%@ page trimDirectiveWhitespaces="true" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="cdr" uri="http://cdr.lib.unc.edu/cdrUI" %>
+<%@ taglib prefix="s" uri="http://www.springframework.org/tags" %>
 
 <header>
     <div class="logo-row-small">
@@ -61,16 +62,22 @@
                 <c:if test="${sessionScope.accessLevel != null && sessionScope.accessLevel.viewAdmin}">
                     <c:choose>
                         <c:when test="${not empty resultResponse && not empty resultResponse.selectedContainer}">
-                            <c:set var="jumpToAdmin" value="list/${resultResponse.selectedContainer.id}" />
+                            <s:eval var="jumpToAdmin" expression=
+                                "T(edu.unc.lib.dl.util.URIUtil).join(adminBaseUrl, 'list', resultResponse.selectedContainer.id)" />
                         </c:when>
                         <c:when test="${not empty briefObject && briefObject.resourceType == 'File'}">
-                            <c:set var="jumpToAdmin" value="list/${briefObject.ancestorPathFacet.searchKey}" />
+                            <s:eval var="jumpToAdmin" expression=
+                                "T(edu.unc.lib.dl.util.URIUtil).join(adminBaseUrl, 'list', briefObject.ancestorPathFacet.searchKey)" />
                         </c:when>
                         <c:when test="${not empty briefObject}">
-                            <c:set var="jumpToAdmin" value="list/${briefObject.id}" />
+                            <s:eval var="jumpToAdmin" expression=
+                                "T(edu.unc.lib.dl.util.URIUtil).join(adminBaseUrl, 'list', briefObject.id)" />
                         </c:when>
+                        <c:otherwise>
+                            <c:set var="jumpToAdmin" value="${adminBaseUrl}" />
+                        </c:otherwise>
                     </c:choose>
-                    <a href="${adminBaseUrl}/${jumpToAdmin}" class="navbar-item" target="_blank">Admin</a>
+                    <a href="${jumpToAdmin}" class="navbar-item" target="_blank">Admin</a>
                 </c:if>
                 <a class="navbar-item navbar-display" href="${contactUrl}">Contact Us</a>
                 <c:choose>

--- a/access/src/main/webapp/WEB-INF/jsp/fullRecord/aggregateRecord.jsp
+++ b/access/src/main/webapp/WEB-INF/jsp/fullRecord/aggregateRecord.jsp
@@ -21,6 +21,7 @@
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 <%@ taglib prefix="cdr" uri="http://cdr.lib.unc.edu/cdrUI"%>
+<%@ taglib prefix="s" uri="http://www.springframework.org/tags" %>
 
 <c:choose>
 	<c:when test="${not empty briefObject.countMap}">
@@ -42,7 +43,9 @@
 					</div>
 					<div class="column is-narrow-desktop action-btn item-actions">
 						<c:if test="${permsHelper.hasEditAccess(accessGroupSet, briefObject)}">
-							<div class="actionlink right"><a class="button" href="${adminBaseUrl}/describe/${briefObject.id}"><i class="fa fa-edit"></i> Edit</a></div>
+							<s:eval var="editDescriptionUrl" expression=
+								"T(edu.unc.lib.dl.util.URIUtil).join(adminBaseUrl, 'describe', briefObject.id)" />
+							<div class="actionlink right"><a class="button" href="${editDescriptionUrl}"><i class="fa fa-edit"></i> Edit</a></div>
 						</c:if>
 
 						<c:choose>

--- a/access/src/main/webapp/WEB-INF/jsp/fullRecord/fileRecord.jsp
+++ b/access/src/main/webapp/WEB-INF/jsp/fullRecord/fileRecord.jsp
@@ -21,6 +21,8 @@
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %> 
 <%@ taglib prefix="cdr" uri="http://cdr.lib.unc.edu/cdrUI"%>
+<%@ taglib prefix="s" uri="http://www.springframework.org/tags" %>
+
 <div class="full_record_top">
     <div class="collinfo_metadata browse-header column">
         <c:import url="fullRecord/navigationBar.jsp" />
@@ -30,9 +32,9 @@
             </div>
             <div class="column is-narrow-desktop action-btn item-actions">
                 <c:if test="${permsHelper.hasEditAccess(accessGroupSet, briefObject)}">
-                    <div class="actionlink right"><a class="button" href="${adminBaseUrl}/describe/${briefObject.id}">
-                        <i class="fa fa-file" aria-hidden="true"></i> Edit</a>
-                    </div>
+                    <s:eval var="editDescriptionUrl" expression=
+                                "T(edu.unc.lib.dl.util.URIUtil).join(adminBaseUrl, 'describe', briefObject.id)" />
+                    <div class="actionlink right"><a class="button" href="${editDescriptionUrl}"><i class="fa fa-edit"></i> Edit</a></div>
                 </c:if>
                 <c:choose>
                     <c:when test="${permsHelper.hasOriginalAccess(requestScope.accessGroupSet, briefObject)}">

--- a/admin/src/main/webapp/WEB-INF/jsp/common/header.jsp
+++ b/admin/src/main/webapp/WEB-INF/jsp/common/header.jsp
@@ -18,6 +18,8 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ page trimDirectiveWhitespaces="true" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="s" uri="http://www.springframework.org/tags" %>
+
 <div class="dark shadowbottom" id="header">
 	<ul id="topbar">
 		<c:choose>
@@ -34,22 +36,9 @@
 				<li class="topbar-menu-option"><a href="<c:out value='${loginUrl}' />" class="login" id="login">Login</a></li>
 			</c:otherwise>
 		</c:choose>
-		<c:if test="${sessionScope.accessLevel != null && sessionScope.accessLevel.viewAdmin}">
-			<c:choose>
-				<c:when test="${not empty resultResponse && not empty resultResponse.selectedContainer}">
-					<c:set var="jumpToAdmin" value="list/${resultResponse.selectedContainer.id}" />
-				</c:when>
-				<c:when test="${not empty briefObject && briefObject.resourceType == 'File'}">
-					<c:set var="jumpToAdmin" value="list/${briefObject.ancestorPathFacet.searchKey}" />
-				</c:when>
-				<c:when test="${not empty briefObject}">
-					<c:set var="jumpToAdmin" value="list/${briefObject.id}" />
-				</c:when>
-			</c:choose>
-			<li class="topbar-menu-option">
-				<a href="${accessBaseUrl}/" data-base-href="${accessBaseUrl}/" id="public_ui_link" target="_blank">Public</a>
-			</li>
-		</c:if>
+		<li class="topbar-menu-option">
+			<a href="${accessBaseUrl}" data-base-href="${accessBaseUrl}" id="public_ui_link" target="_blank">Public</a>
+		</li>
 		<li class="topbar-menu-option">
 		<a href="https://library.unc.edu/wilson/contact/?refer=https%3a%2f%2fdcr.lib.unc.edu%2f">Contact</a></li>
 		<li class="topbar-menu-option">

--- a/admin/src/main/webapp/WEB-INF/jsp/common/header.jsp
+++ b/admin/src/main/webapp/WEB-INF/jsp/common/header.jsp
@@ -18,7 +18,6 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
 <%@ page trimDirectiveWhitespaces="true" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
-<%@ taglib prefix="s" uri="http://www.springframework.org/tags" %>
 
 <div class="dark shadowbottom" id="header">
 	<ul id="topbar">

--- a/admin/src/main/webapp/WEB-INF/jsp/edit/description.jsp
+++ b/admin/src/main/webapp/WEB-INF/jsp/edit/description.jsp
@@ -17,16 +17,24 @@
 --%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="cdr" uri="http://cdr.lib.unc.edu/cdrUI" %>
+<%@ taglib prefix="s" uri="http://www.springframework.org/tags" %>
 
 <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
 <link rel="stylesheet" type="text/css" href="/static/css/admin/jquery.xmleditor.css" />
+
+<s:eval var="viewRecordUrl" expression=
+	"T(edu.unc.lib.dl.util.URIUtil).join(accessBaseUrl, 'record', resultObject.id)" />
+<s:eval var="originalSubpath" expression=
+	"T(edu.unc.lib.dl.ui.util.DatastreamUtil).getOriginalFileUrl(resultObject)" />
+<s:eval var="originalFileUrl" expression=
+	"T(edu.unc.lib.dl.util.URIUtil).join(accessBaseUrl, originalSubpath)" />
 
 <script>
 	var require = {
 		config: {
 			'editDescription' : {
-				'recordUrl' : '${accessBaseUrl}/record/${resultObject.id}',
-				'originalUrl' : '${accessBaseUrl}/${cdr:getOriginalFileUrl(resultObject)}'
+				'recordUrl' : '${viewRecordUrl}',
+				'originalUrl' : '${originalFileUrl}'
 			}
 		}
 	};

--- a/static/js/admin/src/ResultView.js
+++ b/static/js/admin/src/ResultView.js
@@ -164,8 +164,13 @@ define('ResultView', [ 'jquery', 'jquery-ui', 'ResultObjectList', 'URLUtilities'
 					if (data.container) {
 						var $publicLink = $("#public_ui_link");
 						var baseHref = $publicLink.data("base-href");
-						var show_record_text = data.container.id === "collections" ? "" : "record";
-						$publicLink.attr("href", baseHref + show_record_text + "/" + data.container.id);
+						var public_link_path;
+						if (data.container.id === "collections") {
+							public_link_path = data.container.id;
+						} else {
+							public_link_path = "record" + "/" + data.container.id;
+						}
+						$publicLink.attr("href", baseHref + public_link_path);
 					}
 					
 					$("#result_loading_icon").addClass("hidden");


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2390

* Fixes double slash after application name in links between applications
* Resolves most cases where "access" shows up in urls. The Log on and Contact Us links are still incorrect until a separate ansible ticket is merged
* Removes the "Home" link from the front page (it was already gone from interior pages)