### PR TITLE
BXC-2596 - Fix blank admin search

### DIFF
--- a/static/js/admin/src/ResultTableView.js
+++ b/static/js/admin/src/ResultTableView.js
@@ -78,7 +78,7 @@ define('ResultTableView', [ 'jquery', 'jquery-ui', 'ResultObjectList', 'URLUtili
 				navigationBar : navigationBar,
 				containerPath : containerPath,
 				queryMethod : data.queryMethod,
-				icon : ResourceTypeUtilities.getIconNameForType(container.type)
+				icon : container ? ResourceTypeUtilities.getIconNameForType(container.type) : null
 			});
 			
 			var headerHeightClass = self.options.headerHeightClass;


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2596

Fix failure caused by getting the type of container when there is no container, which was causing searching "Everywhere" to result in a blank search in the admin ui.