### PR TITLE
BXC-2580 - View premis log

### DIFF
--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/model/DatastreamType.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/model/DatastreamType.java
@@ -34,7 +34,7 @@ public enum DatastreamType {
     FULLTEXT_EXTRACTION("fulltext", "text/plain", "txt", EXTERNAL, viewHidden),
     JP2_ACCESS_COPY("jp2", "image/jp2", "jp2", EXTERNAL, viewAccessCopies),
     MD_DESCRIPTIVE("md_descriptive", "text/xml", "xml", INTERNAL, viewMetadata),
-    MD_EVENTS("event_log", "application/n-triples", "nt", INTERNAL, viewMetadata),
+    MD_EVENTS("event_log", "application/n-triples", "nt", INTERNAL, viewHidden),
     ORIGINAL_FILE("original_file", null, null, INTERNAL, viewOriginal),
     TECHNICAL_METADATA("techmd_fits", "text/xml", "xml", INTERNAL, viewHidden),
     THUMBNAIL_SMALL("thumbnail_small", "image/png", "png", EXTERNAL, viewMetadata),

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/DatastreamController.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/DatastreamController.java
@@ -43,6 +43,7 @@ import edu.unc.lib.dl.fcrepo4.PIDs;
 import edu.unc.lib.dl.fedora.NotFoundException;
 import edu.unc.lib.dl.fedora.ObjectTypeMismatchException;
 import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.model.DatastreamType;
 import edu.unc.lib.dl.ui.exception.ResourceNotFoundException;
 import edu.unc.lib.dl.ui.service.DerivativeContentService;
 import edu.unc.lib.dl.ui.service.FedoraContentService;
@@ -87,6 +88,8 @@ public class DatastreamController {
         try {
             if (isDerivative(datastream)) {
                 derivativeContentService.streamData(pid, datastream, principals, false, response);
+            } else if (DatastreamType.MD_EVENTS.getId().equals(datastream)) {
+                fedoraContentService.streamEventLog(pid, principals, download, response);
             } else {
                 fedoraContentService.streamData(pid, datastream, principals, download, response);
                 recordDownloadEvent(pid, datastream, principals, request);

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/DatastreamRestControllerIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/DatastreamRestControllerIT.java
@@ -15,6 +15,7 @@
  */
 package edu.unc.lib.dl.cdr.services.rest;
 
+import static edu.unc.lib.dl.acl.util.Permission.viewHidden;
 import static edu.unc.lib.dl.acl.util.Permission.viewMetadata;
 import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.HASHED_PATH_DEPTH;
 import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.HASHED_PATH_SIZE;
@@ -292,7 +293,7 @@ public class DatastreamRestControllerIT extends AbstractAPIIT {
             .writeAndClose();
 
         doThrow(new AccessRestrictionException()).when(accessControlService)
-                .assertHasAccess(anyString(), eq(folderPid), any(AccessGroupSet.class), eq(viewMetadata));
+                .assertHasAccess(anyString(), eq(folderPid), any(AccessGroupSet.class), eq(viewHidden));
 
         MvcResult result = mvc.perform(get("/file/" + id + "/" + MD_EVENTS.getId()))
                 .andExpect(status().isForbidden())

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/DatastreamRestControllerIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/DatastreamRestControllerIT.java
@@ -26,7 +26,7 @@ import static edu.unc.lib.dl.model.DatastreamType.TECHNICAL_METADATA;
 import static edu.unc.lib.dl.model.DatastreamType.THUMBNAIL_SMALL;
 import static edu.unc.lib.dl.ui.service.FedoraContentService.CONTENT_DISPOSITION;
 import static edu.unc.lib.dl.util.RDFModelUtil.createModel;
-import static org.h2.util.IOUtils.getInputStreamFromString;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
@@ -42,6 +42,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.vocabulary.RDF;
 import org.junit.Before;
@@ -258,7 +259,7 @@ public class DatastreamRestControllerIT extends AbstractAPIIT {
         assertEquals("text/turtle", response.getContentType());
         assertEquals("inline; filename=\"" + id + "_event_log.ttl\"", response.getHeader(CONTENT_DISPOSITION));
 
-        Model premisModel = createModel(getInputStreamFromString(response.getContentAsString()), "TURTLE");
+        Model premisModel = createModel(IOUtils.toInputStream(response.getContentAsString(), UTF_8), "TURTLE");
         assertEquals("Response did not contain expected premis event",
                 1, premisModel.listStatements(null, RDF.type, Premis.Event).toList().size());
 

--- a/static/js/admin/src/ResultObjectActionMenu.js
+++ b/static/js/admin/src/ResultObjectActionMenu.js
@@ -114,6 +114,7 @@ define('ResultObjectActionMenu', [ 'jquery', 'jquery-ui', 'StringUtilities',  'A
 			items["viewFile"] = {name : "View File"
 				+ " ("+ StringUtilities.readableFileSize(originalFile['fileSize']) + ")"};
 		}
+    items["viewEventLog"] = {name : "View Event Log"};
 		
 		// Modification options
 		items["sepedit"] = "";
@@ -234,6 +235,14 @@ define('ResultObjectActionMenu', [ 'jquery', 'jquery-ui', 'StringUtilities',  'A
 								application : "access"
 							});
 						}
+						break;
+					case "viewEventLog" :
+						self.actionHandler.addEvent({
+							action : 'ChangeLocation',
+							url : "api/file/" + metadata.id + "/event_log",
+							newWindow : true,
+							application : "services"
+						});
 						break;
 					case "openContainer" :
 						self.actionHandler.addEvent({

--- a/static/js/admin/src/URLUtilities.js
+++ b/static/js/admin/src/URLUtilities.js
@@ -60,6 +60,10 @@ define('URLUtilities', ['jquery'], function($) {
 			return baseURL;
 		},
 
+		getServicesUrl: function() {
+			return this.getServerUrl() + 'services/';
+		},
+
 		getAdminUrl: function() {
 			return this.getServerUrl() + 'admin/';
 		},

--- a/static/js/admin/src/action/ChangeLocationAction.js
+++ b/static/js/admin/src/action/ChangeLocationAction.js
@@ -7,6 +7,8 @@ define('ChangeLocationAction', [ 'jquery', 'URLUtilities'], function($, URLUtili
 		var url;
 		if (this.context.application == "access") {
 			url = URLUtilities.getAccessUrl();
+		} else if (this.context.application == "services") {
+			url = URLUtilities.getServicesUrl();
 		} else {
 			url = URLUtilities.getAdminUrl();
 		}


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2580

* Adds link to download premis log per object in the admin ui
* Updates datastream controller and supporting service to be able to return the premis