### PR TITLE
BXC-2557/2558/2559 - Update PREMIS properties

### DIFF
--- a/deposit/src/main/java/edu/unc/lib/deposit/validate/VirusScanJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/validate/VirusScanJob.java
@@ -101,6 +101,7 @@ public class VirusScanJob extends AbstractDepositJob {
 
                 premisEventBuilder.addSoftwareAgent(SoftwareAgent.clamav.getFullname())
                     .addEventDetail("File passed pre-ingest scan for viruses")
+                    .addOutcome(true)
                     .write();
 
                 scannedObjects++;

--- a/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJobIT.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJobIT.java
@@ -223,7 +223,7 @@ public class IngestContentObjectsJobIT extends AbstractFedoraDepositJobIT {
         assertEquals("Folder title was not correctly set", label, title);
         // Verify that ingestion event gets added for folder
         Model logModel = folder.getPremisLog().getEventsModel();
-        assertTrue(logModel.contains(null, Premis.hasEventDetail,
+        assertTrue(logModel.contains(null, Premis.note,
                 "ingested as PID: " + folder.getPid().getQualifiedId()));
 
         assertClickCount(1);
@@ -287,20 +287,20 @@ public class IngestContentObjectsJobIT extends AbstractFedoraDepositJobIT {
         assertBinaryProperties(supObj, FILE2_LOC, FILE2_MIMETYPE, null, null, FILE2_SIZE);
         // Verify that ingestion event gets added for work
         Model workLogModel = mWork.getPremisLog().getEventsModel();
-        assertTrue(workLogModel.contains(null, Premis.hasEventDetail,
+        assertTrue(workLogModel.contains(null, Premis.note,
                 "ingested as PID: " + mWork.getPid().getQualifiedId()));
-        assertTrue(workLogModel.contains(null, Premis.hasEventDetail,
+        assertTrue(workLogModel.contains(null, Premis.note,
                 "added 2 child objects to this container"));
 
         // Verify that ingestion event gets added for primary object
         Model primLogModel = primaryObj.getPremisLog().getEventsModel();
-        assertTrue(primLogModel.contains(null, Premis.hasEventDetail,
+        assertTrue(primLogModel.contains(null, Premis.note,
                 "ingested as PID: " + mainPid.getQualifiedId()
                 + "\n ingested as filename: " + FILE1_LOC));
 
         // Verify that ingestion event gets added for supplementary object
         Model supLogModel = supObj.getPremisLog().getEventsModel();
-        assertTrue(supLogModel.contains(null, Premis.hasEventDetail,
+        assertTrue(supLogModel.contains(null, Premis.note,
                 "ingested as PID: " + supPid.getQualifiedId()
                 + "\n ingested as filename: " + FILE2_LOC));
 
@@ -620,9 +620,9 @@ public class IngestContentObjectsJobIT extends AbstractFedoraDepositJobIT {
         FolderObject folder = repoObjLoader.getFolderObject(folderObjPid);
 
         Model logModel = folder.getPremisLog().getEventsModel();
-        assertTrue(logModel.contains(null, Premis.hasEventType, Premis.Ingestion));
-        assertTrue(logModel.contains(null, Premis.hasEventType, Premis.Normalization));
-        assertTrue(logModel.contains(null, Premis.hasEventType, Premis.VirusCheck));
+        assertTrue(logModel.contains(null, RDF.type, Premis.Ingestion));
+        assertTrue(logModel.contains(null, RDF.type, Premis.Normalization));
+        assertTrue(logModel.contains(null, RDF.type, Premis.VirusCheck));
 
         assertLinksToDepositRecord(folder);
     }
@@ -659,7 +659,7 @@ public class IngestContentObjectsJobIT extends AbstractFedoraDepositJobIT {
         FolderObject folder = repoObjLoader.getFolderObject(folderObjPid);
 
         Model logModel = folder.getPremisLog().getEventsModel();
-        assertTrue(logModel.contains(null, Premis.hasEventType, Premis.Ingestion));
+        assertTrue(logModel.contains(null, RDF.type, Premis.Ingestion));
     }
 
     private void assertBinaryProperties(FileObject fileObj, String loc, String mimetype,

--- a/deposit/src/test/java/edu/unc/lib/deposit/validate/VirusScanJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/validate/VirusScanJobTest.java
@@ -18,6 +18,7 @@ package edu.unc.lib.deposit.validate;
 import static edu.unc.lib.dl.test.TestHelpers.setField;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.argThat;
@@ -110,6 +111,8 @@ public class VirusScanJobTest extends AbstractDepositJobTest {
 
         File examplesFile = new File("src/test/resources/examples");
         FileUtils.copyDirectory(examplesFile, depositDir);
+
+        when(premisEventBuilder.addOutcome(anyBoolean())).thenReturn(premisEventBuilder);
     }
 
     @Test
@@ -135,6 +138,7 @@ public class VirusScanJobTest extends AbstractDepositJobTest {
         verify(premisLoggerFactory).createPremisLogger(eq(file1Pid), any(File.class));
         verify(premisLoggerFactory).createPremisLogger(eq(file2Pid), any(File.class));
         verify(premisLoggerFactory).createPremisLogger(eq(depositPid), any(File.class));
+        verify(premisEventBuilder, times(2)).addOutcome(true);
     }
 
     @Test
@@ -168,6 +172,7 @@ public class VirusScanJobTest extends AbstractDepositJobTest {
             verify(premisLogger).buildEvent(eq(Premis.VirusCheck));
             verify(premisLoggerFactory).createPremisLogger(any(PID.class), any(File.class));
             verify(premisLoggerFactory).createPremisLogger(eq(file1Pid), any(File.class));
+            verify(premisEventBuilder).addOutcome(true);
         }
     }
 

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/event/FilePremisLogger.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/event/FilePremisLogger.java
@@ -32,7 +32,6 @@ import org.apache.jena.util.FileManager;
 
 import edu.unc.lib.dl.fcrepo4.RepositoryPIDMinter;
 import edu.unc.lib.dl.fedora.PID;
-import edu.unc.lib.dl.rdf.Premis;
 import edu.unc.lib.dl.util.ObjectPersistenceException;
 
 /**
@@ -63,7 +62,7 @@ public class FilePremisLogger implements PremisLogger {
             date = new Date();
         }
 
-        return new PremisEventBuilder(eventPid, eventType, date, this);
+        return new PremisEventBuilder(objectPid, eventPid, eventType, date, this);
     }
 
     /**
@@ -86,11 +85,8 @@ public class FilePremisLogger implements PremisLogger {
     @Override
     public PremisLogger writeEvents(Resource... eventResources) {
         Model logModel = getModel();
-        String pidString = objectPid.getRepositoryPath();
-        Resource objResc = logModel.getResource(pidString);
         // Add the events to the model for this event log
         for (Resource eventResc: eventResources) {
-            objResc.addProperty(Premis.hasEvent, eventResc);
             logModel.add(eventResc.getModel());
         }
 

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/event/FilePremisLogger.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/event/FilePremisLogger.java
@@ -29,9 +29,11 @@ import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFFormat;
 import org.apache.jena.util.FileManager;
+import org.apache.jena.vocabulary.RDF;
 
 import edu.unc.lib.dl.fcrepo4.RepositoryPIDMinter;
 import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.rdf.Premis;
 import edu.unc.lib.dl.util.ObjectPersistenceException;
 
 /**
@@ -85,18 +87,22 @@ public class FilePremisLogger implements PremisLogger {
     @Override
     public PremisLogger writeEvents(Resource... eventResources) {
         Model logModel = getModel();
+        // For new logs, add in representation statement
+        if (!premisFile.exists()) {
+            Resource repoObjResc = logModel.getResource(objectPid.getRepositoryPath());
+            repoObjResc.addProperty(RDF.type, Premis.Representation);
+        }
+
         // Add the events to the model for this event log
         for (Resource eventResc: eventResources) {
             logModel.add(eventResc.getModel());
         }
 
-        if (premisFile != null) {
-            // Persist the log to file
-            try (FileOutputStream rdfFile = new FileOutputStream(premisFile)) {
-                RDFDataMgr.write(rdfFile, logModel, RDFFormat.NTRIPLES);
-            } catch (IOException e) {
-                throw new ObjectPersistenceException("Failed to stream PREMIS log to file for " + objectPid, e);
-            }
+        // Persist the log to file
+        try (FileOutputStream rdfFile = new FileOutputStream(premisFile)) {
+            RDFDataMgr.write(rdfFile, logModel, RDFFormat.NTRIPLES);
+        } catch (IOException e) {
+            throw new ObjectPersistenceException("Failed to stream PREMIS log to file for " + objectPid, e);
         }
 
         return this;

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/event/PremisEventBuilder.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/event/PremisEventBuilder.java
@@ -35,6 +35,7 @@ import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.rdf.Premis;
 import edu.unc.lib.dl.rdf.PremisAgentType;
 import edu.unc.lib.dl.rdf.Prov;
+import edu.unc.lib.dl.rdf.Rdf;
 import edu.unc.lib.dl.util.DateTimeUtil;
 
 /**
@@ -164,26 +165,6 @@ public class PremisEventBuilder {
     }
 
     /**
-     * Add details describing the creation of a derivative datastream
-     *
-     * @param sourceDataStream
-     *            The identifier of source datastream
-     * @param destDataStream
-     *            The identifier of the datastream derived from the source.
-     * @return this event builder
-     */
-    public PremisEventBuilder addDerivative(String sourceDataStream, String destDataStream) {
-        Resource premisObjResc = getResource();
-
-        premisObjResc.addProperty(Premis.hasAgentName, sourceDataStream);
-        premisObjResc.addProperty(Premis.hasAgentType, "Source Data");
-        premisObjResc.addProperty(Premis.hasAgentName, destDataStream);
-        premisObjResc.addProperty(Premis.hasAgentType, "Derived Data");
-
-        return this;
-    }
-
-    /**
      * Add an agent to this event
      *
      * @param role
@@ -196,8 +177,8 @@ public class PremisEventBuilder {
         Resource premisObjResc = getResource();
         Resource linkingAgentInfo = model.createResource(eventPid.getRepositoryPath() + agentId);
 
-        linkingAgentInfo.addProperty(Premis.hasAgentType, type);
-        linkingAgentInfo.addProperty(Premis.hasAgentName, name);
+        linkingAgentInfo.addProperty(RDF.type, type);
+        linkingAgentInfo.addProperty(Rdf.label, name);
         premisObjResc.addProperty(role, linkingAgentInfo);
 
         return this;

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/event/PremisEventBuilder.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/event/PremisEventBuilder.java
@@ -103,22 +103,15 @@ public class PremisEventBuilder {
     }
 
     /**
-     * Add an event detail outcome note property to this event
+     * Add an event outcome property
      *
-     * @param detailNote
-     *            The message for this outcome detail
-     * @param args
-     *            Optional parameters that should be formatted into the message,
-     *            using String.format syntax.
+     * @param success if true, the outcome will be Success, otherwise Fail
      * @return this event builder
      */
-    public PremisEventBuilder addEventDetailOutcomeNote(String detailNote, Object... args) {
-        if (args != null) {
-            detailNote = MessageFormat.format(detailNote, args);
-        }
-
+    public PremisEventBuilder addOutcome(boolean success) {
         Resource premisObjResc = getResource();
-        premisObjResc.addProperty(Premis.hasEventOutcomeDetailNote, detailNote);
+        premisObjResc.addProperty(Premis.outcome, success ?
+                Premis.Success : Premis.Fail);
 
         return this;
     }

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/event/PremisEventBuilder.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/event/PremisEventBuilder.java
@@ -28,9 +28,8 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.vocabulary.DCTerms;
 import org.apache.jena.vocabulary.RDF;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.rdf.Premis;
@@ -44,18 +43,17 @@ import edu.unc.lib.dl.util.DateTimeUtil;
  *
  */
 public class PremisEventBuilder {
-    private static final Logger log = LoggerFactory.getLogger(PremisEventBuilder.class);
 
     private PID eventPid;
     private Model model;
     private PremisLogger premisLogger;
     private Resource premisObjResc;
 
-    public PremisEventBuilder(PID eventPid, Resource eventType, Date date,
+    public PremisEventBuilder(PID eventSubject, PID eventPid, Resource eventType, Date date,
             PremisLogger premisLogger) {
         this.eventPid = eventPid;
         this.premisLogger = premisLogger;
-        addEvent(eventType, date);
+        addEvent(eventSubject, eventType, date);
     }
 
     /**
@@ -65,12 +63,23 @@ public class PremisEventBuilder {
      * @param date
      * @return
      */
-    private PremisEventBuilder addEvent(Resource eventType, Date date) {
+    private PremisEventBuilder addEvent(PID eventSubject, Resource eventType, Date date) {
         Resource premisObjResc = getResource();
 
+        Model logModel = getModel();
+        Resource eventSubjectResc = logModel.getResource(eventSubject.getRepositoryPath());
+//        if (Premis.InformationPackageCreation.equals(eventType)
+//                || Premis.VirusCheck.equals(eventType)
+//                || Premis.Validation.equals(eventType)) {
+//            premisObjResc.addProperty(Prov.wasUsedBy, eventSubjectResc);
+//        } else if (Premis.Ingestion.equals(eventType)) {
+//            premisObjResc.addProperty(Prov.wasGeneratedBy, eventSubjectResc);
+//        } else {
+            eventSubjectResc.addProperty(Premis.hasEvent, premisObjResc);
+//        }
         premisObjResc.addProperty(RDF.type, Premis.Event);
-        premisObjResc.addProperty(Premis.hasEventType, eventType);
-        premisObjResc.addProperty(Premis.hasEventDateTime,
+        premisObjResc.addProperty(RDF.type, eventType);
+        premisObjResc.addProperty(DCTerms.date,
                 DateTimeUtil.formatDateToUTC(date), XSDDatatype.XSDdateTime);
 
         return this;
@@ -91,7 +100,7 @@ public class PremisEventBuilder {
             message = MessageFormat.format(message, args);
         }
         Resource premisObjResc = getResource();
-        premisObjResc.addProperty(Premis.hasEventDetail, message);
+        premisObjResc.addProperty(Premis.note, message);
 
         return this;
     }

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/event/PremisEventBuilder.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/event/PremisEventBuilder.java
@@ -73,9 +73,9 @@ public class PremisEventBuilder {
         Resource eventSubjectResc = logModel.getResource(eventSubject.getRepositoryPath());
         if (Premis.Ingestion.equals(eventType)
                 || Premis.Creation.equals(eventType)) {
-            eventSubjectResc.addProperty(Prov.wasGeneratedBy, premisObjResc);
+            premisObjResc.addProperty(Prov.generated, eventSubjectResc);
         } else {
-            eventSubjectResc.addProperty(Prov.wasUsedBy, premisObjResc);
+            premisObjResc.addProperty(Prov.used, eventSubjectResc);
         }
         premisObjResc.addProperty(RDF.type, eventType);
         premisObjResc.addProperty(DCTerms.date,

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/event/PremisEventBuilder.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/event/PremisEventBuilder.java
@@ -34,6 +34,7 @@ import org.apache.jena.vocabulary.RDF;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.rdf.Premis;
 import edu.unc.lib.dl.rdf.PremisAgentType;
+import edu.unc.lib.dl.rdf.Prov;
 import edu.unc.lib.dl.util.DateTimeUtil;
 
 /**
@@ -68,16 +69,12 @@ public class PremisEventBuilder {
 
         Model logModel = getModel();
         Resource eventSubjectResc = logModel.getResource(eventSubject.getRepositoryPath());
-//        if (Premis.InformationPackageCreation.equals(eventType)
-//                || Premis.VirusCheck.equals(eventType)
-//                || Premis.Validation.equals(eventType)) {
-//            premisObjResc.addProperty(Prov.wasUsedBy, eventSubjectResc);
-//        } else if (Premis.Ingestion.equals(eventType)) {
-//            premisObjResc.addProperty(Prov.wasGeneratedBy, eventSubjectResc);
-//        } else {
-            eventSubjectResc.addProperty(Premis.hasEvent, premisObjResc);
-//        }
-        premisObjResc.addProperty(RDF.type, Premis.Event);
+        if (Premis.Ingestion.equals(eventType)
+                || Premis.Creation.equals(eventType)) {
+            eventSubjectResc.addProperty(Prov.wasGeneratedBy, premisObjResc);
+        } else {
+            eventSubjectResc.addProperty(Prov.wasUsedBy, premisObjResc);
+        }
         premisObjResc.addProperty(RDF.type, eventType);
         premisObjResc.addProperty(DCTerms.date,
                 DateTimeUtil.formatDateToUTC(date), XSDDatatype.XSDdateTime);

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/event/PremisEventBuilder.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/event/PremisEventBuilder.java
@@ -28,6 +28,7 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.sparql.vocabulary.FOAF;
 import org.apache.jena.vocabulary.DCTerms;
 import org.apache.jena.vocabulary.RDF;
 
@@ -178,7 +179,12 @@ public class PremisEventBuilder {
         Resource linkingAgentInfo = model.createResource(eventPid.getRepositoryPath() + agentId);
 
         linkingAgentInfo.addProperty(RDF.type, type);
-        linkingAgentInfo.addProperty(Rdf.label, name);
+        if (PremisAgentType.Person.equals(type) || PremisAgentType.Organization.equals(type)) {
+            linkingAgentInfo.addProperty(FOAF.name, name);
+        } else {
+            linkingAgentInfo.addProperty(Rdf.label, name);
+        }
+
         premisObjResc.addProperty(role, linkingAgentInfo);
 
         return this;

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/event/RepositoryPremisLogger.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/event/RepositoryPremisLogger.java
@@ -91,7 +91,7 @@ public class RepositoryPremisLogger implements PremisLogger {
             date = new Date();
         }
 
-        return new PremisEventBuilder(eventPid, eventType, date, this);
+        return new PremisEventBuilder(repoObject.getPid(), eventPid, eventType, date, this);
     }
 
     @Override
@@ -99,12 +99,12 @@ public class RepositoryPremisLogger implements PremisLogger {
         return buildEvent(null, eventType, null);
     }
 
+
+
     @Override
     public PremisLogger writeEvents(Resource... eventResources) {
         Model logModel = ModelFactory.createDefaultModel();
         for (Resource eventResc: eventResources) {
-            // Add link from the object to this event
-            logModel.add(repoObject.getResource(), Premis.hasEvent, eventResc);
             logModel.add(eventResc.getModel());
         }
 

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/event/FilePremisLoggerTest.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/event/FilePremisLoggerTest.java
@@ -116,7 +116,7 @@ public class FilePremisLoggerTest extends AbstractFedoraTest {
 
         Resource objResc = model.getResource(pid.getRepositoryPath());
         assertTrue(objResc.hasProperty(RDF.type, Premis.Representation));
-        assertTrue(objResc.hasProperty(Prov.wasUsedBy, resource));
+        assertTrue(resource.hasProperty(Prov.used, objResc));
     }
 
     @Test
@@ -157,8 +157,8 @@ public class FilePremisLoggerTest extends AbstractFedoraTest {
 
         Resource objResc = model.getResource(pid.getRepositoryPath());
         assertTrue(objResc.hasProperty(RDF.type, Premis.Representation));
-        assertTrue(objResc.hasProperty(Prov.wasUsedBy, resc1));
-        assertTrue(objResc.hasProperty(Prov.wasUsedBy, resc2));
+        assertTrue(resc1.hasProperty(Prov.used, objResc));
+        assertTrue(resc2.hasProperty(Prov.used, objResc));
     }
 
     @Test
@@ -198,7 +198,7 @@ public class FilePremisLoggerTest extends AbstractFedoraTest {
 
         Resource objResc = logModel.getResource(pid.getRepositoryPath());
         assertTrue(objResc.hasProperty(RDF.type, Premis.Representation));
-        assertTrue(objResc.hasProperty(Prov.wasUsedBy, logEvent1Resc));
-        assertTrue(objResc.hasProperty(Prov.wasUsedBy, logEvent2Resc));
+        assertTrue(logEvent1Resc.hasProperty(Prov.used, objResc));
+        assertTrue(logEvent2Resc.hasProperty(Prov.used, objResc));
     }
 }

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/event/FilePremisLoggerTest.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/event/FilePremisLoggerTest.java
@@ -42,6 +42,7 @@ import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.rdf.Premis;
 import edu.unc.lib.dl.rdf.PremisAgentType;
 import edu.unc.lib.dl.rdf.Prov;
+import edu.unc.lib.dl.rdf.Rdf;
 import edu.unc.lib.dl.util.SoftwareAgentConstants.SoftwareAgent;
 
 /**
@@ -107,10 +108,10 @@ public class FilePremisLoggerTest extends AbstractFedoraTest {
                 resource.getProperty(Premis.outcome).getResource());
         assertEquals("Virus check property depositing agent not written to file", SoftwareAgent.clamav.getFullname(),
                 resource.getProperty(Premis.hasEventRelatedAgentExecutor)
-                .getProperty(Premis.hasAgentName).getObject().toString());
+                .getProperty(Rdf.label).getObject().toString());
         assertEquals("Virus check property authorizing agent not written to file", SoftwareAgent.depositService.getFullname(),
                 resource.getProperty(Premis.hasEventRelatedAgentAuthorizor)
-                .getProperty(Premis.hasAgentName).getObject().toString());
+                .getProperty(Rdf.label).getObject().toString());
 
         Resource objResc = model.getResource(pid.getRepositoryPath());
         assertTrue(objResc.hasProperty(RDF.type, Premis.Representation));
@@ -143,7 +144,7 @@ public class FilePremisLoggerTest extends AbstractFedoraTest {
                 resc1.getProperty(Premis.note).getObject().toString());
         assertEquals("Authorizing agent not written to file", SoftwareAgent.depositService.getFullname(),
                 resc1.getProperty(Premis.hasEventRelatedAgentAuthorizor)
-                        .getProperty(Premis.hasAgentName).getObject().toString());
+                        .getProperty(Rdf.label).getObject().toString());
 
         assertEquals("VirusCheck type not written to file", Premis.VirusCheck,
                 resc2.getProperty(RDF.type).getObject());
@@ -151,7 +152,7 @@ public class FilePremisLoggerTest extends AbstractFedoraTest {
                 resc2.getProperty(Premis.note).getObject().toString());
         assertEquals("Related agent not written to file", SoftwareAgent.clamav.getFullname(),
                 resc2.getProperty(Premis.hasEventRelatedAgentExecutor)
-                        .getProperty(Premis.hasAgentName).getObject().toString());
+                        .getProperty(Rdf.label).getObject().toString());
 
         Resource objResc = model.getResource(pid.getRepositoryPath());
         assertTrue(objResc.hasProperty(RDF.type, Premis.Representation));
@@ -178,23 +179,21 @@ public class FilePremisLoggerTest extends AbstractFedoraTest {
                 logEvent1Resc.getProperty(RDF.type).getObject());
         assertEquals("Event detail not written to file", "Event 1",
                 logEvent1Resc.getProperty(Premis.note).getString());
+        Resource event1AgentExecutor = logEvent1Resc.getProperty(Premis.hasEventRelatedAgentExecutor).getResource();
         assertEquals("Software agent not written to file", PremisAgentType.Software,
-                logEvent1Resc.getProperty(Premis.hasEventRelatedAgentExecutor).getResource()
-                    .getProperty(Premis.hasAgentType).getObject());
+                event1AgentExecutor.getProperty(RDF.type).getObject());
         assertEquals("Software agent name not written to file", "Agent 1",
-                logEvent1Resc.getProperty(Premis.hasEventRelatedAgentExecutor).getResource()
-                    .getProperty(Premis.hasAgentName).getObject().toString());
+                event1AgentExecutor.getProperty(Rdf.label).getObject().toString());
 
         assertEquals("VirusCheck type not written to file", Premis.VirusCheck,
                 logEvent2Resc.getProperty(RDF.type).getObject());
         assertEquals("Event detail not written to file", "Event 2",
                 logEvent2Resc.getProperty(Premis.note).getString());
+        Resource event2AgentAuth = logEvent2Resc.getProperty(Premis.hasEventRelatedAgentAuthorizor).getResource();
         assertEquals("Authorizing agent not written to file", PremisAgentType.Person,
-                logEvent2Resc.getProperty(Premis.hasEventRelatedAgentAuthorizor).getResource()
-                    .getProperty(Premis.hasAgentType).getObject());
+                event2AgentAuth.getProperty(RDF.type).getObject());
         assertEquals("Authorizing agent name not written to file", "Agent 2",
-                logEvent2Resc.getProperty(Premis.hasEventRelatedAgentAuthorizor).getResource()
-                    .getProperty(Premis.hasAgentName).getObject().toString());
+                event2AgentAuth.getProperty(Rdf.label).getObject().toString());
 
         Resource objResc = logModel.getResource(pid.getRepositoryPath());
         assertTrue(objResc.hasProperty(RDF.type, Premis.Representation));

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/event/FilePremisLoggerTest.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/event/FilePremisLoggerTest.java
@@ -39,6 +39,7 @@ import edu.unc.lib.dl.fcrepo4.RepositoryPathConstants;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.rdf.Premis;
 import edu.unc.lib.dl.rdf.PremisAgentType;
+import edu.unc.lib.dl.rdf.Prov;
 import edu.unc.lib.dl.util.SoftwareAgentConstants.SoftwareAgent;
 
 /**
@@ -107,7 +108,7 @@ public class FilePremisLoggerTest extends AbstractFedoraTest {
                 .getProperty(Premis.hasAgentName).getObject().toString());
 
         Resource objResc = model.getResource(pid.getRepositoryPath());
-        assertTrue(objResc.hasProperty(Premis.hasEvent, resource));
+        assertTrue(objResc.hasProperty(Prov.wasUsedBy, resource));
     }
 
     @Test
@@ -147,8 +148,8 @@ public class FilePremisLoggerTest extends AbstractFedoraTest {
                         .getProperty(Premis.hasAgentName).getObject().toString());
 
         Resource objResc = model.getResource(pid.getRepositoryPath());
-        assertTrue(objResc.hasProperty(Premis.hasEvent, resc1));
-        assertTrue(objResc.hasProperty(Premis.hasEvent, resc2));
+        assertTrue(objResc.hasProperty(Prov.wasUsedBy, resc1));
+        assertTrue(objResc.hasProperty(Prov.wasUsedBy, resc2));
     }
 
     @Test
@@ -189,7 +190,7 @@ public class FilePremisLoggerTest extends AbstractFedoraTest {
                     .getProperty(Premis.hasAgentName).getObject().toString());
 
         Resource objResc = logModel.getResource(pid.getRepositoryPath());
-        assertTrue(objResc.hasProperty(Premis.hasEvent, logEvent1Resc));
-        assertTrue(objResc.hasProperty(Premis.hasEvent, logEvent2Resc));
+        assertTrue(objResc.hasProperty(Prov.wasUsedBy, logEvent1Resc));
+        assertTrue(objResc.hasProperty(Prov.wasUsedBy, logEvent2Resc));
     }
 }

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/event/FilePremisLoggerTest.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/event/FilePremisLoggerTest.java
@@ -29,6 +29,7 @@ import java.util.UUID;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.sparql.vocabulary.FOAF;
 import org.apache.jena.vocabulary.RDF;
 import org.junit.Before;
 import org.junit.Rule;
@@ -111,7 +112,7 @@ public class FilePremisLoggerTest extends AbstractFedoraTest {
                 .getProperty(Rdf.label).getObject().toString());
         assertEquals("Virus check property authorizing agent not written to file", SoftwareAgent.depositService.getFullname(),
                 resource.getProperty(Premis.hasEventRelatedAgentAuthorizor)
-                .getProperty(Rdf.label).getObject().toString());
+                .getProperty(FOAF.name).getObject().toString());
 
         Resource objResc = model.getResource(pid.getRepositoryPath());
         assertTrue(objResc.hasProperty(RDF.type, Premis.Representation));
@@ -144,7 +145,7 @@ public class FilePremisLoggerTest extends AbstractFedoraTest {
                 resc1.getProperty(Premis.note).getObject().toString());
         assertEquals("Authorizing agent not written to file", SoftwareAgent.depositService.getFullname(),
                 resc1.getProperty(Premis.hasEventRelatedAgentAuthorizor)
-                        .getProperty(Rdf.label).getObject().toString());
+                        .getProperty(FOAF.name).getObject().toString());
 
         assertEquals("VirusCheck type not written to file", Premis.VirusCheck,
                 resc2.getProperty(RDF.type).getObject());
@@ -193,7 +194,7 @@ public class FilePremisLoggerTest extends AbstractFedoraTest {
         assertEquals("Authorizing agent not written to file", PremisAgentType.Person,
                 event2AgentAuth.getProperty(RDF.type).getObject());
         assertEquals("Authorizing agent name not written to file", "Agent 2",
-                event2AgentAuth.getProperty(Rdf.label).getObject().toString());
+                event2AgentAuth.getProperty(FOAF.name).getObject().toString());
 
         Resource objResc = logModel.getResource(pid.getRepositoryPath());
         assertTrue(objResc.hasProperty(RDF.type, Premis.Representation));

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/event/FilePremisLoggerTest.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/event/FilePremisLoggerTest.java
@@ -29,6 +29,7 @@ import java.util.UUID;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.vocabulary.RDF;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -93,9 +94,9 @@ public class FilePremisLoggerTest extends AbstractFedoraTest {
 
         assertTrue("File doesn't exist", premisFile.exists());
         assertEquals("Virus check property event not written to file", eventType,
-                resource.getProperty(Premis.hasEventType).getObject());
+                resource.getProperty(RDF.type).getObject());
         assertEquals("Virus check property message not written to file", message,
-                resource.getProperty(Premis.hasEventDetail).getObject().toString());
+                resource.getProperty(Premis.note).getObject().toString());
         assertEquals("Virus check property detailed note not written to file", detailedNote,
                 resource.getProperty(Premis.hasEventOutcomeDetailNote).getObject().toString());
         assertEquals("Virus check property depositing agent not written to file", SoftwareAgent.clamav.getFullname(),
@@ -130,17 +131,17 @@ public class FilePremisLoggerTest extends AbstractFedoraTest {
         assertNotEquals("Events must have separate uris", resc1, resc2);
 
         assertEquals("Normalization type not written to file", Premis.Normalization,
-                resc1.getProperty(Premis.hasEventType).getObject());
+                resc1.getProperty(RDF.type).getObject());
         assertEquals("Event detail not written to file", "Event 1",
-                resc1.getProperty(Premis.hasEventDetail).getObject().toString());
+                resc1.getProperty(Premis.note).getObject().toString());
         assertEquals("Authorizing agent not written to file", SoftwareAgent.depositService.getFullname(),
                 resc1.getProperty(Premis.hasEventRelatedAgentAuthorizor)
                         .getProperty(Premis.hasAgentName).getObject().toString());
 
         assertEquals("VirusCheck type not written to file", Premis.VirusCheck,
-                resc2.getProperty(Premis.hasEventType).getObject());
+                resc2.getProperty(RDF.type).getObject());
         assertEquals("Event detail not written to file", "Event 2",
-                resc2.getProperty(Premis.hasEventDetail).getObject().toString());
+                resc2.getProperty(Premis.note).getObject().toString());
         assertEquals("Related agent not written to file", SoftwareAgent.clamav.getFullname(),
                 resc2.getProperty(Premis.hasEventRelatedAgentExecutor)
                         .getProperty(Premis.hasAgentName).getObject().toString());
@@ -166,9 +167,9 @@ public class FilePremisLoggerTest extends AbstractFedoraTest {
         Resource logEvent2Resc = logModel.getResource(event2.getURI());
 
         assertEquals("Normalization type not written to file", Premis.Normalization,
-                logEvent1Resc.getProperty(Premis.hasEventType).getObject());
+                logEvent1Resc.getProperty(RDF.type).getObject());
         assertEquals("Event detail not written to file", "Event 1",
-                logEvent1Resc.getProperty(Premis.hasEventDetail).getString());
+                logEvent1Resc.getProperty(Premis.note).getString());
         assertEquals("Software agent not written to file", PremisAgentType.Software,
                 logEvent1Resc.getProperty(Premis.hasEventRelatedAgentExecutor).getResource()
                     .getProperty(Premis.hasAgentType).getObject());
@@ -177,9 +178,9 @@ public class FilePremisLoggerTest extends AbstractFedoraTest {
                     .getProperty(Premis.hasAgentName).getObject().toString());
 
         assertEquals("VirusCheck type not written to file", Premis.VirusCheck,
-                logEvent2Resc.getProperty(Premis.hasEventType).getObject());
+                logEvent2Resc.getProperty(RDF.type).getObject());
         assertEquals("Event detail not written to file", "Event 2",
-                logEvent2Resc.getProperty(Premis.hasEventDetail).getString());
+                logEvent2Resc.getProperty(Premis.note).getString());
         assertEquals("Authorizing agent not written to file", PremisAgentType.Person,
                 logEvent2Resc.getProperty(Premis.hasEventRelatedAgentAuthorizor).getResource()
                     .getProperty(Premis.hasAgentType).getObject());

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/event/FilePremisLoggerTest.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/event/FilePremisLoggerTest.java
@@ -31,7 +31,9 @@ import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.vocabulary.RDF;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import edu.unc.lib.dl.fcrepo4.AbstractFedoraTest;
 import edu.unc.lib.dl.fcrepo4.PIDs;
@@ -55,14 +57,18 @@ public class FilePremisLoggerTest extends AbstractFedoraTest {
     private PremisLogger premis;
     private Date date;
 
+    @Rule
+    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+
     @Before
     public void setup() throws Exception {
 
         depositUUID = UUID.randomUUID().toString();
         pid = PIDs.get(RepositoryPathConstants.DEPOSIT_RECORD_BASE + "/" + depositUUID);
         eventType = Premis.VirusCheck;
-        premisFile = File.createTempFile(depositUUID, ".nt");
-        premisFile.deleteOnExit();
+
+        tmpFolder.create();
+        premisFile = new File(tmpFolder.getRoot(), depositUUID + ".nt");
         premis = new FilePremisLogger(pid, premisFile, pidMinter);
         date = new Date();
     }
@@ -107,6 +113,7 @@ public class FilePremisLoggerTest extends AbstractFedoraTest {
                 .getProperty(Premis.hasAgentName).getObject().toString());
 
         Resource objResc = model.getResource(pid.getRepositoryPath());
+        assertTrue(objResc.hasProperty(RDF.type, Premis.Representation));
         assertTrue(objResc.hasProperty(Prov.wasUsedBy, resource));
     }
 
@@ -147,6 +154,7 @@ public class FilePremisLoggerTest extends AbstractFedoraTest {
                         .getProperty(Premis.hasAgentName).getObject().toString());
 
         Resource objResc = model.getResource(pid.getRepositoryPath());
+        assertTrue(objResc.hasProperty(RDF.type, Premis.Representation));
         assertTrue(objResc.hasProperty(Prov.wasUsedBy, resc1));
         assertTrue(objResc.hasProperty(Prov.wasUsedBy, resc2));
     }
@@ -189,6 +197,7 @@ public class FilePremisLoggerTest extends AbstractFedoraTest {
                     .getProperty(Premis.hasAgentName).getObject().toString());
 
         Resource objResc = logModel.getResource(pid.getRepositoryPath());
+        assertTrue(objResc.hasProperty(RDF.type, Premis.Representation));
         assertTrue(objResc.hasProperty(Prov.wasUsedBy, logEvent1Resc));
         assertTrue(objResc.hasProperty(Prov.wasUsedBy, logEvent2Resc));
     }

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/event/FilePremisLoggerTest.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/event/FilePremisLoggerTest.java
@@ -78,11 +78,10 @@ public class FilePremisLoggerTest extends AbstractFedoraTest {
     @Test
     public void testTripleWrite() throws IOException {
         String message = "Test event successfully added";
-        String detailedNote = "No viruses found";
 
         Resource premisBuilder = premis.buildEvent(null, eventType, date)
                 .addEventDetail(message)
-                .addEventDetailOutcomeNote(detailedNote)
+                .addOutcome(true)
                 .addSoftwareAgent(SoftwareAgent.clamav.getFullname())
                 .addAuthorizingAgent(SoftwareAgent.depositService.getFullname())
                 .create();
@@ -98,8 +97,8 @@ public class FilePremisLoggerTest extends AbstractFedoraTest {
                 resource.getProperty(RDF.type).getObject());
         assertEquals("Virus check property message not written to file", message,
                 resource.getProperty(Premis.note).getObject().toString());
-        assertEquals("Virus check property detailed note not written to file", detailedNote,
-                resource.getProperty(Premis.hasEventOutcomeDetailNote).getObject().toString());
+        assertEquals("Virus check did not have success outcome", Premis.Success,
+                resource.getProperty(Premis.outcome).getResource());
         assertEquals("Virus check property depositing agent not written to file", SoftwareAgent.clamav.getFullname(),
                 resource.getProperty(Premis.hasEventRelatedAgentExecutor)
                 .getProperty(Premis.hasAgentName).getObject().toString());

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/event/RepositoryPremisLoggerIT.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/event/RepositoryPremisLoggerIT.java
@@ -105,13 +105,12 @@ public class RepositoryPremisLoggerIT extends AbstractFedoraIT {
         Model logModel = logger.getEventsModel();
         Resource logEventResc = logModel.getResource(eventResc.getURI());
 
-        assertTrue("Must contain premis:hasEvent references from obj to event",
-                logModel.contains(parentObject.getResource(), Prov.wasUsedBy, logEventResc));
+        assertTrue("Must contain prov:used references from obj to event",
+                logModel.contains(logEventResc, Prov.used, parentObject.getResource()));
         assertTrue(logEventResc.hasProperty(RDF.type, Premis.VirusCheck));
 
         Resource objResc = logModel.getResource(parentObject.getPid().getRepositoryPath());
         assertTrue(objResc.hasProperty(RDF.type, Premis.Representation));
-        assertTrue(objResc.hasProperty(Prov.wasUsedBy, logEventResc));
     }
 
     @Test
@@ -151,9 +150,9 @@ public class RepositoryPremisLoggerIT extends AbstractFedoraIT {
         // Verify that hasEvent relations are present
         Resource objResc = logModel.getResource(parentObject.getPid().getRepositoryPath());
         assertTrue(objResc.hasProperty(RDF.type, Premis.Representation));
-        assertTrue(logModel.contains(objResc, Prov.wasUsedBy, logEvent1Resc));
-        assertTrue(logModel.contains(objResc, Prov.wasGeneratedBy, logEvent2Resc));
-        assertTrue(logModel.contains(objResc, Prov.wasUsedBy, logEvent3Resc));
+        assertTrue(logModel.contains(logEvent1Resc, Prov.used, objResc));
+        assertTrue(logModel.contains(logEvent2Resc, Prov.generated, objResc));
+        assertTrue(logModel.contains(logEvent3Resc, Prov.used, objResc));
 
         retrieveLogger.close();
     }

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/event/RepositoryPremisLoggerIT.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/event/RepositoryPremisLoggerIT.java
@@ -46,6 +46,7 @@ import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferService;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferSession;
 import edu.unc.lib.dl.rdf.Premis;
+import edu.unc.lib.dl.rdf.Prov;
 import edu.unc.lib.dl.util.SoftwareAgentConstants.SoftwareAgent;
 
 /**
@@ -105,7 +106,7 @@ public class RepositoryPremisLoggerIT extends AbstractFedoraIT {
         Resource logEventResc = logModel.getResource(eventResc.getURI());
 
         assertTrue("Must contain premis:hasEvent references from obj to event",
-                logModel.contains(parentObject.getResource(), Premis.hasEvent, logEventResc));
+                logModel.contains(parentObject.getResource(), Prov.wasUsedBy, logEventResc));
         assertTrue(logEventResc.hasProperty(RDF.type, Premis.VirusCheck));
     }
 
@@ -144,9 +145,9 @@ public class RepositoryPremisLoggerIT extends AbstractFedoraIT {
         assertTrue(logEvent3Resc.hasProperty(RDF.type, Premis.MessageDigestCalculation));
 
         // Verify that hasEvent relations are present
-        assertTrue(logModel.contains(parentObject.getResource(), Premis.hasEvent, logEvent1Resc));
-        assertTrue(logModel.contains(parentObject.getResource(), Premis.hasEvent, logEvent2Resc));
-        assertTrue(logModel.contains(parentObject.getResource(), Premis.hasEvent, logEvent3Resc));
+        assertTrue(logModel.contains(parentObject.getResource(), Prov.wasUsedBy, logEvent1Resc));
+        assertTrue(logModel.contains(parentObject.getResource(), Prov.wasGeneratedBy, logEvent2Resc));
+        assertTrue(logModel.contains(parentObject.getResource(), Prov.wasUsedBy, logEvent3Resc));
 
         retrieveLogger.close();
     }

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/event/RepositoryPremisLoggerIT.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/event/RepositoryPremisLoggerIT.java
@@ -108,6 +108,10 @@ public class RepositoryPremisLoggerIT extends AbstractFedoraIT {
         assertTrue("Must contain premis:hasEvent references from obj to event",
                 logModel.contains(parentObject.getResource(), Prov.wasUsedBy, logEventResc));
         assertTrue(logEventResc.hasProperty(RDF.type, Premis.VirusCheck));
+
+        Resource objResc = logModel.getResource(parentObject.getPid().getRepositoryPath());
+        assertTrue(objResc.hasProperty(RDF.type, Premis.Representation));
+        assertTrue(objResc.hasProperty(Prov.wasUsedBy, logEventResc));
     }
 
     @Test
@@ -145,9 +149,11 @@ public class RepositoryPremisLoggerIT extends AbstractFedoraIT {
         assertTrue(logEvent3Resc.hasProperty(RDF.type, Premis.MessageDigestCalculation));
 
         // Verify that hasEvent relations are present
-        assertTrue(logModel.contains(parentObject.getResource(), Prov.wasUsedBy, logEvent1Resc));
-        assertTrue(logModel.contains(parentObject.getResource(), Prov.wasGeneratedBy, logEvent2Resc));
-        assertTrue(logModel.contains(parentObject.getResource(), Prov.wasUsedBy, logEvent3Resc));
+        Resource objResc = logModel.getResource(parentObject.getPid().getRepositoryPath());
+        assertTrue(objResc.hasProperty(RDF.type, Premis.Representation));
+        assertTrue(logModel.contains(objResc, Prov.wasUsedBy, logEvent1Resc));
+        assertTrue(logModel.contains(objResc, Prov.wasGeneratedBy, logEvent2Resc));
+        assertTrue(logModel.contains(objResc, Prov.wasUsedBy, logEvent3Resc));
 
         retrieveLogger.close();
     }

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/event/RepositoryPremisLoggerIT.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/event/RepositoryPremisLoggerIT.java
@@ -31,6 +31,8 @@ import java.util.Date;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.vocabulary.DCTerms;
+import org.apache.jena.vocabulary.RDF;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -104,7 +106,7 @@ public class RepositoryPremisLoggerIT extends AbstractFedoraIT {
 
         assertTrue("Must contain premis:hasEvent references from obj to event",
                 logModel.contains(parentObject.getResource(), Premis.hasEvent, logEventResc));
-        assertTrue(logEventResc.hasProperty(Premis.hasEventType, Premis.VirusCheck));
+        assertTrue(logEventResc.hasProperty(RDF.type, Premis.VirusCheck));
     }
 
     @Test
@@ -136,15 +138,17 @@ public class RepositoryPremisLoggerIT extends AbstractFedoraIT {
         Resource logEvent2Resc = logModel.getResource(event2Resc.getURI());
         Resource logEvent3Resc = logModel.getResource(event3Resc.getURI());
 
-        assertTrue(logEvent1Resc.hasProperty(Premis.hasEventType, Premis.VirusCheck));
-        assertTrue(logEvent2Resc.hasProperty(Premis.hasEventType, Premis.Ingestion));
-        assertEquals("2010-01-02T12:00:00.000Z", logEvent2Resc.getProperty(Premis.hasEventDateTime).getString());
-        assertTrue(logEvent3Resc.hasProperty(Premis.hasEventType, Premis.MessageDigestCalculation));
+        assertTrue(logEvent1Resc.hasProperty(RDF.type, Premis.VirusCheck));
+        assertTrue(logEvent2Resc.hasProperty(RDF.type, Premis.Ingestion));
+        assertEquals("2010-01-02T12:00:00.000Z", logEvent2Resc.getProperty(DCTerms.date).getString());
+        assertTrue(logEvent3Resc.hasProperty(RDF.type, Premis.MessageDigestCalculation));
 
         // Verify that hasEvent relations are present
         assertTrue(logModel.contains(parentObject.getResource(), Premis.hasEvent, logEvent1Resc));
         assertTrue(logModel.contains(parentObject.getResource(), Premis.hasEvent, logEvent2Resc));
         assertTrue(logModel.contains(parentObject.getResource(), Premis.hasEvent, logEvent3Resc));
+
+        retrieveLogger.close();
     }
 
     @Test

--- a/metadata/src/main/java/edu/unc/lib/dl/rdf/Premis.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/rdf/Premis.java
@@ -222,7 +222,7 @@ public class Premis {
     public static final Resource Dissemination = createResource(
             "http://id.loc.gov/vocabulary/preservation/eventType/dis");
 
-    public static final Resource EventRelatedAgentRole = createResource(
+    public static final Resource Execution = createResource(
             "http://id.loc.gov/vocabulary/preservation/eventType/exe");
 
     public static final Resource FilenameChange = createResource(

--- a/metadata/src/main/java/edu/unc/lib/dl/rdf/Premis.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/rdf/Premis.java
@@ -260,4 +260,10 @@ public class Premis {
     public static final Resource Event = createResource("http://www.loc.gov/premis/rdf/v1#Event");
 
     public static final Property note = createProperty("http://www.loc.gov/premis/rdf/v3/note");
+
+    public static final Property outcome = createProperty("http://www.loc.gov/premis/rdf/v3/outcome");
+
+    public static final Resource Fail = createResource("http://id.loc.gov/vocabulary/preservation/eventOutcome/fai");
+
+    public static final Resource Success = createResource("http://id.loc.gov/vocabulary/preservation/eventOutcome/suc");
 }

--- a/metadata/src/main/java/edu/unc/lib/dl/rdf/Premis.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/rdf/Premis.java
@@ -258,4 +258,6 @@ public class Premis {
             "http://id.loc.gov/vocabulary/preservation/eventType/ipc");
 
     public static final Resource Event = createResource("http://www.loc.gov/premis/rdf/v1#Event");
+
+    public static final Property note = createProperty("http://www.loc.gov/premis/rdf/v3/note");
 }

--- a/metadata/src/main/java/edu/unc/lib/dl/rdf/Prov.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/rdf/Prov.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.rdf;
+
+import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
+
+import org.apache.jena.rdf.model.Property;
+
+/**
+ * PROV namespace properties
+ *
+ * @author bbpennel
+ */
+public class Prov {
+    private Prov() {
+    }
+
+    public static final String NS = "http://w3.org/ns/prov#";
+
+    /** The namespace of the vocabulary as a string
+     *  @see #NS */
+    public static String getURI() {
+        return NS;
+    }
+
+    public static final Property wasGeneratedBy = createProperty(NS + "wasGeneratedBy");
+    public static final Property wasUsedBy = createProperty(NS + "wasUsedBy");
+}

--- a/metadata/src/main/java/edu/unc/lib/dl/rdf/Prov.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/rdf/Prov.java
@@ -36,6 +36,6 @@ public class Prov {
         return NS;
     }
 
-    public static final Property wasGeneratedBy = createProperty(NS + "wasGeneratedBy");
-    public static final Property wasUsedBy = createProperty(NS + "wasUsedBy");
+    public static final Property generated = createProperty(NS + "generated");
+    public static final Property used = createProperty(NS + "used");
 }

--- a/metadata/src/test/java/edu/unc/lib/dl/sparql/SparqlUpdateHelperTest.java
+++ b/metadata/src/test/java/edu/unc/lib/dl/sparql/SparqlUpdateHelperTest.java
@@ -63,7 +63,7 @@ public class SparqlUpdateHelperTest {
         // Define a hash uri resource off of the main resource
         String hashUri = RESC_URI + "#event";
         Resource hashResc = insertModel.createResource(hashUri);
-        hashResc.addProperty(Premis.hasEventType, Premis.Capture);
+        hashResc.addProperty(RDF.type, Premis.Capture);
 
         // Build the update query
         String query = SparqlUpdateHelper.createSparqlInsert(insertModel);
@@ -83,7 +83,7 @@ public class SparqlUpdateHelperTest {
 
         // Make sure the hash uri got added too
         Resource destHash = destModel.getResource(hashUri);
-        assertTrue(destHash.hasProperty(Premis.hasEventType, Premis.Capture));
+        assertTrue(destHash.hasProperty(RDF.type, Premis.Capture));
     }
 
     @Test

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/premis/AbstractPremisToRdfTransformer.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/premis/AbstractPremisToRdfTransformer.java
@@ -112,6 +112,26 @@ public abstract class AbstractPremisToRdfTransformer extends RecursiveAction imp
         return outcomeDetailEl.getChildTextTrim("eventOutcomeDetailNote", PREMIS_V2_NS);
     }
 
+    protected Boolean getEventOutcome(Element eventEl) {
+        Element infoEl = eventEl.getChild("eventOutcomeInformation", PREMIS_V2_NS);
+        if (infoEl == null) {
+            return null;
+        }
+        Element outcomeEl = infoEl.getChild("eventOutcome", PREMIS_V2_NS);
+        if (outcomeEl == null) {
+            return null;
+        }
+
+        String outcomeText = outcomeEl.getTextTrim();
+        if ("success".equalsIgnoreCase(outcomeText) ) {
+            return true;
+        } else if ("failed".equalsIgnoreCase(outcomeText) || "fail".equalsIgnoreCase(outcomeText)) {
+            return false;
+        } else {
+            return null;
+        }
+    }
+
     protected PID getEventPid(Element eventEl) {
         String idVal = eventEl.getChild("eventIdentifier", PREMIS_V2_NS)
                 .getChildTextTrim("eventIdentifierValue", PREMIS_V2_NS);
@@ -135,6 +155,12 @@ public abstract class AbstractPremisToRdfTransformer extends RecursiveAction imp
     protected PremisEventBuilder createEventBuilder(Resource eventTypeResc, Element eventEl) {
         Date dateTime = getEventDateTime(eventEl);
         PID eventPid = getEventPid(eventEl);
-        return premisLogger.buildEvent(eventPid, eventTypeResc, dateTime);
+        Boolean outcome = getEventOutcome(eventEl);
+        PremisEventBuilder builder = premisLogger.buildEvent(eventPid, eventTypeResc, dateTime);
+        if (outcome != null) {
+            builder.addOutcome(outcome);
+        }
+
+        return builder;
     }
 }

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/premis/ContentPremisToRdfTransformer.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/premis/ContentPremisToRdfTransformer.java
@@ -290,20 +290,20 @@ public class ContentPremisToRdfTransformer extends AbstractPremisToRdfTransforme
         PremisEventBuilder builder = createEventBuilder(Premis.FixityCheck, eventEl)
                 .addEventDetail(eventOutcome);
 
-            eventEl.getChildren("linkingAgentIdentifier", PREMIS_V2_NS).forEach(agentEl -> {
-                String idType = agentEl.getChildTextTrim("linkingAgentIdentifierType", PREMIS_V2_NS);
-                String idVal = agentEl.getChildTextTrim("linkingAgentIdentifierValue", PREMIS_V2_NS);
-                builder.addSoftwareAgent(idType + " " + idVal);
-            });
-            builder.addSoftwareAgent(fixityCheckingService.getFullname());
+        eventEl.getChildren("linkingAgentIdentifier", PREMIS_V2_NS).forEach(agentEl -> {
+            String idType = agentEl.getChildTextTrim("linkingAgentIdentifierType", PREMIS_V2_NS);
+            String idVal = agentEl.getChildTextTrim("linkingAgentIdentifierValue", PREMIS_V2_NS);
+            builder.addSoftwareAgent(idType + " " + idVal);
+        });
+        builder.addSoftwareAgent(fixityCheckingService.getFullname());
 
-            eventEl.getChildren("linkingObjectIdentifier", PREMIS_V2_NS).stream().forEach(objEl -> {
-                String objectType = objEl.getChildTextTrim("linkingObjectIdentifierType", PREMIS_V2_NS);
-                String objectPath = objEl.getChildTextTrim("linkingObjectIdentifierValue", PREMIS_V2_NS);
-                builder.addEventDetail(objectType + " " + objectPath);
-            });
+        eventEl.getChildren("linkingObjectIdentifier", PREMIS_V2_NS).stream().forEach(objEl -> {
+            String objectType = objEl.getChildTextTrim("linkingObjectIdentifierType", PREMIS_V2_NS);
+            String objectPath = objEl.getChildTextTrim("linkingObjectIdentifierValue", PREMIS_V2_NS);
+            builder.addEventDetail(objectType + " " + objectPath);
+        });
 
-            builder.write();
+        builder.write();
     }
 
     private void addEvent(Element eventEl, Resource eventType, String eventDetail, SoftwareAgent agent) {

--- a/migration-util/src/test/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformerTest.java
+++ b/migration-util/src/test/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformerTest.java
@@ -868,7 +868,7 @@ public class ContentObjectTransformerTest {
 
         Resource eventResc = eventRescs.get(0);
         assertEquals("Event type did not match expected value",
-                Premis.VirusCheck, eventResc.getPropertyResourceValue(Premis.hasEventType));
+                Premis.VirusCheck, eventResc.getPropertyResourceValue(RDF.type));
     }
 
     private void addPatronAccess(Model bxc3Model, PID startingPid) {

--- a/migration-util/src/test/java/edu/unc/lib/dcr/migration/premis/AbstractPremisToRdfTransformerTest.java
+++ b/migration-util/src/test/java/edu/unc/lib/dcr/migration/premis/AbstractPremisToRdfTransformerTest.java
@@ -18,6 +18,8 @@ package edu.unc.lib.dcr.migration.premis;
 import static edu.unc.lib.dcr.migration.premis.TestPremisEventHelpers.createPremisDoc;
 import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
@@ -94,5 +96,20 @@ public abstract class AbstractPremisToRdfTransformerTest {
     protected void assertEventDateTime(String expected, Resource eventResc) {
         assertEquals("Event date time did not match expected value",
                 expected, eventResc.getProperty(DCTerms.date).getString());
+    }
+
+    protected void assertEventOutcomeSuccess(Resource eventResc) {
+        assertTrue("Expected event outcome to be Success",
+                eventResc.hasProperty(Premis.outcome, Premis.Success));
+    }
+
+    protected void assertEventOutcomeFail(Resource eventResc) {
+        assertTrue("Expected event outcome to be Fail",
+                eventResc.hasProperty(Premis.outcome, Premis.Fail));
+    }
+
+    protected void assertNoEventOutcome(Resource eventResc) {
+        assertFalse("Expected event to have no outcome status",
+                eventResc.hasProperty(Premis.outcome));
     }
 }

--- a/migration-util/src/test/java/edu/unc/lib/dcr/migration/premis/AbstractPremisToRdfTransformerTest.java
+++ b/migration-util/src/test/java/edu/unc/lib/dcr/migration/premis/AbstractPremisToRdfTransformerTest.java
@@ -25,6 +25,8 @@ import java.util.List;
 
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.vocabulary.DCTerms;
+import org.apache.jena.vocabulary.RDF;
 import org.jdom2.Document;
 import org.jgroups.util.UUID;
 import org.junit.Before;
@@ -70,17 +72,17 @@ public abstract class AbstractPremisToRdfTransformerTest {
     }
 
     protected Resource getResourceByEventDate(List<Resource> rescs, String eventDate) {
-        return rescs.stream().filter(r -> eventDate.equals(r.getProperty(Premis.hasEventDateTime).getString()))
+        return rescs.stream().filter(r -> eventDate.equals(r.getProperty(DCTerms.date).getString()))
                 .findFirst().get();
     }
 
     protected void assertEventType(Resource expectedType, Resource eventResc) {
         assertEquals("Event type did not match expected value",
-                expectedType, eventResc.getPropertyResourceValue(Premis.hasEventType));
+                expectedType, eventResc.getPropertyResourceValue(RDF.type));
     }
 
     protected void assertEventDetail(String expected, Resource eventResc) {
-        List<String> details = eventResc.listProperties(Premis.hasEventDetail).toList().stream()
+        List<String> details = eventResc.listProperties(Premis.note).toList().stream()
                 .map(Statement::getString).collect(toList());
         if (details.contains(expected)) {
             return;
@@ -91,6 +93,6 @@ public abstract class AbstractPremisToRdfTransformerTest {
 
     protected void assertEventDateTime(String expected, Resource eventResc) {
         assertEquals("Event date time did not match expected value",
-                expected, eventResc.getProperty(Premis.hasEventDateTime).getString());
+                expected, eventResc.getProperty(DCTerms.date).getString());
     }
 }

--- a/migration-util/src/test/java/edu/unc/lib/dcr/migration/premis/ContentPremisToRdfTransformerTest.java
+++ b/migration-util/src/test/java/edu/unc/lib/dcr/migration/premis/ContentPremisToRdfTransformerTest.java
@@ -56,12 +56,14 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.sparql.vocabulary.FOAF;
 import org.apache.jena.vocabulary.RDF;
 import org.jdom2.Element;
 import org.junit.Before;
 import org.junit.Test;
 
 import edu.unc.lib.dl.rdf.Premis;
+import edu.unc.lib.dl.rdf.PremisAgentType;
 import edu.unc.lib.dl.rdf.Rdf;
 
 /**
@@ -597,9 +599,16 @@ public class ContentPremisToRdfTransformerTest extends AbstractPremisToRdfTransf
     private void assertAgent(String agentName, Property hasProperty, Resource agentType, Resource eventResc) {
         for (Statement stmt: eventResc.listProperties(hasProperty).toList()) {
             Resource agentResc = stmt.getResource();
-            if (agentType.equals(agentResc.getPropertyResourceValue(RDF.type))
-                    && agentName.equals(agentResc.getProperty(Rdf.label).getString())) {
-                return;
+            if (agentType.equals(agentResc.getPropertyResourceValue(RDF.type))) {
+                String name;
+                if (Person.equals(agentType) || PremisAgentType.Organization.equals(agentType)) {
+                    name = agentResc.getProperty(FOAF.name).getString();
+                } else {
+                    name = agentResc.getProperty(Rdf.label).getString();
+                }
+                if (name.equals(agentName)) {
+                    return;
+                }
             }
         }
 

--- a/migration-util/src/test/java/edu/unc/lib/dcr/migration/premis/ContentPremisToRdfTransformerTest.java
+++ b/migration-util/src/test/java/edu/unc/lib/dcr/migration/premis/ContentPremisToRdfTransformerTest.java
@@ -56,11 +56,13 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.vocabulary.RDF;
 import org.jdom2.Element;
 import org.junit.Before;
 import org.junit.Test;
 
 import edu.unc.lib.dl.rdf.Premis;
+import edu.unc.lib.dl.rdf.Rdf;
 
 /**
  * @author bbpennel
@@ -595,8 +597,8 @@ public class ContentPremisToRdfTransformerTest extends AbstractPremisToRdfTransf
     private void assertAgent(String agentName, Property hasProperty, Resource agentType, Resource eventResc) {
         for (Statement stmt: eventResc.listProperties(hasProperty).toList()) {
             Resource agentResc = stmt.getResource();
-            if (agentType.equals(agentResc.getPropertyResourceValue(Premis.hasAgentType))
-                    && agentName.equals(agentResc.getProperty(Premis.hasAgentName).getString())) {
+            if (agentType.equals(agentResc.getPropertyResourceValue(RDF.type))
+                    && agentName.equals(agentResc.getProperty(Rdf.label).getString())) {
                 return;
             }
         }

--- a/migration-util/src/test/java/edu/unc/lib/dcr/migration/premis/ContentPremisToRdfTransformerTest.java
+++ b/migration-util/src/test/java/edu/unc/lib/dcr/migration/premis/ContentPremisToRdfTransformerTest.java
@@ -130,6 +130,7 @@ public class ContentPremisToRdfTransformerTest extends AbstractPremisToRdfTransf
         assertEventDetail("File passed pre-ingest scan for viruses.", eventResc);
         assertEventDateTime(EVENT_DATE_UTC, eventResc);
         assertAgent(clamav.getFullname(), Software, eventResc);
+        assertNoEventOutcome(eventResc);
     }
 
     @Test
@@ -138,6 +139,7 @@ public class ContentPremisToRdfTransformerTest extends AbstractPremisToRdfTransf
         Element eventEl = addEvent(premisDoc, VIRUS_CHECK_TYPE, detail, EVENT_DATE);
         addAgent(eventEl, "PID", INITIATOR_ROLE, VIRUS_AGENT);
         addAgent(eventEl, "Name", "ClamAV (ClamAV 0.100.2/25220/Tue Dec 18 21:49:44 2018)", SOFTWARE_ROLE);
+        addEventOutcome(eventEl, "success", null);
 
         transformer.compute();
 
@@ -150,6 +152,7 @@ public class ContentPremisToRdfTransformerTest extends AbstractPremisToRdfTransf
         assertEventDetail(detail, eventResc);
         assertEventDateTime(EVENT_DATE_UTC, eventResc);
         assertAgent(clamav.getFullname(), Software, eventResc);
+        assertEventOutcomeSuccess(eventResc);
     }
 
     @Test
@@ -445,6 +448,7 @@ public class ContentPremisToRdfTransformerTest extends AbstractPremisToRdfTransf
         assertAgent("Class " + FIXITY_AGENT, Software, eventResc);
         assertAgent("Jargon version 2.2", Software, eventResc);
         assertAgent("iRODS release version rods3.2", Software, eventResc);
+        assertNoEventOutcome(eventResc);
     }
 
     @Test
@@ -488,6 +492,7 @@ public class ContentPremisToRdfTransformerTest extends AbstractPremisToRdfTransf
         assertAgent("Class " + FIXITY_AGENT, Software, eventResc);
         assertAgent("Jargon version 2.2", Software, eventResc);
         assertAgent("iRODS release version rods3.2", Software, eventResc);
+        assertEventOutcomeFail(eventResc);
     }
 
     @Test

--- a/migration-util/src/test/java/edu/unc/lib/dcr/migration/premis/DepositRecordPremisToRdfTransformerTest.java
+++ b/migration-util/src/test/java/edu/unc/lib/dcr/migration/premis/DepositRecordPremisToRdfTransformerTest.java
@@ -39,12 +39,14 @@ import java.util.List;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.vocabulary.RDF;
 import org.jdom2.Element;
 import org.junit.Before;
 import org.junit.Test;
 
 import edu.unc.lib.dl.rdf.Premis;
 import edu.unc.lib.dl.rdf.PremisAgentType;
+import edu.unc.lib.dl.rdf.Rdf;
 
 /**
  * @author bbpennel
@@ -298,8 +300,8 @@ public class DepositRecordPremisToRdfTransformerTest extends AbstractPremisToRdf
 
     private void assertAgent(String agentName, Resource eventResc) {
         Resource agentResc = eventResc.getPropertyResourceValue(Premis.hasEventRelatedAgentExecutor);
-        assertEquals(PremisAgentType.Software, agentResc.getPropertyResourceValue(Premis.hasAgentType));
-        assertEquals(agentName, agentResc.getProperty(Premis.hasAgentName).getString());
+        assertEquals(PremisAgentType.Software, agentResc.getPropertyResourceValue(RDF.type));
+        assertEquals(agentName, agentResc.getProperty(Rdf.label).getString());
     }
 
     private void addInitiatorAgent(Element eventEl, String agent) {

--- a/migration-util/src/test/java/edu/unc/lib/dcr/migration/premis/TestPremisEventHelpers.java
+++ b/migration-util/src/test/java/edu/unc/lib/dcr/migration/premis/TestPremisEventHelpers.java
@@ -110,10 +110,15 @@ public class TestPremisEventHelpers {
     }
 
     public static void addEventOutcome(Element eventEl, String outcome, String note) {
-        eventEl.addContent(new Element("eventOutcomeInformation", PREMIS_V2_NS)
-                .addContent(new Element("eventOutcome", PREMIS_V2_NS).setText(outcome))
-                .addContent(new Element("eventOutcomeDetail", PREMIS_V2_NS)
-                        .addContent(new Element("eventOutcomeDetailNote", PREMIS_V2_NS).setText(note))));
+        Element outcomeInfoEl = new Element("eventOutcomeInformation", PREMIS_V2_NS);
+        if (note != null) {
+            outcomeInfoEl.addContent(new Element("eventOutcomeDetail", PREMIS_V2_NS)
+                    .addContent(new Element("eventOutcomeDetailNote", PREMIS_V2_NS).setText(note)));
+        }
+        if (outcome != null) {
+            outcomeInfoEl.addContent(new Element("eventOutcome", PREMIS_V2_NS).setText(outcome));
+        }
+        eventEl.addContent(outcomeInfoEl);
     }
 
     public static void addLinkingObject(Element eventEl, String idType, String idVal) {

--- a/migration-util/src/test/java/edu/unc/lib/dcr/migration/premis/TestPremisEventHelpers.java
+++ b/migration-util/src/test/java/edu/unc/lib/dcr/migration/premis/TestPremisEventHelpers.java
@@ -140,11 +140,11 @@ public class TestPremisEventHelpers {
 
     public static List<Resource> listEventResources(PID pid, Model model) {
         Resource objResc = model.getResource(pid.getRepositoryPath());
-        List<Statement> usedBy = objResc.listProperties(Prov.wasUsedBy).toList();
-        List<Statement> generatedBy = objResc.listProperties(Prov.wasGeneratedBy).toList();
+        List<Statement> used = model.listStatements(null, Prov.used, objResc).toList();
+        List<Statement> generated = model.listStatements(null, Prov.generated, objResc).toList();
 
-        return Stream.concat(usedBy.stream(), generatedBy.stream())
-                .map(Statement::getResource)
+        return Stream.concat(used.stream(), generated.stream())
+                .map(Statement::getSubject)
                 .collect(toList());
     }
 

--- a/migration-util/src/test/java/edu/unc/lib/dcr/migration/premis/TestPremisEventHelpers.java
+++ b/migration-util/src/test/java/edu/unc/lib/dcr/migration/premis/TestPremisEventHelpers.java
@@ -46,7 +46,7 @@ import org.jdom2.output.XMLOutputter;
 import org.jgroups.util.UUID;
 
 import edu.unc.lib.dl.fedora.PID;
-import edu.unc.lib.dl.rdf.Premis;
+import edu.unc.lib.dl.rdf.Prov;
 import edu.unc.lib.dl.util.DateTimeUtil;
 
 /**
@@ -135,8 +135,10 @@ public class TestPremisEventHelpers {
 
     public static List<Resource> listEventResources(PID pid, Model model) {
         Resource objResc = model.getResource(pid.getRepositoryPath());
+        List<Statement> usedBy = objResc.listProperties(Prov.wasUsedBy).toList();
+        List<Statement> generatedBy = objResc.listProperties(Prov.wasGeneratedBy).toList();
 
-        return objResc.listProperties(Premis.hasEvent).toList().stream()
+        return Stream.concat(usedBy.stream(), generatedBy.stream())
                 .map(Statement::getResource)
                 .collect(toList());
     }

--- a/migration-util/src/test/java/edu/unc/lib/dcr/migration/premis/TransformContentPremisServiceTest.java
+++ b/migration-util/src/test/java/edu/unc/lib/dcr/migration/premis/TransformContentPremisServiceTest.java
@@ -41,6 +41,7 @@ import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.vocabulary.RDF;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.junit.Before;
@@ -100,11 +101,11 @@ public class TransformContentPremisServiceTest {
         Model obj1Model = readTransformedLog(outputPath, pid1);
         List<Resource> obj1Events = listEventResources(pid1, obj1Model);
         assertEquals(1, obj1Events.size());
-        assertTrue(obj1Events.get(0).hasProperty(Premis.hasEventType, Premis.VirusCheck));
+        assertTrue(obj1Events.get(0).hasProperty(RDF.type, Premis.VirusCheck));
 
         Model obj2Model = readTransformedLog(outputPath, pid2);
         List<Resource> obj2Events = listEventResources(pid2, obj2Model);
-        assertTrue(obj2Events.get(0).hasProperty(Premis.hasEventType, Premis.Ingestion));
+        assertTrue(obj2Events.get(0).hasProperty(RDF.type, Premis.Ingestion));
     }
 
     @Test
@@ -127,11 +128,11 @@ public class TransformContentPremisServiceTest {
         Model obj1Model = readTransformedLog(outputPath, pid1);
         List<Resource> obj1Events = listEventResources(pid1, obj1Model);
         assertEquals(1, obj1Events.size());
-        assertTrue(obj1Events.get(0).hasProperty(Premis.hasEventType, Premis.VirusCheck));
+        assertTrue(obj1Events.get(0).hasProperty(RDF.type, Premis.VirusCheck));
 
         Model obj2Model = readTransformedLog(outputPath, pid3);
         List<Resource> obj2Events = listEventResources(pid3, obj2Model);
-        assertTrue(obj2Events.get(0).hasProperty(Premis.hasEventType, Premis.Ingestion));
+        assertTrue(obj2Events.get(0).hasProperty(RDF.type, Premis.Ingestion));
 
         Path failedPath = getTransformedPremisPath(outputPath, pid2, true);
         assertFalse("Transformed log for invalid log should not exist",

--- a/migration-util/src/test/java/edu/unc/lib/dcr/migration/premis/TransformDepositPremisServiceTest.java
+++ b/migration-util/src/test/java/edu/unc/lib/dcr/migration/premis/TransformDepositPremisServiceTest.java
@@ -41,6 +41,7 @@ import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.vocabulary.RDF;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.junit.Before;
@@ -100,11 +101,11 @@ public class TransformDepositPremisServiceTest {
         Model obj1Model = readTransformedLog(outputPath, pid1);
         List<Resource> obj1Events = listEventResources(pid1, obj1Model);
         assertEquals(1, obj1Events.size());
-        assertTrue(obj1Events.get(0).hasProperty(Premis.hasEventType, Premis.VirusCheck));
+        assertTrue(obj1Events.get(0).hasProperty(RDF.type, Premis.VirusCheck));
 
         Model obj2Model = readTransformedLog(outputPath, pid2);
         List<Resource> obj2Events = listEventResources(pid2, obj2Model);
-        assertTrue(obj2Events.get(0).hasProperty(Premis.hasEventType, Premis.Validation));
+        assertTrue(obj2Events.get(0).hasProperty(RDF.type, Premis.Validation));
     }
 
     @Test
@@ -127,11 +128,11 @@ public class TransformDepositPremisServiceTest {
         Model obj1Model = readTransformedLog(outputPath, pid1);
         List<Resource> obj1Events = listEventResources(pid1, obj1Model);
         assertEquals(1, obj1Events.size());
-        assertTrue(obj1Events.get(0).hasProperty(Premis.hasEventType, Premis.VirusCheck));
+        assertTrue(obj1Events.get(0).hasProperty(RDF.type, Premis.VirusCheck));
 
         Model obj3Model = readTransformedLog(outputPath, pid3);
         List<Resource> obj3Events = listEventResources(pid3, obj3Model);
-        assertTrue(obj3Events.get(0).hasProperty(Premis.hasEventType, Premis.Validation));
+        assertTrue(obj3Events.get(0).hasProperty(RDF.type, Premis.Validation));
 
         Path failedPath = getTransformedPremisPath(outputPath, pid2, true);
         assertFalse("Transformed log for invalid log should not exist",

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/acl/PatronAccessAssignmentServiceIT.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/acl/PatronAccessAssignmentServiceIT.java
@@ -50,6 +50,7 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.sparql.vocabulary.FOAF;
 import org.apache.jena.vocabulary.RDF;
 import org.junit.Before;
 import org.junit.Test;
@@ -87,7 +88,6 @@ import edu.unc.lib.dl.fedora.ServiceException;
 import edu.unc.lib.dl.rdf.CdrAcl;
 import edu.unc.lib.dl.rdf.Premis;
 import edu.unc.lib.dl.rdf.Prov;
-import edu.unc.lib.dl.rdf.Rdf;
 import edu.unc.lib.dl.services.OperationsMessageSender;
 import edu.unc.lib.dl.test.AclModelBuilder;
 import edu.unc.lib.dl.test.RepositoryObjectTreeIndexer;
@@ -687,7 +687,7 @@ public class PatronAccessAssignmentServiceIT {
                     eventResc.hasProperty(RDF.type, Premis.PolicyAssignment));
             Resource agentResc = eventResc.getPropertyResourceValue(Premis.hasEventRelatedAgentImplementor);
             assertTrue("Event agent was not set",
-                    agentResc.hasLiteral(Rdf.label, USER_NAMESPACE + USER_PRINC));
+                    agentResc.hasLiteral(FOAF.name, USER_NAMESPACE + USER_PRINC));
             details.add(eventResc.getProperty(Premis.note).getString());
         }
 

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/acl/PatronAccessAssignmentServiceIT.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/acl/PatronAccessAssignmentServiceIT.java
@@ -87,6 +87,7 @@ import edu.unc.lib.dl.fedora.ServiceException;
 import edu.unc.lib.dl.rdf.CdrAcl;
 import edu.unc.lib.dl.rdf.Premis;
 import edu.unc.lib.dl.rdf.Prov;
+import edu.unc.lib.dl.rdf.Rdf;
 import edu.unc.lib.dl.services.OperationsMessageSender;
 import edu.unc.lib.dl.test.AclModelBuilder;
 import edu.unc.lib.dl.test.RepositoryObjectTreeIndexer;
@@ -686,7 +687,7 @@ public class PatronAccessAssignmentServiceIT {
                     eventResc.hasProperty(RDF.type, Premis.PolicyAssignment));
             Resource agentResc = eventResc.getPropertyResourceValue(Premis.hasEventRelatedAgentImplementor);
             assertTrue("Event agent was not set",
-                    agentResc.hasLiteral(Premis.hasAgentName, USER_NAMESPACE + USER_PRINC));
+                    agentResc.hasLiteral(Rdf.label, USER_NAMESPACE + USER_PRINC));
             details.add(eventResc.getProperty(Premis.note).getString());
         }
 

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/acl/PatronAccessAssignmentServiceIT.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/acl/PatronAccessAssignmentServiceIT.java
@@ -50,6 +50,7 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.vocabulary.RDF;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -681,11 +682,11 @@ public class PatronAccessAssignmentServiceIT {
             Resource eventResc = stmt.getResource();
 
             assertTrue("Event type was not set",
-                    eventResc.hasProperty(Premis.hasEventType, Premis.PolicyAssignment));
+                    eventResc.hasProperty(RDF.type, Premis.PolicyAssignment));
             Resource agentResc = eventResc.getPropertyResourceValue(Premis.hasEventRelatedAgentImplementor);
             assertTrue("Event agent was not set",
                     agentResc.hasLiteral(Premis.hasAgentName, USER_NAMESPACE + USER_PRINC));
-            details.add(eventResc.getProperty(Premis.hasEventDetail).getString());
+            details.add(eventResc.getProperty(Premis.note).getString());
         }
 
         return details;

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/acl/PatronAccessAssignmentServiceIT.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/acl/PatronAccessAssignmentServiceIT.java
@@ -678,10 +678,10 @@ public class PatronAccessAssignmentServiceIT {
 
         Model eventsModel = repoObj.getPremisLog().getEventsModel();
         Resource objResc = eventsModel.getResource(repoObj.getPid().getRepositoryPath());
-        StmtIterator it = objResc.listProperties(Prov.wasUsedBy);
+        StmtIterator it = eventsModel.listStatements(null, Prov.used, objResc);
         while (it.hasNext()) {
             Statement stmt = it.next();
-            Resource eventResc = stmt.getResource();
+            Resource eventResc = stmt.getSubject();
 
             assertTrue("Event type was not set",
                     eventResc.hasProperty(RDF.type, Premis.PolicyAssignment));

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/acl/PatronAccessAssignmentServiceIT.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/acl/PatronAccessAssignmentServiceIT.java
@@ -86,6 +86,7 @@ import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.fedora.ServiceException;
 import edu.unc.lib.dl.rdf.CdrAcl;
 import edu.unc.lib.dl.rdf.Premis;
+import edu.unc.lib.dl.rdf.Prov;
 import edu.unc.lib.dl.services.OperationsMessageSender;
 import edu.unc.lib.dl.test.AclModelBuilder;
 import edu.unc.lib.dl.test.RepositoryObjectTreeIndexer;
@@ -676,7 +677,7 @@ public class PatronAccessAssignmentServiceIT {
 
         Model eventsModel = repoObj.getPremisLog().getEventsModel();
         Resource objResc = eventsModel.getResource(repoObj.getPid().getRepositoryPath());
-        StmtIterator it = objResc.listProperties(Premis.hasEvent);
+        StmtIterator it = objResc.listProperties(Prov.wasUsedBy);
         while (it.hasNext()) {
             Statement stmt = it.next();
             Resource eventResc = stmt.getResource();

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/acl/StaffRoleAssignmentServiceIT.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/acl/StaffRoleAssignmentServiceIT.java
@@ -84,6 +84,7 @@ import edu.unc.lib.dl.fedora.ServiceException;
 import edu.unc.lib.dl.rdf.CdrAcl;
 import edu.unc.lib.dl.rdf.Premis;
 import edu.unc.lib.dl.rdf.Prov;
+import edu.unc.lib.dl.rdf.Rdf;
 import edu.unc.lib.dl.services.OperationsMessageSender;
 import edu.unc.lib.dl.test.AclModelBuilder;
 import edu.unc.lib.dl.test.RepositoryObjectTreeIndexer;
@@ -514,7 +515,7 @@ public class StaffRoleAssignmentServiceIT {
                 eventResc.hasProperty(RDF.type, Premis.PolicyAssignment));
         Resource agentResc = eventResc.getPropertyResourceValue(Premis.hasEventRelatedAgentImplementor);
         assertTrue("Event agent was not set",
-                agentResc.hasLiteral(Premis.hasAgentName, USER_NAMESPACE + USER_PRINC));
+                agentResc.hasLiteral(Rdf.label, USER_NAMESPACE + USER_PRINC));
         String eventDetail = eventResc.getProperty(Premis.note).getString();
         assertThat(eventDetail, containsString("Staff roles for item set to:"));
         return eventDetail;

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/acl/StaffRoleAssignmentServiceIT.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/acl/StaffRoleAssignmentServiceIT.java
@@ -46,6 +46,7 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.sparql.vocabulary.FOAF;
 import org.apache.jena.vocabulary.RDF;
 import org.junit.Before;
 import org.junit.Test;
@@ -84,7 +85,6 @@ import edu.unc.lib.dl.fedora.ServiceException;
 import edu.unc.lib.dl.rdf.CdrAcl;
 import edu.unc.lib.dl.rdf.Premis;
 import edu.unc.lib.dl.rdf.Prov;
-import edu.unc.lib.dl.rdf.Rdf;
 import edu.unc.lib.dl.services.OperationsMessageSender;
 import edu.unc.lib.dl.test.AclModelBuilder;
 import edu.unc.lib.dl.test.RepositoryObjectTreeIndexer;
@@ -515,7 +515,7 @@ public class StaffRoleAssignmentServiceIT {
                 eventResc.hasProperty(RDF.type, Premis.PolicyAssignment));
         Resource agentResc = eventResc.getPropertyResourceValue(Premis.hasEventRelatedAgentImplementor);
         assertTrue("Event agent was not set",
-                agentResc.hasLiteral(Rdf.label, USER_NAMESPACE + USER_PRINC));
+                agentResc.hasLiteral(FOAF.name, USER_NAMESPACE + USER_PRINC));
         String eventDetail = eventResc.getProperty(Premis.note).getString();
         assertThat(eventDetail, containsString("Staff roles for item set to:"));
         return eventDetail;

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/acl/StaffRoleAssignmentServiceIT.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/acl/StaffRoleAssignmentServiceIT.java
@@ -46,6 +46,7 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.vocabulary.RDF;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -509,11 +510,11 @@ public class StaffRoleAssignmentServiceIT {
         Resource objResc = eventsModel.getResource(repoObj.getPid().getRepositoryPath());
         Resource eventResc = objResc.getPropertyResourceValue(Premis.hasEvent);
         assertTrue("Event type was not set",
-                eventResc.hasProperty(Premis.hasEventType, Premis.PolicyAssignment));
+                eventResc.hasProperty(RDF.type, Premis.PolicyAssignment));
         Resource agentResc = eventResc.getPropertyResourceValue(Premis.hasEventRelatedAgentImplementor);
         assertTrue("Event agent was not set",
                 agentResc.hasLiteral(Premis.hasAgentName, USER_NAMESPACE + USER_PRINC));
-        String eventDetail = eventResc.getProperty(Premis.hasEventDetail).getString();
+        String eventDetail = eventResc.getProperty(Premis.note).getString();
         assertThat(eventDetail, containsString("Staff roles for item set to:"));
         return eventDetail;
     }

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/acl/StaffRoleAssignmentServiceIT.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/acl/StaffRoleAssignmentServiceIT.java
@@ -510,7 +510,8 @@ public class StaffRoleAssignmentServiceIT {
     private String assertEventCreatedAndGetDetail(ContentObject repoObj) {
         Model eventsModel = repoObj.getPremisLog().getEventsModel();
         Resource objResc = eventsModel.getResource(repoObj.getPid().getRepositoryPath());
-        Resource eventResc = objResc.getPropertyResourceValue(Prov.wasUsedBy);
+        List<Resource> eventRescs = eventsModel.listResourcesWithProperty(Prov.used, objResc).toList();
+        Resource eventResc = eventRescs.get(0);
         assertTrue("Event type was not set",
                 eventResc.hasProperty(RDF.type, Premis.PolicyAssignment));
         Resource agentResc = eventResc.getPropertyResourceValue(Premis.hasEventRelatedAgentImplementor);

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/acl/StaffRoleAssignmentServiceIT.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/acl/StaffRoleAssignmentServiceIT.java
@@ -83,6 +83,7 @@ import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.fedora.ServiceException;
 import edu.unc.lib.dl.rdf.CdrAcl;
 import edu.unc.lib.dl.rdf.Premis;
+import edu.unc.lib.dl.rdf.Prov;
 import edu.unc.lib.dl.services.OperationsMessageSender;
 import edu.unc.lib.dl.test.AclModelBuilder;
 import edu.unc.lib.dl.test.RepositoryObjectTreeIndexer;
@@ -508,7 +509,7 @@ public class StaffRoleAssignmentServiceIT {
     private String assertEventCreatedAndGetDetail(ContentObject repoObj) {
         Model eventsModel = repoObj.getPremisLog().getEventsModel();
         Resource objResc = eventsModel.getResource(repoObj.getPid().getRepositoryPath());
-        Resource eventResc = objResc.getPropertyResourceValue(Premis.hasEvent);
+        Resource eventResc = objResc.getPropertyResourceValue(Prov.wasUsedBy);
         assertTrue("Event type was not set",
                 eventResc.hasProperty(RDF.type, Premis.PolicyAssignment));
         Resource agentResc = eventResc.getPropertyResourceValue(Premis.hasEventRelatedAgentImplementor);

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsJobIT.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsJobIT.java
@@ -205,8 +205,8 @@ public class DestroyObjectsJobIT {
         assertTrue(stoneFolder.getResource().hasProperty(RDF.type, Cdr.Folder));
 
         Model logModel = stoneFolder.getPremisLog().getEventsModel();
-        assertTrue(logModel.contains(null, Premis.hasEventType, Premis.Deletion));
-        assertTrue(logModel.contains(null, Premis.hasEventDetail,
+        assertTrue(logModel.contains(null, RDF.type, Premis.Deletion));
+        assertTrue(logModel.contains(null, Premis.note,
                 "Item deleted from repository and replaced by tombstone"));
 
         verify(indexingMessageSender).sendIndexingOperation(anyString(), eq(folderObjPid), eq(DELETE_SOLR_TREE));
@@ -233,13 +233,13 @@ public class DestroyObjectsJobIT {
         assertTrue(stoneFolder2.getModel().contains(stoneFolder2.getResource(), RDF.type, Cdr.Tombstone));
 
         Model logModel1 = stoneFolder1.getPremisLog().getEventsModel();
-        assertTrue(logModel1.contains(null, Premis.hasEventType, Premis.Deletion));
-        assertTrue(logModel1.contains(null, Premis.hasEventDetail,
+        assertTrue(logModel1.contains(null, RDF.type, Premis.Deletion));
+        assertTrue(logModel1.contains(null, Premis.note,
                 "Item deleted from repository and replaced by tombstone"));
 
         Model logModel2 = stoneFolder2.getPremisLog().getEventsModel();
-        assertTrue(logModel2.contains(null, Premis.hasEventType, Premis.Deletion));
-        assertTrue(logModel2.contains(null, Premis.hasEventDetail,
+        assertTrue(logModel2.contains(null, RDF.type, Premis.Deletion));
+        assertTrue(logModel2.contains(null, Premis.note,
                 "Item deleted from repository and replaced by tombstone"));
 
         verify(indexingMessageSender).sendIndexingOperation(anyString(), eq(folderObj1Pid), eq(DELETE_SOLR_TREE));
@@ -277,8 +277,8 @@ public class DestroyObjectsJobIT {
         assertTrue(stoneFile.getModel().contains(stoneFile.getResource(), RDF.type, Cdr.Tombstone));
 
         Model logModel = stoneFile.getPremisLog().getEventsModel();
-        assertTrue(logModel.contains(null, Premis.hasEventType, Premis.Deletion));
-        assertTrue(logModel.contains(event, Premis.hasEventType, Premis.Ingestion));
+        assertTrue(logModel.contains(null, RDF.type, Premis.Deletion));
+        assertTrue(logModel.contains(event, RDF.type, Premis.Ingestion));
     }
 
     private List<PID> createContentTree() throws Exception {

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/DatastreamRestControllerIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/DatastreamRestControllerIT.java
@@ -261,7 +261,7 @@ public class DatastreamRestControllerIT extends AbstractAPIIT {
 
         Model premisModel = createModel(IOUtils.toInputStream(response.getContentAsString(), UTF_8), "TURTLE");
         assertEquals("Response did not contain expected premis event",
-                1, premisModel.listStatements(null, RDF.type, Premis.Event).toList().size());
+                1, premisModel.listResourcesWithProperty(RDF.type).toList().size());
 
         assertTrue("Expected content length to be set", response.getContentLength() > 0);
     }

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/DatastreamRestControllerIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/DatastreamRestControllerIT.java
@@ -261,7 +261,7 @@ public class DatastreamRestControllerIT extends AbstractAPIIT {
 
         Model premisModel = createModel(IOUtils.toInputStream(response.getContentAsString(), UTF_8), "TURTLE");
         assertEquals("Response did not contain expected premis event",
-                1, premisModel.listResourcesWithProperty(RDF.type).toList().size());
+                1, premisModel.listResourcesWithProperty(RDF.type, Premis.Creation).toList().size());
 
         assertTrue("Expected content length to be set", response.getContentLength() > 0);
     }

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/MarkForDeletionIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/MarkForDeletionIT.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.vocabulary.RDF;
 import org.junit.Test;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.ContextHierarchy;
@@ -180,7 +181,7 @@ public class MarkForDeletionIT extends AbstractAPIIT {
         assertTrue(resc.getProperty(CdrAcl.markedForDeletion).getBoolean());
 
         Model logModel = repoObj.getPremisLog().getEventsModel();
-        assertTrue(logModel.contains(null, Premis.hasEventType, Premis.Deletion));
+        assertTrue(logModel.contains(null, RDF.type, Premis.Deletion));
     }
 
     private void assertNotMarkedForDeletion(PID pid) {


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2557
https://jira.lib.unc.edu/browse/BXC-2558
https://jira.lib.unc.edu/browse/BXC-2559

This PR depends on https://github.com/UNC-Libraries/Carolina-Digital-Repository/pull/915

* All premis log files now include `rdf:type premis:Representation`
* premis:hasEvent has been replaced by two Prov relations
* Many agent and event properties have been replaced by RDF, RDFS, and FOAF properties based on https://docs.google.com/spreadsheets/d/1fQIsYbRYRNeDvSm_SKwjXVSrn18mXu3W96A-n5vVVCg/edit#
* Adds event outcomes