### PR TITLE
BXC-2577 - Close binary object input streams

### DIFF
--- a/access-common/src/main/java/edu/unc/lib/dl/ui/service/FedoraContentService.java
+++ b/access-common/src/main/java/edu/unc/lib/dl/ui/service/FedoraContentService.java
@@ -22,6 +22,7 @@ import static org.apache.http.HttpHeaders.CONTENT_TYPE;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 
 import javax.servlet.http.HttpServletResponse;
@@ -102,8 +103,10 @@ public class FedoraContentService {
         }
 
         // Stream binary content to http response
-        OutputStream outStream = response.getOutputStream();
-        IOUtils.copy(binObj.getBinaryStream(), outStream, BUFFER_SIZE);
+        try (InputStream binStream = binObj.getBinaryStream()) {
+            OutputStream outStream = response.getOutputStream();
+            IOUtils.copy(binStream, outStream, BUFFER_SIZE);
+        }
     }
 
     public void streamEventLog(PID pid, AccessGroupSet principals, boolean asAttachment,

--- a/access/src/main/java/edu/unc/lib/dl/ui/controller/FedoraContentController.java
+++ b/access/src/main/java/edu/unc/lib/dl/ui/controller/FedoraContentController.java
@@ -34,6 +34,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.context.request.WebRequest;
 
 import edu.unc.lib.dl.acl.exception.AccessRestrictionException;
 import edu.unc.lib.dl.acl.util.AccessGroupSet;
@@ -121,5 +122,11 @@ public class FedoraContentController {
     public String handleObjectTypeMismatchException(HttpServletRequest request) {
         request.setAttribute("pageSubtitle", "Invalid content");
         return "error/invalidRecord";
+    }
+
+    @ExceptionHandler(value = { RuntimeException.class })
+    protected String handleUncaught(RuntimeException ex, WebRequest request) {
+        log.error("Uncaught exception while streaming content", ex);
+        return "error/exception";
     }
 }

--- a/access/src/main/java/edu/unc/lib/dl/ui/controller/FullRecordController.java
+++ b/access/src/main/java/edu/unc/lib/dl/ui/controller/FullRecordController.java
@@ -19,6 +19,7 @@ import static edu.unc.lib.dl.acl.util.GroupsThreadStore.getAgentPrincipals;
 import static edu.unc.lib.dl.xml.SecureXMLFactory.createSAXBuilder;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -59,7 +60,6 @@ import edu.unc.lib.dl.search.solr.model.SearchResultResponse;
 import edu.unc.lib.dl.search.solr.model.SimpleIdRequest;
 import edu.unc.lib.dl.search.solr.service.ChildrenCountService;
 import edu.unc.lib.dl.search.solr.service.NeighborQueryService;
-import edu.unc.lib.dl.search.solr.service.SearchStateFactory;
 import edu.unc.lib.dl.search.solr.util.SearchFieldKeys;
 import edu.unc.lib.dl.ui.exception.InvalidRecordRequestException;
 import edu.unc.lib.dl.ui.exception.RenderViewException;
@@ -85,8 +85,6 @@ public class FullRecordController extends AbstractSolrSearchController {
 
     @Autowired(required = true)
     private XSLViewResolver xslViewResolver;
-    @Autowired
-    private SearchStateFactory stateFactory;
     @Autowired
     private RepositoryObjectLoader repositoryObjectLoader;
 
@@ -128,9 +126,11 @@ public class FullRecordController extends AbstractSolrSearchController {
             BinaryObject modsObj = contentObj.getDescription();
             if (modsObj != null) {
                 SAXBuilder builder = createSAXBuilder();
-                Document modsDoc = builder.build(modsObj.getBinaryStream());
+                try (InputStream modsStream = modsObj.getBinaryStream()) {
+                    Document modsDoc = builder.build(modsStream);
 
-                fullObjectView = xslViewResolver.renderView("external.xslView.fullRecord.url", modsDoc);
+                    fullObjectView = xslViewResolver.renderView("external.xslView.fullRecord.url", modsDoc);
+                }
             }
         } catch (NotFoundException e) {
             throw new InvalidRecordRequestException(e);

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/event/RepositoryPremisLogger.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/event/RepositoryPremisLogger.java
@@ -40,6 +40,7 @@ import org.apache.jena.riot.RDFFormat;
 import org.apache.jena.vocabulary.RDF;
 import org.slf4j.Logger;
 
+import edu.unc.lib.dl.exceptions.RepositoryException;
 import edu.unc.lib.dl.fcrepo4.BinaryObject;
 import edu.unc.lib.dl.fcrepo4.RepositoryObject;
 import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
@@ -143,11 +144,15 @@ public class RepositoryPremisLogger implements PremisLogger {
                     new ByteArrayInputStream(lineSeparator().getBytes(UTF_8)),
                     modelStream);
 
-            InputStream mergedStream = new SequenceInputStream(
-                    logObj.getBinaryStream(),
-                    newContentStream);
+            try (InputStream existingLogStream = logObj.getBinaryStream()) {
+                InputStream mergedStream = new SequenceInputStream(
+                        existingLogStream,
+                        newContentStream);
 
-            updateOrCreateLog(mergedStream);
+                updateOrCreateLog(mergedStream);
+            } catch (IOException e) {
+                throw new RepositoryException("Failed to close log existing stream", e);
+            }
         }
 
         return this;

--- a/metadata/src/main/java/edu/unc/lib/dl/util/RDFModelUtil.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/util/RDFModelUtil.java
@@ -27,6 +27,8 @@ import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.riot.RDFFormat;
 
+import edu.unc.lib.dl.exceptions.RepositoryException;
+
 /**
  * Utility containing common methods for manipulating and transforming RDF
  * models
@@ -91,9 +93,13 @@ public class RDFModelUtil {
      * @return
      */
     public static Model createModel(InputStream inStream, String lang) {
-        Model model = ModelFactory.createDefaultModel();
-        model.read(inStream, null, lang);
-        return model;
+        try (InputStream stream = inStream) {
+            Model model = ModelFactory.createDefaultModel();
+            model.read(inStream, null, lang);
+            return model;
+        } catch (IOException e) {
+            throw new RepositoryException("Failed to close model stream", e);
+        }
     }
 
 

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/edit/EditTitleService.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/edit/EditTitleService.java
@@ -77,21 +77,17 @@ public class EditTitleService {
             BinaryObject mods = obj.getDescription();
 
             Document newMods;
-            InputStream modsStream;
+
             if (mods != null) {
-                modsStream = mods.getBinaryStream();
-            } else {
-                modsStream = null;
-            }
+                try (InputStream modsStream = mods.getBinaryStream()) {
+                    Document document = createSAXBuilder().build(modsStream);
+                    Element rootEl = document.getRootElement();
 
-            if (modsStream != null) {
-                Document document = createSAXBuilder().build(modsStream);
-                Element rootEl = document.getRootElement();
-
-                if (hasExistingTitle(rootEl)) {
-                    newMods = updateTitle(document, title);
-                } else {
-                    newMods = addTitleToMODS(document, title);
+                    if (hasExistingTitle(rootEl)) {
+                        newMods = updateTitle(document, title);
+                    } else {
+                        newMods = addTitleToMODS(document, title);
+                    }
                 }
             } else {
                 Document document = new Document();


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2577

* Close inputstreams from `BinaryObject.getBinaryStream` via `try` blocks to ensure they are not left open if clients abort the connection partway through reading.