### PR TITLE
BXC-2564 - Image derivative fixes

### DIFF
--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/images/AddDerivativeProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/images/AddDerivativeProcessor.java
@@ -70,8 +70,8 @@ public class AddDerivativeProcessor implements Processor {
         try {
             // Prevent further processing if the execution failed
             if (result.getExitValue() != 0) {
-                String stdout = result.getStdout() == null? "" : IOUtils.toString(result.getStdout(), UTF_8).trim();
-                String stderr = result.getStderr() == null? "" : IOUtils.toString(result.getStderr(), UTF_8).trim();
+                String stdout = result.getStdout() == null ? "" : IOUtils.toString(result.getStdout(), UTF_8).trim();
+                String stderr = result.getStderr() == null ? "" : IOUtils.toString(result.getStderr(), UTF_8).trim();
                 log.error("Failed to generate derivative for {}: {} {}", binaryId, stdout, stderr);
                 return;
             }

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/images/AddDerivativeProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/images/AddDerivativeProcessor.java
@@ -59,6 +59,7 @@ public class AddDerivativeProcessor implements Processor {
 
     @Override
     public void process(Exchange exchange) throws Exception {
+
         Message in = exchange.getIn();
         String binaryUri = (String) in.getHeader(FCREPO_URI);
         String binaryId = PIDs.get(binaryUri).getId();
@@ -66,14 +67,31 @@ public class AddDerivativeProcessor implements Processor {
 
         final ExecResult result = (ExecResult) in.getBody();
 
-        // Read command result as path to derived file, and trim off trailing whitespace
-        String derivativeTmpPath = IOUtils.toString(result.getStdout(), UTF_8).trim();
-        derivativeTmpPath += "." + fileExtension;
+        try {
+            // Prevent further processing if the execution failed
+            if (result.getExitValue() != 0) {
+                String stdout = result.getStdout() == null? "" : IOUtils.toString(result.getStdout(), UTF_8).trim();
+                String stderr = result.getStderr() == null? "" : IOUtils.toString(result.getStderr(), UTF_8).trim();
+                log.error("Failed to generate derivative for {}: {} {}", binaryId, stdout, stderr);
+                return;
+            }
 
-        Path derivativeFinalPath = Paths.get(derivativeBasePath,  derivativePath, binaryId + "." + fileExtension);
+            // Read command result as path to derived file, and trim off trailing whitespace
+            String derivativeTmpPath = IOUtils.toString(result.getStdout(), UTF_8).trim();
+            derivativeTmpPath += "." + fileExtension;
 
-        moveFile(derivativeTmpPath, derivativeFinalPath);
-        log.info("Added derivative for {} from {}", binaryUri, derivativeFinalPath);
+            Path derivativeFinalPath = Paths.get(derivativeBasePath,  derivativePath, binaryId + "." + fileExtension);
+
+            moveFile(derivativeTmpPath, derivativeFinalPath);
+            log.info("Added derivative for {} from {}", binaryUri, derivativeFinalPath);
+        } catch (IOException e) {
+            String stderr = "";
+            if (result != null && result.getStderr() != null) {
+                stderr = IOUtils.toString(result.getStderr(), UTF_8).trim();
+            }
+            log.error("Failed to generated derivative to {} for {}: {}", derivativeBasePath, binaryId, stderr);
+            throw e;
+        }
     }
 
     private void moveFile(String derivativeTmpPath, Path derivativeFinalPath)

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/images/ImageDerivativeProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/images/ImageDerivativeProcessor.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.services.camel.images;
+
+import java.util.regex.Pattern;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import edu.unc.lib.dl.services.camel.util.CdrFcrepoHeaders;
+
+/**
+ * Processor which validates and prepares image objects for producing derivatives
+ *
+ * @author bbpennel
+ */
+public class ImageDerivativeProcessor implements Processor {
+    private static final Logger log = LoggerFactory.getLogger(ImageDerivativeProcessor.class);
+
+    private static final Pattern MIMETYPE_PATTERN = Pattern.compile("^(image.*$|application.*?(photoshop|psd)$)");
+
+    private static final Pattern DISALLOWED_PATTERN = Pattern.compile(".*(vnd\\.fpx).*");
+
+    private static final Pattern RESTRICT_TO_FIRST_ENTRY_PATTERN =
+            Pattern.compile("^(image|application).*?(photoshop|psd)$");
+
+    /**
+     * Returns true if the subject of the exchange is a binary which
+     * is eligible for having image derivatives generated from it.
+     *
+     * @param exchange
+     * @return
+     */
+    public boolean allowedImageType(Exchange exchange) {
+        Message in = exchange.getIn();
+        String mimetype = (String) in.getHeader(CdrFcrepoHeaders.CdrBinaryMimeType);
+        String binPath = (String) in.getHeader(CdrFcrepoHeaders.CdrBinaryPath);
+
+        if (!MIMETYPE_PATTERN.matcher(mimetype).matches()) {
+            log.debug("File type {} on object {} is not applicable for image derivatives", mimetype, binPath);
+            return false;
+        }
+
+        if (DISALLOWED_PATTERN.matcher(mimetype).matches()) {
+            log.debug("File type {} on object {} is disallowed for image derivatives", mimetype, binPath);
+            return false;
+        }
+
+        log.debug("Object {} with type {} is permitted for image derivatives", binPath, mimetype);
+        return true;
+    }
+
+    @Override
+    public void process(Exchange exchange) throws Exception {
+        Message in = exchange.getIn();
+        String mimetype = (String) in.getHeader(CdrFcrepoHeaders.CdrBinaryMimeType);
+
+        String binPath = (String) in.getHeader(CdrFcrepoHeaders.CdrBinaryPath);
+        if (RESTRICT_TO_FIRST_ENTRY_PATTERN.matcher(mimetype).matches()) {
+            log.debug("Adjusting image path to {} for type {}", binPath + "[0]", mimetype);
+            in.setHeader(CdrFcrepoHeaders.CdrImagePath, binPath + "[0]");
+        } else {
+            log.debug("Keeping existing image path as {} for type {}", binPath, mimetype);
+            in.setHeader(CdrFcrepoHeaders.CdrImagePath, binPath);
+        }
+    }
+}

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/util/CdrFcrepoHeaders.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/util/CdrFcrepoHeaders.java
@@ -30,6 +30,9 @@ public abstract class CdrFcrepoHeaders {
     // URI identifying the location of content for a binary
     public static final String CdrBinaryPath = "CdrBinaryPath";
 
+    // URI identifying the location
+    public static final String CdrImagePath = "CdrImagePath";
+
     public static final String CdrUpdateAction = "CdrUpdateAction";
 
     public static final String CdrEnhancementSet = "CdrEnhancementSet";

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/images/AddDerivativeProcessorTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/images/AddDerivativeProcessorTest.java
@@ -17,6 +17,7 @@ package edu.unc.lib.dl.services.camel.images;
 
 import static edu.unc.lib.dl.services.camel.util.CdrFcrepoHeaders.CdrBinaryMimeType;
 import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
@@ -26,6 +27,7 @@ import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileWriter;
+import java.io.IOException;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
@@ -112,5 +114,22 @@ public class AddDerivativeProcessorTest {
         processor.process(exchange);
 
         assertTrue(mvFile.exists());
+    }
+
+    @Test
+    public void executionFailedTest() throws Exception {
+        when(result.getExitValue()).thenReturn(1);
+
+        mvFile = new File(finalDir.getAbsolutePath() + "/"+ fileName + ".PNG");
+        processor.process(exchange);
+
+        assertFalse(mvFile.exists());
+    }
+
+    @Test(expected = IOException.class)
+    public void resultFileDoesNotExistTest() throws Exception {
+        when(result.getStdout()).thenReturn(new ByteArrayInputStream(".png".getBytes()));
+
+        processor.process(exchange);
     }
 }

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/images/ImageEnhancementsRouterTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/images/ImageEnhancementsRouterTest.java
@@ -108,6 +108,21 @@ public class ImageEnhancementsRouterTest extends CamelSpringTestSupport {
     }
 
     @Test
+    public void testThumbDisallowedImageType() throws Exception {
+        createContext(thumbnailRoute);
+
+        getMockEndpoint("mock:direct:small.thumbnail").expectedMessageCount(0);
+        getMockEndpoint("mock:direct:large.thumbnail").expectedMessageCount(0);
+
+        Map<String, Object> headers = createEvent(fileID, eventTypes);
+        headers.put(CdrBinaryMimeType, "image/vnd.fpx");
+
+        template.sendBodyAndHeaders("", headers);
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Test
     public void testThumbSmallRoute() throws Exception {
         createContext(smallThumbRoute);
 
@@ -157,6 +172,21 @@ public class ImageEnhancementsRouterTest extends CamelSpringTestSupport {
 
         Map<String, Object> headers = createEvent(fileID, eventTypes);
         headers.put(CdrBinaryMimeType, "plain/text");
+
+        template.sendBodyAndHeaders("", headers);
+
+        verify(addAccessCopyProcessor, never()).process(any(Exchange.class));
+        assertMockEndpointsSatisfied();
+    }
+
+    @Test
+    public void testAccessCopyDisallowedImageType() throws Exception {
+        createContext(accessCopyRoute);
+
+        getMockEndpoint("mock:exec:/bin/sh").expectedMessageCount(0);
+
+        Map<String, Object> headers = createEvent(fileID, eventTypes);
+        headers.put(CdrBinaryMimeType, "image/vnd.fpx");
 
         template.sendBodyAndHeaders("", headers);
 


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2564

* Special treatment for image files that have multiple layers
* Added exclusions for image mimetypes that should be processed
* Improved error logging for derivative failures