### PR TITLE
BXC-2527 - MODS History/versioning

### DIFF
--- a/deposit/src/main/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJob.java
@@ -17,17 +17,12 @@ package edu.unc.lib.deposit.transfer;
 
 import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.DEPOSIT_RECORD_BASE;
 import static edu.unc.lib.dl.model.DatastreamPids.getDepositManifestPid;
-import static edu.unc.lib.dl.model.DatastreamPids.getMdDescriptivePid;
 import static edu.unc.lib.dl.model.DatastreamPids.getOriginalFilePid;
 import static edu.unc.lib.dl.model.DatastreamPids.getTechnicalMetadataPid;
-import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toSet;
 
 import java.io.File;
 import java.net.URI;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -57,9 +52,6 @@ import edu.unc.lib.dl.rdf.CdrDeposit;
 public class TransferBinariesToStorageJob extends AbstractDepositJob {
 
     private static final Logger log = LoggerFactory.getLogger(TransferBinariesToStorageJob.class);
-
-    private static final Set<Resource> TYPES_ALLOWING_DESC = new HashSet<>(asList(
-            Cdr.Folder, Cdr.Work, Cdr.Collection, Cdr.AdminUnit, Cdr.FileObject));
 
     /**
      *
@@ -92,10 +84,6 @@ public class TransferBinariesToStorageJob extends AbstractDepositJob {
         Set<Resource> rescTypes = resc.listProperties(RDF.type).toList().stream()
                 .map(Statement::getResource).collect(toSet());
 
-        if (TYPES_ALLOWING_DESC.stream().anyMatch(rescTypes::contains)) {
-            transferModsFile(objPid, resc, transferSession);
-        }
-
         if (rescTypes.contains(Cdr.FileObject)) {
             transferOriginalFile(objPid, resc, transferSession);
             transferFitsExtract(objPid, resc, transferSession);
@@ -126,20 +114,6 @@ public class TransferBinariesToStorageJob extends AbstractDepositJob {
             URI stagingUri = URI.create(resc.getProperty(CdrDeposit.stagingLocation).getString());
             URI storageUri = transferSession.transfer(originalPid, stagingUri);
             resc.addLiteral(CdrDeposit.storageUri, storageUri.toString());
-        }
-    }
-
-    private void transferModsFile(PID objPid, Resource resc, BinaryTransferSession transferSession) {
-        // add descStorageUri if doesn't already exist. It will exist in a resume scenario.
-        if (!resc.hasProperty(CdrDeposit.descriptiveStorageUri)) {
-            Path modsPath = getModsPath(objPid);
-            if (!Files.exists(modsPath)) {
-                return;
-            }
-
-            PID originalPid = getMdDescriptivePid(objPid);
-            URI storageUri = transferSession.transferReplaceExisting(originalPid, modsPath.toUri());
-            resc.addLiteral(CdrDeposit.descriptiveStorageUri, storageUri.toString());
         }
     }
 

--- a/deposit/src/main/webapp/WEB-INF/deposit-jobs-context.xml
+++ b/deposit/src/main/webapp/WEB-INF/deposit-jobs-context.xml
@@ -96,6 +96,22 @@
             </bean>
         </property>
     </bean>
+    
+    <bean id="versionedDatastreamService" class="edu.unc.lib.dl.persist.services.versioning.VersionedDatastreamService" >
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
+        <property name="binaryTransferService" ref="binaryTransferService" />
+    </bean>
+    
+    <bean id="updateDescriptionService" class="edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService" >
+        <property name="aclService" ref="aclService" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
+        <property name="validate" value="false" />
+        <property name="checksAccess" value="false" />
+        <property name="sendsMessages" value="false" />
+        <property name="versionedDatastreamService" ref="versionedDatastreamService" />
+    </bean>
 
     <bean id="metsSipSchema" class="javax.xml.validation.Schema"
         factory-bean="schemaFactory" factory-method="newSchema">

--- a/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJobIT.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJobIT.java
@@ -68,6 +68,7 @@ import edu.unc.lib.dl.fcrepo4.TransactionManager;
 import edu.unc.lib.dl.fcrepo4.WorkObject;
 import edu.unc.lib.dl.fedora.FedoraException;
 import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService;
 import edu.unc.lib.dl.rdf.Cdr;
 import edu.unc.lib.dl.rdf.CdrDeposit;
 import edu.unc.lib.dl.rdf.Premis;
@@ -118,6 +119,8 @@ public class IngestContentObjectsJobIT extends AbstractFedoraDepositJobIT {
     private RepositoryObjectTreeIndexer treeIndexer;
     @Autowired
     private VerifyObjectsAreInFedoraService verificationService;
+    @Autowired
+    private UpdateDescriptionService updateDescService;
 
     private DepositRecord depositRecord;
 
@@ -143,6 +146,7 @@ public class IngestContentObjectsJobIT extends AbstractFedoraDepositJobIT {
         setField(job, "verificationService", verificationService);
         setField(job, "transferService", binaryTransferService);
         setField(job, "locationManager", storageLocationManager);
+        setField(job, "updateDescService", updateDescService);
         job.init();
 
         // Create a destination folder where deposits will be ingested to
@@ -541,7 +545,6 @@ public class IngestContentObjectsJobIT extends AbstractFedoraDepositJobIT {
         Bag folderBag = model.createBag(folderPid.getRepositoryPath());
         folderBag.addProperty(RDF.type, Cdr.Folder);
         folderBag.addProperty(CdrDeposit.label, label);
-        folderBag.addProperty(CdrDeposit.descriptiveStorageUri, modsPath.toUri().toString());
 
         depBag.add(folderBag);
 

--- a/deposit/src/test/resources/spring-test/cdr-client-container.xml
+++ b/deposit/src/test/resources/spring-test/cdr-client-container.xml
@@ -123,6 +123,22 @@
         <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
     </bean>
     
+    <bean id="versionedDatastreamService" class="edu.unc.lib.dl.persist.services.versioning.VersionedDatastreamService" >
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
+        <property name="binaryTransferService" ref="binaryTransferService" />
+    </bean>
+
+    <bean id="updateDescriptionService" class="edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService" >
+        <property name="aclService" ref="aclService" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
+        <property name="validate" value="false" />
+        <property name="sendsMessages" value="false" />
+        <property name="checksAccess" value="false" />
+        <property name="versionedDatastreamService" ref="versionedDatastreamService" />
+    </bean>
+    
     <bean id="transactionManager" class="edu.unc.lib.dl.fcrepo4.TransactionManager">
         <property name="client" ref="fcrepoClient" />
     </bean>

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/ContentObject.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/ContentObject.java
@@ -16,8 +16,6 @@
 package edu.unc.lib.dl.fcrepo4;
 
 import static edu.unc.lib.dl.fcrepo4.RepositoryPaths.getMetadataContainerUri;
-import static edu.unc.lib.dl.model.DatastreamPids.getMdDescriptivePid;
-import static edu.unc.lib.dl.model.DatastreamType.MD_DESCRIPTIVE;
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
 
 import java.io.InputStream;
@@ -49,32 +47,6 @@ public abstract class ContentObject extends RepositoryObject {
     protected ContentObject(PID pid, RepositoryObjectDriver driver,
             RepositoryObjectFactory repoObjFactory) {
         super(pid, driver, repoObjFactory);
-    }
-
-    /**
-     * If no description exists, adds description information to this object (which includes a MODS record).
-     * If description already exists, updates description information for this object.
-     * @param modsStream
-     * @return the BinaryObject for the descriptive record
-     */
-    public BinaryObject setDescription(URI modsUri) {
-        PID modsPid = getMdDescriptivePid(pid);
-
-        BinaryObject descObj = this.getDescription();
-        if (descObj == null) {
-            Model descModel = createDefaultModel();
-            descModel.getResource("").addProperty(RDF.type, Cdr.DescriptiveMetadata);
-
-            descObj = repoObjFactory.createOrUpdateBinary(modsPid, modsUri, MD_DESCRIPTIVE.getDefaultFilename(),
-                    MD_DESCRIPTIVE.getMimetype(), null, null, descModel);
-
-            repoObjFactory.createRelationship(this, Cdr.hasMods, descObj.getResource());
-
-            return descObj;
-        } else {
-            return repoObjFactory.createOrUpdateBinary(modsPid, modsUri, MD_DESCRIPTIVE.getDefaultFilename(),
-                    MD_DESCRIPTIVE.getMimetype(), null, null, null);
-        }
     }
 
     /**

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObject.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObject.java
@@ -47,6 +47,7 @@ public abstract class RepositoryObject {
     protected Model model;
 
     protected Date lastModified;
+    protected Date created;
     protected String etag;
 
     protected List<String> types;
@@ -181,6 +182,18 @@ public abstract class RepositoryObject {
      */
     public void setLastModified(Date lastModified) {
         this.lastModified = lastModified;
+    }
+
+    /**
+     * Get the creation date for this object
+     * @return
+     */
+    public Date getCreatedDate() {
+        if (created == null) {
+            created = ((XSDDateTime) getResource().getProperty(Fcrepo4Repository.created)
+                    .getLiteral().getValue()).asCalendar().getTime();
+        }
+        return created;
     }
 
     /**

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectLoader.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectLoader.java
@@ -23,6 +23,7 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 
 import edu.unc.lib.dl.fedora.FedoraException;
+import edu.unc.lib.dl.fedora.NotFoundException;
 import edu.unc.lib.dl.fedora.ObjectTypeMismatchException;
 import edu.unc.lib.dl.fedora.PID;
 
@@ -144,4 +145,23 @@ public class RepositoryObjectLoader {
         }
     }
 
+    /**
+     * @param pid
+     * @return true if an object exists with the given pid
+     */
+    public boolean exists(PID pid) {
+        try {
+            repositoryObjCache.get(pid);
+            return true;
+        } catch (NotFoundException e) {
+            return false;
+        } catch (UncheckedExecutionException | ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            } else {
+                throw new FedoraException((Exception) cause);
+            }
+        }
+    }
 }

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectLoader.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectLoader.java
@@ -143,4 +143,5 @@ public class RepositoryObjectLoader {
             }
         }
     }
+
 }

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectLoader.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectLoader.java
@@ -23,7 +23,6 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 
 import edu.unc.lib.dl.fedora.FedoraException;
-import edu.unc.lib.dl.fedora.NotFoundException;
 import edu.unc.lib.dl.fedora.ObjectTypeMismatchException;
 import edu.unc.lib.dl.fedora.PID;
 
@@ -135,26 +134,6 @@ public class RepositoryObjectLoader {
     public RepositoryObject getRepositoryObject(PID pid) {
         try {
             return repositoryObjCache.get(pid);
-        } catch (UncheckedExecutionException | ExecutionException e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof RuntimeException) {
-                throw (RuntimeException) cause;
-            } else {
-                throw new FedoraException((Exception) cause);
-            }
-        }
-    }
-
-    /**
-     * @param pid
-     * @return true if an object exists with the given pid
-     */
-    public boolean exists(PID pid) {
-        try {
-            repositoryObjCache.get(pid);
-            return true;
-        } catch (NotFoundException e) {
-            return false;
         } catch (UncheckedExecutionException | ExecutionException e) {
             Throwable cause = e.getCause();
             if (cause instanceof RuntimeException) {

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/ServiceException.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/ServiceException.java
@@ -15,11 +15,13 @@
  */
 package edu.unc.lib.dl.fedora;
 
+import edu.unc.lib.dl.exceptions.RepositoryException;
+
 /**
  * @author Gregory Jansen
  *
  */
-public class ServiceException extends RuntimeException {
+public class ServiceException extends RepositoryException {
 
     public ServiceException(String message) {
         super(message);

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/model/DatastreamPids.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/model/DatastreamPids.java
@@ -35,6 +35,8 @@ import edu.unc.lib.dl.util.URIUtil;
  */
 public class DatastreamPids {
 
+    public static final String HISTORY_SUFFIX = "_history";
+
     private DatastreamPids() {
     }
 
@@ -60,6 +62,17 @@ public class DatastreamPids {
 
     public static PID getDepositManifestPid(PID pid, String name) {
         String path = URIUtil.join(pid.getRepositoryPath(), DEPOSIT_MANIFEST_CONTAINER, name);
+        return PIDs.get(path);
+    }
+
+    /**
+     * Get the PID for the history object for the given datastream.
+     *
+     * @param datastreamPid pid of the datastream binary
+     * @return history object pid
+     */
+    public static PID getDatastreamHistoryPid(PID datastreamPid) {
+        String path = datastreamPid.getRepositoryPath() + HISTORY_SUFFIX;
         return PIDs.get(path);
     }
 }

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/model/DatastreamType.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/model/DatastreamType.java
@@ -19,6 +19,8 @@ import static edu.unc.lib.dl.acl.util.Permission.viewAccessCopies;
 import static edu.unc.lib.dl.acl.util.Permission.viewHidden;
 import static edu.unc.lib.dl.acl.util.Permission.viewMetadata;
 import static edu.unc.lib.dl.acl.util.Permission.viewOriginal;
+import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.DATA_FILE_FILESET;
+import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.METADATA_CONTAINER;
 import static edu.unc.lib.dl.model.StoragePolicy.EXTERNAL;
 import static edu.unc.lib.dl.model.StoragePolicy.INTERNAL;
 
@@ -31,26 +33,29 @@ import edu.unc.lib.dl.acl.util.Permission;
  *
  */
 public enum DatastreamType {
-    FULLTEXT_EXTRACTION("fulltext", "text/plain", "txt", EXTERNAL, viewHidden),
-    JP2_ACCESS_COPY("jp2", "image/jp2", "jp2", EXTERNAL, viewAccessCopies),
-    MD_DESCRIPTIVE("md_descriptive", "text/xml", "xml", INTERNAL, viewMetadata),
-    MD_EVENTS("event_log", "application/n-triples", "nt", INTERNAL, viewHidden),
-    ORIGINAL_FILE("original_file", null, null, INTERNAL, viewOriginal),
-    TECHNICAL_METADATA("techmd_fits", "text/xml", "xml", INTERNAL, viewHidden),
-    THUMBNAIL_SMALL("thumbnail_small", "image/png", "png", EXTERNAL, viewMetadata),
-    THUMBNAIL_LARGE("thumbnail_large", "image/png", "png", EXTERNAL, viewMetadata);
+    FULLTEXT_EXTRACTION("fulltext", "text/plain", "txt", null, EXTERNAL, viewHidden),
+    JP2_ACCESS_COPY("jp2", "image/jp2", "jp2", null, EXTERNAL, viewAccessCopies),
+    MD_DESCRIPTIVE("md_descriptive", "text/xml", "xml", METADATA_CONTAINER, INTERNAL, viewMetadata),
+    MD_DESCRIPTIVE_HISTORY("md_descriptive_history", "text/xml", "xml", METADATA_CONTAINER, INTERNAL, viewHidden),
+    MD_EVENTS("event_log", "application/n-triples", "nt", METADATA_CONTAINER, INTERNAL, viewHidden),
+    ORIGINAL_FILE("original_file", null, null, DATA_FILE_FILESET, INTERNAL, viewOriginal),
+    TECHNICAL_METADATA("techmd_fits", "text/xml", "xml", DATA_FILE_FILESET, INTERNAL, viewHidden),
+    THUMBNAIL_SMALL("thumbnail_small", "image/png", "png", null, EXTERNAL, viewMetadata),
+    THUMBNAIL_LARGE("thumbnail_large", "image/png", "png", null, EXTERNAL, viewMetadata);
 
     private final String id;
     private final String mimetype;
     private final String extension;
+    private final String container;
     private final StoragePolicy storagePolicy;
     private final Permission accessPermission;
 
-    private DatastreamType(String identifier, String mimetype, String extension, StoragePolicy storagePolicy,
-            Permission accessPermission) {
+    private DatastreamType(String identifier, String mimetype, String extension, String container,
+            StoragePolicy storagePolicy, Permission accessPermission) {
         this.id = identifier;
         this.mimetype = mimetype;
         this.extension = extension;
+        this.container = container;
         this.storagePolicy = storagePolicy;
         this.accessPermission = accessPermission;
     }
@@ -74,6 +79,13 @@ public enum DatastreamType {
      */
     public String getExtension() {
         return extension;
+    }
+
+    /**
+     * @return The name of the fedora container where this datastream is stored
+     */
+    public String getContainer() {
+        return container;
     }
 
     /**

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/WorkObjectIT.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/WorkObjectIT.java
@@ -15,21 +15,17 @@
  */
 package edu.unc.lib.dl.fcrepo4;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.commons.io.FileUtils.writeStringToFile;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedReader;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.apache.activemq.util.ByteArrayInputStream;
 import org.apache.commons.io.FileUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -146,52 +142,6 @@ public class WorkObjectIT extends AbstractFedoraIT {
         FileObject suppMember = (FileObject) findContentObjectByPid(members, supp.getPid());
         BinaryObject suppFile = suppMember.getOriginalFile();
         assertEquals(filenameS, suppFile.getFilename());
-    }
-
-    @Test
-    public void addModsTest() throws Exception {
-        WorkObject obj = repoObjFactory.createWorkObject(null);
-        String bodyString = "some MODS content";
-        Path modsPath = Files.createTempFile(null, null);
-        writeStringToFile(modsPath.toFile(), bodyString, UTF_8);
-        BinaryObject modsObj = obj.setDescription(modsPath.toUri());
-
-        assertObjectExists(obj.getDescription().getPid());
-        assertObjectExists(modsObj.getPid());
-        // make sure content is added to MODS
-        String respString = new BufferedReader(new InputStreamReader(modsObj.getBinaryStream()))
-                .lines().collect(Collectors.joining("\n"));
-        assertEquals("Original content did not match submitted value", bodyString, respString);
-    }
-
-    @Test
-    public void addSourceMdTest() throws Exception {
-        // Setup work with MODS and source description
-        WorkObject anotherObj = repoObjFactory.createWorkObject(null);
-        String sourceProfile = "some source md";
-        String sourceMdBodyString = "source md content";
-        String modsBodyString = "MODS content";
-        InputStream sourceMdStream = new ByteArrayInputStream(sourceMdBodyString.getBytes());
-        Path modsPath = Files.createTempFile(null, null);
-        writeStringToFile(modsPath.toFile(), modsBodyString, UTF_8);
-        BinaryObject modsObj = anotherObj.setDescription(modsPath.toUri());
-        BinaryObject sourceObj = anotherObj.addSourceMetadata(sourceMdStream, sourceProfile);
-
-        // tests that listDescriptions returns binary objects for source md and mods
-        List<BinaryObject> descs = anotherObj.listMetadata();
-        assertTrue("Result must contain mods object", descs.contains(modsObj));
-        assertTrue("Result must contain source md object", descs.contains(sourceObj));
-
-        assertObjectExists(modsObj.getPid());
-        assertObjectExists(sourceObj.getPid());
-
-        String sourceMdRespString = new BufferedReader(new InputStreamReader(sourceObj.getBinaryStream()))
-                .lines().collect(Collectors.joining("\n"));
-        assertEquals("Source content did not match submitted value", sourceMdBodyString, sourceMdRespString);
-
-        String modsRespString = new BufferedReader(new InputStreamReader(modsObj.getBinaryStream()))
-                .lines().collect(Collectors.joining("\n"));
-        assertEquals("MODS content did not match submitted value", modsBodyString, modsRespString);
     }
 
     @Test

--- a/metadata/src/main/java/edu/unc/lib/dl/exceptions/RepositoryException.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/exceptions/RepositoryException.java
@@ -28,6 +28,10 @@ public class RepositoryException extends RuntimeException {
         super(message);
     }
 
+    public RepositoryException(Throwable ex) {
+        super(ex);
+    }
+
     public RepositoryException(String message, Throwable ex) {
         super(message, ex);
     }

--- a/metadata/src/main/java/edu/unc/lib/dl/xml/JDOMNamespaceUtil.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/xml/JDOMNamespaceUtil.java
@@ -21,6 +21,8 @@ import static edu.unc.lib.dl.xml.NamespaceConstants.CDR_MESSAGE_PREFIX;
 import static edu.unc.lib.dl.xml.NamespaceConstants.CDR_MESSAGE_URI;
 import static edu.unc.lib.dl.xml.NamespaceConstants.CDR_PREFIX;
 import static edu.unc.lib.dl.xml.NamespaceConstants.CDR_URI;
+import static edu.unc.lib.dl.xml.NamespaceConstants.DCR_PACKAGING_PREFIX;
+import static edu.unc.lib.dl.xml.NamespaceConstants.DCR_PACKAGING_URI;
 import static edu.unc.lib.dl.xml.NamespaceConstants.DCTERMS_PREFIX;
 import static edu.unc.lib.dl.xml.NamespaceConstants.DCTERMS_URI;
 import static edu.unc.lib.dl.xml.NamespaceConstants.DC_PREFIX;
@@ -90,6 +92,9 @@ public class JDOMNamespaceUtil {
      */
     public static final Namespace CDR_MESSAGE_NS = Namespace.getNamespace(
             CDR_MESSAGE_PREFIX, CDR_MESSAGE_URI);
+
+    public static final Namespace DCR_PACKAGING_NS = Namespace.getNamespace(DCR_PACKAGING_PREFIX,
+            DCR_PACKAGING_URI);
 
     /**
      * DCMI namespace with standard prefix.

--- a/metadata/src/main/java/edu/unc/lib/dl/xml/NamespaceConstants.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/xml/NamespaceConstants.java
@@ -58,6 +58,12 @@ public final class NamespaceConstants {
 
     public static final String CDR_MESSAGE_PREFIX = "cdrmsg";
 
+    public static final String DCR_PACKAGING_PREFIX = "dcr-packaging";
+    /**
+     * Namespace URI for DCR packaging elements
+     */
+    public static final String DCR_PACKAGING_URI = "https://library.unc.edu/dcr/packaging/";
+
     /**
      * The Dublin Core namespace prefix.
      */

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/InterruptedLockException.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/InterruptedLockException.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.persist.services;
+
+import edu.unc.lib.dl.exceptions.RepositoryException;
+
+/**
+ * Exception indicating that a lock or acquisition of one was interrupted
+ *
+ * @author bbpennel
+ */
+public class InterruptedLockException extends RepositoryException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * @param message
+     */
+    public InterruptedLockException(String message) {
+        super(message);
+    }
+
+}

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/PidLockManager.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/PidLockManager.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.persist.services;
+
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+
+import com.google.common.util.concurrent.Striped;
+
+import edu.unc.lib.dl.fedora.PID;
+
+/**
+ * Manager for getting locks on PID objects
+ *
+ * @author bbpennel
+ */
+public class PidLockManager {
+    private static final int DEFAULT_MAX_LOCKS = 1000;
+    private static final PidLockManager DEFAULT_LOCK_MANAGER = new PidLockManager();
+
+    private Striped<ReadWriteLock> locks;
+
+    public PidLockManager() {
+        this(DEFAULT_MAX_LOCKS);
+    }
+
+    public PidLockManager(int numLocks) {
+        locks = Striped.lazyWeakReadWriteLock(numLocks);
+    }
+
+    public static PidLockManager getDefaultPidLockManager() {
+        return DEFAULT_LOCK_MANAGER;
+    }
+
+    /**
+     * Get a read write lock for the provided pid
+     *
+     * @param pid
+     * @return
+     */
+    public ReadWriteLock lockPid(PID pid) {
+        return locks.get(pid.getQualifiedId());
+    }
+
+    /**
+     * Locks and returns the write lock to a pid once it is available
+     *
+     * @param pid
+     */
+    public Lock awaitWriteLock(PID pid) {
+        try {
+            Lock lock = lockPid(pid).writeLock();
+            lock.lockInterruptibly();
+            return lock;
+        } catch (InterruptedException e) {
+            throw new InterruptedLockException("Interrupted while waiting for lock on " + pid.getQualifiedId());
+        }
+    }
+
+    /**
+     * Locks and returns the read lock to a pid once it is available
+     *
+     * @param pid
+     */
+    public Lock awaitReadLock(PID pid) {
+        try {
+            Lock lock = lockPid(pid).readLock();
+            lock.lockInterruptibly();
+            return lock;
+        } catch (InterruptedException e) {
+            throw new InterruptedLockException("Interrupted while waiting for lock on " + pid.getQualifiedId());
+        }
+    }
+}

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/versioning/DatastreamHistoryLog.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/versioning/DatastreamHistoryLog.java
@@ -52,7 +52,6 @@ public class DatastreamHistoryLog {
     public static final String CONTENT_TYPE_ATTR = "contentType";
     public static final String CREATED_ATTR = "created";
 
-
     private Document historyDoc;
     private PID datastreamPid;
 

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/versioning/DatastreamHistoryLog.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/versioning/DatastreamHistoryLog.java
@@ -15,6 +15,7 @@
  */
 package edu.unc.lib.dl.persist.services.versioning;
 
+import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.DCR_PACKAGING_NS;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.ByteArrayInputStream;
@@ -63,7 +64,7 @@ public class DatastreamHistoryLog {
     public DatastreamHistoryLog(PID datastreamPid) {
         this.datastreamPid = datastreamPid;
         historyDoc = new Document();
-        Element historyEl = new Element(HISTORY_TAG)
+        Element historyEl = new Element(HISTORY_TAG, DCR_PACKAGING_NS)
                 .setAttribute(ID_ATTR, datastreamPid.getQualifiedId());
         historyDoc.addContent(historyEl);
     }
@@ -92,7 +93,7 @@ public class DatastreamHistoryLog {
      * @param created timestamp the datastream version was created
      */
     public void addVersion(InputStream content, String contentType, Date created) {
-        Element versionEl = new Element(VERSION_TAG)
+        Element versionEl = new Element(VERSION_TAG, DCR_PACKAGING_NS)
                 .setAttribute(CREATED_ATTR, DateTimeUtil.formatDateToUTC(created))
                 .setAttribute(CONTENT_TYPE_ATTR, contentType);
 

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/versioning/DatastreamHistoryLog.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/versioning/DatastreamHistoryLog.java
@@ -45,8 +45,12 @@ public class DatastreamHistoryLog {
     private static final String XML_TYPE_TEXT = "text/xml";
     private static final String XML_TYPE_APP = "application/xml";
 
-    private static final String HISTORY_TAG = "datastreamHistory";
-    private static final String VERSION_TAG = "version";
+    public static final String HISTORY_TAG = "datastreamHistory";
+    public static final String VERSION_TAG = "version";
+    public static final String ID_ATTR = "id";
+    public static final String CONTENT_TYPE_ATTR = "contentType";
+    public static final String CREATED_ATTR = "created";
+
 
     private Document historyDoc;
     private PID datastreamPid;
@@ -60,7 +64,7 @@ public class DatastreamHistoryLog {
         this.datastreamPid = datastreamPid;
         historyDoc = new Document();
         Element historyEl = new Element(HISTORY_TAG)
-                .setAttribute("id", datastreamPid.getQualifiedId());
+                .setAttribute(ID_ATTR, datastreamPid.getQualifiedId());
         historyDoc.addContent(historyEl);
     }
 
@@ -89,8 +93,8 @@ public class DatastreamHistoryLog {
      */
     public void addVersion(InputStream content, String contentType, Date created) {
         Element versionEl = new Element(VERSION_TAG)
-                .setAttribute("created", DateTimeUtil.formatDateToUTC(created))
-                .setAttribute("contentType", contentType);
+                .setAttribute(CREATED_ATTR, DateTimeUtil.formatDateToUTC(created))
+                .setAttribute(CONTENT_TYPE_ATTR, contentType);
 
         try {
             if (XML_TYPE_TEXT.equals(contentType) || XML_TYPE_APP.equals(contentType)) {

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/versioning/DatastreamHistoryLog.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/versioning/DatastreamHistoryLog.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.persist.services.versioning;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Date;
+
+import org.apache.commons.io.IOUtils;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.JDOMException;
+import org.jdom2.output.Format;
+import org.jdom2.output.XMLOutputter;
+
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.fedora.ServiceException;
+import edu.unc.lib.dl.util.DateTimeUtil;
+import edu.unc.lib.dl.xml.SecureXMLFactory;
+
+/**
+ * Object representing the history of a datastream as a timestamped XML based log.
+ *
+ * @author bbpennel
+ */
+public class DatastreamHistoryLog {
+
+    private static final String XML_TYPE_TEXT = "text/xml";
+    private static final String XML_TYPE_APP = "application/xml";
+
+    private static final String HISTORY_TAG = "datastreamHistory";
+    private static final String VERSION_TAG = "version";
+
+    private Document historyDoc;
+    private PID datastreamPid;
+
+    /**
+     * Instantiate a new history log for the specified datastream
+     *
+     * @param datastreamPid
+     */
+    public DatastreamHistoryLog(PID datastreamPid) {
+        this.datastreamPid = datastreamPid;
+        historyDoc = new Document();
+        Element historyEl = new Element(HISTORY_TAG)
+                .setAttribute("id", datastreamPid.getQualifiedId());
+        historyDoc.addContent(historyEl);
+    }
+
+    /**
+     * Instantiate from an existing history log
+     *
+     * @param logStream
+     * @throws JDOMException
+     * @throws IOException
+     */
+    public DatastreamHistoryLog(PID datastreamPid, InputStream logStream) {
+        this.datastreamPid = datastreamPid;
+        try {
+            historyDoc = SecureXMLFactory.createSAXBuilder().build(logStream);
+        } catch (JDOMException | IOException e) {
+            throw new ServiceException("Failed to parse datastream history for " + datastreamPid.getQualifiedId(), e);
+        }
+    }
+
+    /**
+     * Add a version of the datastream to the history log
+     *
+     * @param content InputStream containing the content of the new datastream version
+     * @param contentType content type of the datastream version
+     * @param created timestamp the datastream version was created
+     */
+    public void addVersion(InputStream content, String contentType, Date created) {
+        Element versionEl = new Element(VERSION_TAG)
+                .setAttribute("created", DateTimeUtil.formatDateToUTC(created))
+                .setAttribute("contentType", contentType);
+
+        try {
+            if (XML_TYPE_TEXT.equals(contentType) || XML_TYPE_APP.equals(contentType)) {
+                Document contentDoc = SecureXMLFactory.createSAXBuilder().build(content);
+                Element contentRoot = contentDoc.getRootElement();
+                versionEl.addContent(contentRoot.detach());
+            } else {
+                versionEl.setText(IOUtils.toString(content, UTF_8));
+            }
+        } catch (JDOMException | IOException e) {
+            throw new ServiceException("Failed to add new version of " + datastreamPid.getQualifiedId(), e);
+        }
+
+        historyDoc.getRootElement().addContent(versionEl);
+    }
+
+    /**
+     * Serialize the history log into an inputstream
+     *
+     * @return the XML log as an InputStream
+     * @throws IOException thrown if unable to serialize the log
+     */
+    public InputStream toInputStream() throws IOException {
+        try (ByteArrayOutputStream outStream = new ByteArrayOutputStream()) {
+            new XMLOutputter(Format.getPrettyFormat()).output(historyDoc, outStream);
+            return new ByteArrayInputStream(outStream.toByteArray());
+        }
+    }
+}

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/versioning/VersionedDatastreamService.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/versioning/VersionedDatastreamService.java
@@ -60,8 +60,8 @@ public class VersionedDatastreamService {
         BinaryObject dsObj = getBinaryObject(dsPid);
 
         // Get a session for transferring the binary and its history
-        try (BinaryTransferSession session = getTransferSession(newVersion, dsObj)) {
-
+        BinaryTransferSession session = getTransferSession(newVersion, dsObj);
+        try {
             // if datastream is new, go ahead and create it
             if (dsObj == null) {
                 return updateHeadVersion(newVersion, session);
@@ -72,6 +72,11 @@ public class VersionedDatastreamService {
 
                 // Replace the head version with the new content
                 return updateHeadVersion(newVersion, session);
+            }
+        } finally {
+            // Only close the transfer session if it was created within this method call
+            if (newVersion.getTransferSession() == null) {
+                session.close();
             }
         }
     }

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/versioning/VersionedDatastreamService.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/versioning/VersionedDatastreamService.java
@@ -1,0 +1,279 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.persist.services.versioning;
+
+import static edu.unc.lib.dl.model.DatastreamPids.getDatastreamHistoryPid;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+
+import org.apache.jena.rdf.model.Model;
+
+import edu.unc.lib.dl.fcrepo4.BinaryObject;
+import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fcrepo4.RepositoryObject;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
+import edu.unc.lib.dl.fedora.NotFoundException;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.fedora.ServiceException;
+import edu.unc.lib.dl.persist.api.transfer.BinaryTransferService;
+import edu.unc.lib.dl.persist.api.transfer.BinaryTransferSession;
+
+/**
+ * Service for managing versions of a datastream using an XML based history log.
+ *
+ * This form of versioning should only be used for small or text based datastreams.
+ *
+ * @author bbpennel
+ */
+public class VersionedDatastreamService {
+    private RepositoryObjectLoader repoObjLoader;
+    private RepositoryObjectFactory repoObjFactory;
+    private BinaryTransferService transferService;
+
+    /**
+     * Update a versioned datastream. If the datastream already exists, its previous
+     * value will be moved into a history log object.
+     *
+     * @param newVersion details of the new datastream version
+     * @return the BinaryObject representation of the datastream updated
+     */
+    public BinaryObject addVersion(DatastreamVersion newVersion) {
+
+        PID dsPid = newVersion.getDsPid();
+
+        BinaryObject dsObj = getBinaryObject(dsPid);
+
+        // Get a session for transferring the binary and its history
+        try (BinaryTransferSession session = getTransferSession(newVersion, dsObj)) {
+
+            // if datastream is new, go ahead and create it
+            if (dsObj == null) {
+                return updateHeadVersion(newVersion, session);
+            } else {
+                // Datastream already exists
+                // Add the current head version to the history log
+                updateDatastreamHistory(session, dsObj);
+
+                // Replace the head version with the new content
+                return updateHeadVersion(newVersion, session);
+            }
+        }
+    }
+
+    /**
+     * Get the binary object represented by the given pid, or null if it does not exist.
+     * @param dsPid
+     * @return
+     */
+    private BinaryObject getBinaryObject(PID dsPid) {
+        try {
+            return repoObjLoader.getBinaryObject(dsPid);
+        } catch (NotFoundException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Add the current state of the datastream to its history log. If no history log exists,
+     * one will be created.
+     *
+     * @param session
+     * @param currentDsObj
+     */
+    private void updateDatastreamHistory(BinaryTransferSession session, BinaryObject currentDsObj) {
+        PID currentDsPid = currentDsObj.getPid();
+
+        // Load existing datastream history if present
+        PID dsHistoryPid = getDatastreamHistoryPid(currentDsPid);
+        BinaryObject dsHistory = getBinaryObject(dsHistoryPid);
+        // No history, start new one
+        DatastreamHistoryLog historyLog;
+        if (dsHistory == null) {
+            historyLog = new DatastreamHistoryLog(currentDsPid);
+        } else {
+            historyLog = new DatastreamHistoryLog(currentDsPid, dsHistory.getBinaryStream());
+        }
+
+        historyLog.addVersion(currentDsObj.getBinaryStream(),
+                currentDsObj.getMimetype(),
+                currentDsObj.getCreatedDate());
+
+        URI historyStorageUri;
+        try {
+            historyStorageUri = session.transferReplaceExisting(dsHistoryPid, historyLog.toInputStream());
+        } catch (IOException e) {
+            throw new ServiceException("Failed to serialize history for " + currentDsPid, e);
+        }
+
+        // Update the history object in fedora
+        repoObjFactory.createOrUpdateBinary(dsHistoryPid,
+                historyStorageUri,
+                null,
+                "text/xml",
+                null,
+                null,
+                null);
+    }
+
+    private BinaryObject updateHeadVersion(DatastreamVersion newVersion, BinaryTransferSession session) {
+        PID dsPid = newVersion.getDsPid();
+        // Transfer the incoming content to its storage location
+        URI dsStorageUri;
+        if (newVersion.getStagedContentUri() == null) {
+            dsStorageUri = session.transferReplaceExisting(dsPid, newVersion.getContentStream());
+        } else {
+            dsStorageUri = session.transferReplaceExisting(dsPid, newVersion.getStagedContentUri());
+        }
+
+        return repoObjFactory.createOrUpdateBinary(newVersion.getDsPid(),
+                dsStorageUri,
+                newVersion.getFilename(),
+                newVersion.getContentType(),
+                newVersion.getMd5(),
+                newVersion.getSha1(),
+                newVersion.getProperties());
+    }
+
+    /**
+     * Get a transfer session for copying the new content to its destination location.
+     * This may either be a new session, or an existing session if one was provided.
+     *
+     * @param newVersion
+     * @param dsObj
+     * @return
+     */
+    private BinaryTransferSession getTransferSession(DatastreamVersion newVersion, RepositoryObject dsObj) {
+        if (newVersion.getTransferSession() != null) {
+            return newVersion.getTransferSession();
+        }
+
+        if (dsObj != null) {
+            return transferService.getSession(dsObj);
+        }
+
+        PID parentPid = PIDs.get(newVersion.getDsPid().getId());
+        if (parentPid.equals(newVersion.getDsPid())) {
+            throw new IllegalArgumentException("Unable to determine parent of datastream, the provided PID does not "
+                    + "confirm to the expected datastream PID format: " + newVersion.getDsPid().getQualifiedId());
+        }
+        RepositoryObject parentObj = repoObjLoader.getRepositoryObject(parentPid);
+        return transferService.getSession(parentObj);
+    }
+
+    public void setRepositoryObjectLoader(RepositoryObjectLoader repoObjLoader) {
+        this.repoObjLoader = repoObjLoader;
+    }
+
+    public void setRepositoryObjectFactory(RepositoryObjectFactory repoObjFactory) {
+        this.repoObjFactory = repoObjFactory;
+    }
+
+    public void setBinaryTransferService(BinaryTransferService transferService) {
+        this.transferService = transferService;
+    }
+
+    /**
+     * Details of a datastream version
+     *
+     * @author bbpennel
+     */
+    public static class DatastreamVersion {
+        private PID dsPid;
+        private InputStream contentStream;
+        private URI stagedContentUri;
+        private String contentType;
+        private BinaryTransferSession transferSession;
+        private String md5;
+        private String sha1;
+        private String filename;
+        private Model properties;
+
+        public DatastreamVersion(PID dsPid) {
+            this.dsPid = dsPid;
+        }
+
+        public PID getDsPid() {
+            return dsPid;
+        }
+
+        public InputStream getContentStream() {
+            return contentStream;
+        }
+
+        public void setContentStream(InputStream contentStream) {
+            this.contentStream = contentStream;
+        }
+
+        public URI getStagedContentUri() {
+            return stagedContentUri;
+        }
+
+        public void setStagedContentUri(URI contentUri) {
+            this.stagedContentUri = contentUri;
+        }
+
+        public String getContentType() {
+            return contentType;
+        }
+
+        public void setContentType(String contentType) {
+            this.contentType = contentType;
+        }
+
+        public BinaryTransferSession getTransferSession() {
+            return transferSession;
+        }
+
+        public void setTransferSession(BinaryTransferSession transferSession) {
+            this.transferSession = transferSession;
+        }
+
+        public String getMd5() {
+            return md5;
+        }
+
+        public void setMd5(String md5) {
+            this.md5 = md5;
+        }
+
+        public String getSha1() {
+            return sha1;
+        }
+
+        public void setSha1(String sha1) {
+            this.sha1 = sha1;
+        }
+
+        public String getFilename() {
+            return filename;
+        }
+
+        public void setFilename(String filename) {
+            this.filename = filename;
+        }
+
+        public Model getProperties() {
+            return properties;
+        }
+
+        public void setProperties(Model properties) {
+            this.properties = properties;
+        }
+    }
+}

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/versioning/VersionedDatastreamService.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/versioning/VersionedDatastreamService.java
@@ -20,6 +20,7 @@ import static edu.unc.lib.dl.model.DatastreamPids.getDatastreamHistoryPid;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.util.Date;
 
 import org.apache.jena.rdf.model.Model;
 
@@ -109,15 +110,19 @@ public class VersionedDatastreamService {
         BinaryObject dsHistory = getBinaryObject(dsHistoryPid);
         // No history, start new one
         DatastreamHistoryLog historyLog;
+        // For the first entry in the log, use when the datastream was created. After use modified date
+        Date versionDate;
         if (dsHistory == null) {
             historyLog = new DatastreamHistoryLog(currentDsPid);
+            versionDate = currentDsObj.getCreatedDate();
         } else {
             historyLog = new DatastreamHistoryLog(currentDsPid, dsHistory.getBinaryStream());
+            versionDate = currentDsObj.getLastModified();
         }
 
         historyLog.addVersion(currentDsObj.getBinaryStream(),
                 currentDsObj.getMimetype(),
-                currentDsObj.getCreatedDate());
+                versionDate);
 
         URI historyStorageUri;
         try {

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/edit/UpdateDescriptionServiceTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/edit/UpdateDescriptionServiceTest.java
@@ -140,8 +140,6 @@ public class UpdateDescriptionServiceTest {
         assertEquals("text/xml", version.getContentType());
         assertEquals(FILE_CONTENT, IOUtils.toString(version.getContentStream()));
 
-        verify(versioningService).addVersion(any(DatastreamVersion.class));
-
         assertMessageSent();
     }
 
@@ -156,8 +154,6 @@ public class UpdateDescriptionServiceTest {
         assertEquals(modsPid, version.getDsPid());
         assertEquals("text/xml", version.getContentType());
         assertEquals(FILE_CONTENT, IOUtils.toString(version.getContentStream()));
-
-        verify(versioningService).addVersion(any(DatastreamVersion.class));
 
         assertMessageSent();
     }
@@ -221,8 +217,6 @@ public class UpdateDescriptionServiceTest {
         assertEquals(modsPid, version.getDsPid());
         assertEquals("text/xml", version.getContentType());
         assertEquals(FILE_CONTENT, IOUtils.toString(version.getContentStream()));
-
-        verify(versioningService).addVersion(any(DatastreamVersion.class));
 
         verify(messageSender, never()).sendUpdateDescriptionOperation(anyString(), pidsCaptor.capture());
     }

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/edit/UpdateDescriptionServiceTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/edit/UpdateDescriptionServiceTest.java
@@ -22,13 +22,12 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.io.InputStream;
-import java.net.URI;
 import java.util.Collection;
 import java.util.UUID;
 
@@ -48,11 +47,13 @@ import edu.unc.lib.dl.acl.util.Permission;
 import edu.unc.lib.dl.fcrepo4.BinaryObject;
 import edu.unc.lib.dl.fcrepo4.ContentObject;
 import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
 import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.persist.api.storage.StorageLocation;
-import edu.unc.lib.dl.persist.api.transfer.BinaryTransferService;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferSession;
+import edu.unc.lib.dl.persist.services.versioning.VersionedDatastreamService;
+import edu.unc.lib.dl.persist.services.versioning.VersionedDatastreamService.DatastreamVersion;
 import edu.unc.lib.dl.services.OperationsMessageSender;
 import edu.unc.lib.dl.validation.MODSValidator;
 import edu.unc.lib.dl.validation.MetadataValidationException;
@@ -71,15 +72,19 @@ public class UpdateDescriptionServiceTest {
     @Mock
     private RepositoryObjectLoader repoObjLoader;
     @Mock
+    private RepositoryObjectFactory repoObjFactory;
+    @Mock
     private OperationsMessageSender messageSender;
     @Mock
     private MODSValidator modsValidator;
     @Mock
     private StorageLocation destination;
     @Mock
-    private BinaryTransferService transferService;
-    @Mock
     private BinaryTransferSession transferSession;
+    @Mock
+    private VersionedDatastreamService versioningService;
+    @Mock
+    private BinaryObject mockDescBin;
 
     @Mock
     private AgentPrincipals agent;
@@ -88,12 +93,10 @@ public class UpdateDescriptionServiceTest {
     @Mock
     private ContentObject obj;
 
-    private URI transferredUri;
-
-    @Captor
-    private ArgumentCaptor<InputStream> inputStreamCaptor;
     @Captor
     private ArgumentCaptor<Collection<PID>> pidsCaptor;
+    @Captor
+    private ArgumentCaptor<DatastreamVersion> versionCaptor;
 
     private UpdateDescriptionService service;
     private PID objPid;
@@ -114,34 +117,49 @@ public class UpdateDescriptionServiceTest {
         objPid = PIDs.get(UUID.randomUUID().toString());
         modsPid = getMdDescriptivePid(objPid);
         modsStream = new ByteArrayInputStream(FILE_CONTENT.getBytes());
-        transferredUri = URI.create("file:///path/to/transferred/file.txt");
 
-        when(obj.setDescription(any(URI.class))).thenReturn(mock(BinaryObject.class));
+        when(versioningService.addVersion(any(DatastreamVersion.class))).thenReturn(mockDescBin);
         when(obj.getPid()).thenReturn(objPid);
-
-        when(transferSession.transferReplaceExisting(modsPid, modsStream)).thenReturn(transferredUri);
 
         service = new UpdateDescriptionService();
         service.setAclService(aclService);
         service.setRepositoryObjectLoader(repoObjLoader);
+        service.setRepositoryObjectFactory(repoObjFactory);
         service.setOperationsMessageSender(messageSender);
         service.setModsValidator(modsValidator);
-        service.setTransferService(transferService);
+        service.setVersionedDatastreamService(versioningService);
     }
 
     @Test
     public void updateDescriptionTest() throws Exception {
-        when(transferService.getSession(obj)).thenReturn(transferSession);
+        service.updateDescription(agent, objPid, modsStream);
+
+        verify(versioningService).addVersion(versionCaptor.capture());
+        DatastreamVersion version = versionCaptor.getValue();
+        assertEquals(modsPid, version.getDsPid());
+        assertEquals("text/xml", version.getContentType());
+        assertEquals(FILE_CONTENT, IOUtils.toString(version.getContentStream()));
+
+        verify(versioningService).addVersion(any(DatastreamVersion.class));
+
+        assertMessageSent();
+    }
+
+    @Test
+    public void updateDescriptionAlreadyExistsTest() throws Exception {
+        when(repoObjFactory.objectExists(modsPid.getRepositoryUri())).thenReturn(true);
 
         service.updateDescription(agent, objPid, modsStream);
 
-        verify(transferSession).transferReplaceExisting(eq(modsPid), inputStreamCaptor.capture());
-        assertEquals(FILE_CONTENT, IOUtils.toString(inputStreamCaptor.getValue()));
+        verify(versioningService).addVersion(versionCaptor.capture());
+        DatastreamVersion version = versionCaptor.getValue();
+        assertEquals(modsPid, version.getDsPid());
+        assertEquals("text/xml", version.getContentType());
+        assertEquals(FILE_CONTENT, IOUtils.toString(version.getContentStream()));
 
-        verify(obj).setDescription(transferredUri);
+        verify(versioningService).addVersion(any(DatastreamVersion.class));
 
         assertMessageSent();
-
     }
 
     @Test(expected = AccessRestrictionException.class)
@@ -150,6 +168,19 @@ public class UpdateDescriptionServiceTest {
                 .assertHasAccess(anyString(), eq(objPid), any(AccessGroupSet.class), any(Permission.class));
 
         service.updateDescription(agent, objPid, modsStream);
+    }
+
+    @Test
+    public void insufficientAccessDisableAccessCheckTest() throws Exception {
+        doThrow(new AccessRestrictionException()).when(aclService)
+                .assertHasAccess(anyString(), eq(objPid), any(AccessGroupSet.class), any(Permission.class));
+
+        service.setChecksAccess(false);
+
+        service.updateDescription(agent, objPid, modsStream);
+
+        verify(versioningService).addVersion(any());
+        assertMessageSent();
     }
 
     @Test(expected = MetadataValidationException.class)
@@ -171,12 +202,29 @@ public class UpdateDescriptionServiceTest {
     public void updateDescriptionProvidedSession() throws Exception {
         service.updateDescription(transferSession, agent, objPid, modsStream);
 
-        verify(transferSession).transferReplaceExisting(eq(modsPid), inputStreamCaptor.capture());
-        assertEquals(FILE_CONTENT, IOUtils.toString(inputStreamCaptor.getValue()));
-
-        verify(obj).setDescription(transferredUri);
+        verify(versioningService).addVersion(versionCaptor.capture());
+        DatastreamVersion version = versionCaptor.getValue();
+        assertEquals(FILE_CONTENT, IOUtils.toString(version.getContentStream()));
+        assertEquals(transferSession, version.getTransferSession());
 
         assertMessageSent();
+    }
+
+    @Test
+    public void updateDescriptionDisableMassgesTest() throws Exception {
+        service.setSendsMessages(false);
+
+        service.updateDescription(agent, objPid, modsStream);
+
+        verify(versioningService).addVersion(versionCaptor.capture());
+        DatastreamVersion version = versionCaptor.getValue();
+        assertEquals(modsPid, version.getDsPid());
+        assertEquals("text/xml", version.getContentType());
+        assertEquals(FILE_CONTENT, IOUtils.toString(version.getContentStream()));
+
+        verify(versioningService).addVersion(any(DatastreamVersion.class));
+
+        verify(messageSender, never()).sendUpdateDescriptionOperation(anyString(), pidsCaptor.capture());
     }
 
     private void assertMessageSent() {

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/importxml/ImportXMLJobIT.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/importxml/ImportXMLJobIT.java
@@ -16,6 +16,7 @@
 package edu.unc.lib.dl.persist.services.importxml;
 
 import static edu.unc.lib.dl.persist.services.importxml.XMLImportTestHelper.addObjectUpdate;
+import static edu.unc.lib.dl.persist.services.importxml.XMLImportTestHelper.documentToInputStream;
 import static edu.unc.lib.dl.persist.services.importxml.XMLImportTestHelper.makeUpdateDocument;
 import static edu.unc.lib.dl.persist.services.importxml.XMLImportTestHelper.modsWithTitleAndDate;
 import static edu.unc.lib.dl.persist.services.importxml.XMLImportTestHelper.writeToFile;
@@ -293,8 +294,8 @@ public class ImportXMLJobIT {
         workObj = factory.createWorkObject(workPid, null);
         Document doc = new Document()
                 .addContent(modsWithTitleAndDate(ORIGINAL_TITLE, ORIGINAL_DATE));
-        File workModsFile = writeToFile(doc);
-        workObj.setDescription(workModsFile.toPath().toUri());
+        InputStream modsStream = documentToInputStream(doc);
+        updateService.updateDescription(null, agent, workObj, modsStream);
         return workPid;
     }
 

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/versioning/DatastreamHistoryLogTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/versioning/DatastreamHistoryLogTest.java
@@ -16,6 +16,7 @@
 package edu.unc.lib.dl.persist.services.versioning;
 
 import static edu.unc.lib.dl.util.DateTimeUtil.parseUTCToDate;
+import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.DCR_PACKAGING_NS;
 import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.MODS_V3_NS;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -70,7 +71,7 @@ public class DatastreamHistoryLogTest {
         Document logDoc = inputStreamToDocument(historyLog.toInputStream());
         assertLogObjectIdEquals(dsPid, logDoc);
 
-        List<Element> versions = logDoc.getRootElement().getChildren(DatastreamHistoryLog.VERSION_TAG);
+        List<Element> versions = listVersions(logDoc);
         assertEquals(1, versions.size());
 
         Element versionEl = versions.get(0);
@@ -90,7 +91,7 @@ public class DatastreamHistoryLogTest {
         Document logDoc = inputStreamToDocument(historyLog.toInputStream());
         assertLogObjectIdEquals(dsPid, logDoc);
 
-        List<Element> versions = logDoc.getRootElement().getChildren(DatastreamHistoryLog.VERSION_TAG);
+        List<Element> versions = listVersions(logDoc);
         assertEquals(1, versions.size());
 
         Element versionEl = versions.get(0);
@@ -121,7 +122,7 @@ public class DatastreamHistoryLogTest {
         Document logDoc = inputStreamToDocument(historyLog.toInputStream());
         assertLogObjectIdEquals(dsPid, logDoc);
 
-        List<Element> versions = logDoc.getRootElement().getChildren(DatastreamHistoryLog.VERSION_TAG);
+        List<Element> versions = listVersions(logDoc);
         assertEquals(2, versions.size());
 
         Element versionEl = versions.get(0);
@@ -150,7 +151,7 @@ public class DatastreamHistoryLogTest {
         Document logDoc = inputStreamToDocument(historyLog.toInputStream());
         assertLogObjectIdEquals(dsPid, logDoc);
 
-        List<Element> versions = logDoc.getRootElement().getChildren(DatastreamHistoryLog.VERSION_TAG);
+        List<Element> versions = listVersions(logDoc);
         assertEquals(2, versions.size());
 
         Element versionEl = versions.get(0);
@@ -171,6 +172,11 @@ public class DatastreamHistoryLogTest {
 
         List<Element> versions = logDoc.getRootElement().getChildren(DatastreamHistoryLog.VERSION_TAG);
         assertEquals(0, versions.size());
+    }
+
+    private List<Element> listVersions(Document logDoc) {
+        return logDoc.getRootElement()
+                .getChildren(DatastreamHistoryLog.VERSION_TAG, DCR_PACKAGING_NS);
     }
 
     private void assertLogObjectIdEquals(PID expected, Document logDoc) {

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/versioning/DatastreamHistoryLogTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/versioning/DatastreamHistoryLogTest.java
@@ -1,0 +1,214 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.persist.services.versioning;
+
+import static edu.unc.lib.dl.util.DateTimeUtil.parseUTCToDate;
+import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.MODS_V3_NS;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Date;
+import java.util.List;
+
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.output.Format;
+import org.jdom2.output.XMLOutputter;
+import org.junit.Before;
+import org.junit.Test;
+
+import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.fedora.ServiceException;
+import edu.unc.lib.dl.xml.SecureXMLFactory;
+
+/**
+ * @author bbpennel
+ */
+public class DatastreamHistoryLogTest {
+
+    private static final String TEST_ID = "a168cf29-a2a9-4da8-9b8d-025855b180d5/md/md_file";
+    private static final String TEST_TITLE = "Historical doc";
+    private static final String VERSION1_TIME = "2020-03-03T12:00:00.000Z";
+    private static final String VERSION2_TIME = "2020-03-15T05:00:00.000Z";
+    private static final Date VERSION1_DATE = parseUTCToDate(VERSION1_TIME);
+    private static final Date VERSION2_DATE = parseUTCToDate(VERSION2_TIME);
+
+    private PID dsPid;
+
+    @Before
+    public void setup() throws Exception {
+        initMocks(this);
+        dsPid = PIDs.get(TEST_ID);
+    }
+
+    @Test
+    public void addVersion_NewLog_XmlContent() throws Exception {
+        DatastreamHistoryLog historyLog = new DatastreamHistoryLog(dsPid);
+
+        InputStream contentStream = getModsDocumentStream(TEST_TITLE);
+
+        historyLog.addVersion(contentStream, "text/xml", VERSION1_DATE);
+
+        Document logDoc = inputStreamToDocument(historyLog.toInputStream());
+        assertLogObjectIdEquals(dsPid, logDoc);
+
+        List<Element> versions = logDoc.getRootElement().getChildren(DatastreamHistoryLog.VERSION_TAG);
+        assertEquals(1, versions.size());
+
+        Element versionEl = versions.get(0);
+        assertVersionAttributes(VERSION1_TIME, "text/xml", versionEl);
+        assertVersionHasModsTitle(TEST_TITLE, versionEl);
+    }
+
+    @Test
+    public void addVersion_NewLog_TextContent() throws Exception {
+        DatastreamHistoryLog historyLog = new DatastreamHistoryLog(dsPid);
+
+        String dsContent = "all of my content";
+        InputStream contentStream = new ByteArrayInputStream(dsContent.getBytes());
+
+        historyLog.addVersion(contentStream, "text/plain", VERSION1_DATE);
+
+        Document logDoc = inputStreamToDocument(historyLog.toInputStream());
+        assertLogObjectIdEquals(dsPid, logDoc);
+
+        List<Element> versions = logDoc.getRootElement().getChildren(DatastreamHistoryLog.VERSION_TAG);
+        assertEquals(1, versions.size());
+
+        Element versionEl = versions.get(0);
+        assertVersionAttributes(VERSION1_TIME, "text/plain", versionEl);
+        assertEquals(dsContent, versionEl.getText());
+    }
+
+    @Test(expected = ServiceException.class)
+    public void addVersion_NewLog_TextContentWithXmlType_Fail() throws Exception {
+        DatastreamHistoryLog historyLog = new DatastreamHistoryLog(dsPid);
+
+        String dsContent = "all of my content";
+        InputStream contentStream = new ByteArrayInputStream(dsContent.getBytes());
+
+        historyLog.addVersion(contentStream, "text/xml", VERSION1_DATE);
+    }
+
+    @Test
+    public void addVersion_NewLog_MultipleVersions() throws Exception {
+        DatastreamHistoryLog historyLog = new DatastreamHistoryLog(dsPid);
+
+        InputStream contentStream = getModsDocumentStream(TEST_TITLE);
+        historyLog.addVersion(contentStream, "text/xml", VERSION1_DATE);
+
+        InputStream contentStream2 = getModsDocumentStream("another title");
+        historyLog.addVersion(contentStream2, "text/xml", VERSION2_DATE);
+
+        Document logDoc = inputStreamToDocument(historyLog.toInputStream());
+        assertLogObjectIdEquals(dsPid, logDoc);
+
+        List<Element> versions = logDoc.getRootElement().getChildren(DatastreamHistoryLog.VERSION_TAG);
+        assertEquals(2, versions.size());
+
+        Element versionEl = versions.get(0);
+        assertVersionAttributes(VERSION1_TIME, "text/xml", versionEl);
+        assertVersionHasModsTitle(TEST_TITLE, versionEl);
+
+        Element versionEl2 = versions.get(1);
+        assertVersionAttributes(VERSION2_TIME, "text/xml", versionEl2);
+        assertVersionHasModsTitle("another title", versionEl2);
+    }
+
+    @Test
+    public void addVersion_ExistingLog_MultipleVersions() throws Exception {
+        DatastreamHistoryLog startingLog = new DatastreamHistoryLog(dsPid);
+
+        InputStream contentStream = getModsDocumentStream(TEST_TITLE);
+        startingLog.addVersion(contentStream, "text/xml", VERSION1_DATE);
+
+        InputStream startingLogStream = startingLog.toInputStream();
+
+        DatastreamHistoryLog historyLog = new DatastreamHistoryLog(dsPid, startingLogStream);
+
+        InputStream contentStream2 = getModsDocumentStream("another title");
+        historyLog.addVersion(contentStream2, "text/xml", VERSION2_DATE);
+
+        Document logDoc = inputStreamToDocument(historyLog.toInputStream());
+        assertLogObjectIdEquals(dsPid, logDoc);
+
+        List<Element> versions = logDoc.getRootElement().getChildren(DatastreamHistoryLog.VERSION_TAG);
+        assertEquals(2, versions.size());
+
+        Element versionEl = versions.get(0);
+        assertVersionAttributes(VERSION1_TIME, "text/xml", versionEl);
+        assertVersionHasModsTitle(TEST_TITLE, versionEl);
+
+        Element versionEl2 = versions.get(1);
+        assertVersionAttributes(VERSION2_TIME, "text/xml", versionEl2);
+        assertVersionHasModsTitle("another title", versionEl2);
+    }
+
+    @Test
+    public void newLog_NoVersions() throws Exception {
+        DatastreamHistoryLog historyLog = new DatastreamHistoryLog(dsPid);
+
+        Document logDoc = inputStreamToDocument(historyLog.toInputStream());
+        assertLogObjectIdEquals(dsPid, logDoc);
+
+        List<Element> versions = logDoc.getRootElement().getChildren(DatastreamHistoryLog.VERSION_TAG);
+        assertEquals(0, versions.size());
+    }
+
+    private void assertLogObjectIdEquals(PID expected, Document logDoc) {
+        String id = logDoc.getRootElement().getAttributeValue(DatastreamHistoryLog.ID_ATTR);
+        assertEquals("Identifier in log doc did not match expected id",
+                expected.getQualifiedId(), id);
+    }
+
+    private void assertVersionHasModsTitle(String expected, Element versionEl) {
+        String titleVal = versionEl.getChild("mods", MODS_V3_NS)
+                .getChild("titleInfo", MODS_V3_NS)
+                .getChildText("title", MODS_V3_NS);
+        assertEquals(expected, titleVal);
+    }
+
+    private void assertVersionAttributes(String expectedTime, String expectedType, Element versionEl) {
+        String created = versionEl.getAttributeValue(DatastreamHistoryLog.CREATED_ATTR);
+        assertEquals(expectedTime, created);
+        String contentType = versionEl.getAttributeValue(DatastreamHistoryLog.CONTENT_TYPE_ATTR);
+        assertEquals(expectedType, contentType);
+    }
+
+    private InputStream getModsDocumentStream(String title) throws Exception {
+        Document document = new Document()
+                .addContent(new Element("mods", MODS_V3_NS)
+                .addContent(new Element("titleInfo", MODS_V3_NS)
+                        .addContent(new Element("title", MODS_V3_NS).setText(title))));
+
+        return convertDocumentToStream(document);
+    }
+
+    private InputStream convertDocumentToStream(Document doc) throws IOException {
+        ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        new XMLOutputter(Format.getPrettyFormat()).output(doc, outStream);
+        return new ByteArrayInputStream(outStream.toByteArray());
+    }
+
+    private Document inputStreamToDocument(InputStream docStream) throws Exception{
+        return SecureXMLFactory.createSAXBuilder().build(docStream);
+    }
+}

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/versioning/VersionedDatastreamServiceIT.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/versioning/VersionedDatastreamServiceIT.java
@@ -1,0 +1,314 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.persist.services.versioning;
+
+import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.MODS_V3_NS;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Date;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.output.Format;
+import org.jdom2.output.XMLOutputter;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import edu.unc.lib.dl.fcrepo4.BinaryObject;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
+import edu.unc.lib.dl.fcrepo4.RepositoryPIDMinter;
+import edu.unc.lib.dl.fcrepo4.WorkObject;
+import edu.unc.lib.dl.fedora.ObjectTypeMismatchException;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.model.DatastreamPids;
+import edu.unc.lib.dl.persist.api.transfer.BinaryTransferSession;
+import edu.unc.lib.dl.persist.services.ingest.IngestSourceManagerImpl;
+import edu.unc.lib.dl.persist.services.ingest.IngestSourceTestHelper;
+import edu.unc.lib.dl.persist.services.transfer.BinaryTransferServiceImpl;
+import edu.unc.lib.dl.persist.services.versioning.VersionedDatastreamService.DatastreamVersion;
+import edu.unc.lib.dl.test.RepositoryObjectTreeIndexer;
+import edu.unc.lib.dl.test.TestHelper;
+import edu.unc.lib.dl.util.DateTimeUtil;
+import edu.unc.lib.dl.xml.SecureXMLFactory;
+
+/**
+ * @author bbpennel
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextHierarchy({
+    @ContextConfiguration("/spring-test/test-fedora-container.xml"),
+    @ContextConfiguration("/spring-test/cdr-client-container.xml")
+})
+public class VersionedDatastreamServiceIT {
+    private static final String TEST_TITLE = "Historical doc";
+
+    @Rule
+    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private VersionedDatastreamService service;
+
+    @Autowired
+    private String baseAddress;
+    @Autowired
+    private RepositoryObjectLoader repoObjLoader;
+    @Autowired
+    private RepositoryObjectFactory repoObjFactory;
+    @Autowired
+    private BinaryTransferServiceImpl transferService;
+    @Autowired
+    private RepositoryPIDMinter pidMinter;
+    @Autowired
+    private RepositoryObjectTreeIndexer treeIndexer;
+
+    private IngestSourceManagerImpl sourceManager;
+    private Path sourcePath;
+
+    private PID parentPid;
+    private PID dsPid;
+
+    @Before
+    public void setup() throws Exception {
+        TestHelper.setContentBase(baseAddress);
+
+        service = new VersionedDatastreamService();
+        service.setBinaryTransferService(transferService);
+        service.setRepositoryObjectFactory(repoObjFactory);
+        service.setRepositoryObjectLoader(repoObjLoader);
+
+        File sourceMappingFile = new File(tmpFolder.getRoot(), "sourceMapping.json");
+        FileUtils.writeStringToFile(sourceMappingFile, "[]", "UTF-8");
+        sourcePath = tmpFolder.newFolder("source_dir").toPath();
+        Path sourceConfigPath = IngestSourceTestHelper.createConfigFile(
+                IngestSourceTestHelper.createFilesystemConfig("source_dir", "src", sourcePath, asList("*")));
+
+        sourceManager = new IngestSourceManagerImpl();
+        sourceManager.setConfigPath(sourceConfigPath.toString());
+        sourceManager.setMappingPath(sourceMappingFile.toString());
+        sourceManager.init();
+
+        transferService.setIngestSourceManager(sourceManager);
+
+        parentPid = pidMinter.mintContentPid();
+        dsPid = DatastreamPids.getMdDescriptivePid(parentPid);
+    }
+
+    @Test
+    public void addVersion_NewDatastream_StreamContent() throws Exception {
+        repoObjFactory.createFolderObject(parentPid, null);
+        treeIndexer.indexAll(baseAddress);
+
+        DatastreamVersion newV = new DatastreamVersion(dsPid);
+        newV.setContentStream(getModsDocumentStream(TEST_TITLE));
+        newV.setContentType("text/xml");
+
+        BinaryObject dsObj = service.addVersion(newV);
+        Document storedDoc = inputStreamToDocument(dsObj.getBinaryStream());
+
+        assertHasModsTitle(TEST_TITLE, storedDoc);
+    }
+
+    @Test
+    public void addVersion_NewDatastream_UriContent() throws Exception {
+        repoObjFactory.createFolderObject(parentPid, null);
+        treeIndexer.indexAll(baseAddress);
+
+        Path srcFile = sourcePath.resolve("src_mods.xml");
+        DatastreamVersion newV = new DatastreamVersion(dsPid);
+        Files.copy(getModsDocumentStream(TEST_TITLE), srcFile);
+        newV.setStagedContentUri(srcFile.toUri());
+        newV.setContentType("text/xml");
+
+        BinaryObject dsObj = service.addVersion(newV);
+        Document storedDoc = inputStreamToDocument(dsObj.getBinaryStream());
+
+        assertHasModsTitle(TEST_TITLE, storedDoc);
+    }
+
+    @Test
+    public void addVersion_ExistingDatastream() throws Exception {
+        repoObjFactory.createFolderObject(parentPid, null);
+        treeIndexer.indexAll(baseAddress);
+
+        DatastreamVersion newV1 = new DatastreamVersion(dsPid);
+        newV1.setContentStream(getModsDocumentStream(TEST_TITLE));
+        newV1.setContentType("text/xml");
+
+        BinaryObject dsObj = service.addVersion(newV1);
+        Date originalCreated = dsObj.getCreatedDate();
+
+        DatastreamVersion newV2 = new DatastreamVersion(dsPid);
+        newV2.setContentStream(getModsDocumentStream("more titles"));
+        newV2.setContentType("text/xml");
+
+        BinaryObject dsObjUpdated = service.addVersion(newV2);
+
+        Document headDoc = inputStreamToDocument(dsObjUpdated.getBinaryStream());
+        assertHasModsTitle("more titles", headDoc);
+
+        PID historyPid = DatastreamPids.getDatastreamHistoryPid(dsPid);
+        BinaryObject dsHistoryObj = repoObjLoader.getBinaryObject(historyPid);
+
+        Document logDoc = inputStreamToDocument(dsHistoryObj.getBinaryStream());
+        List<Element> versions = logDoc.getRootElement().getChildren(DatastreamHistoryLog.VERSION_TAG);
+        assertEquals(1, versions.size());
+
+        Element versionEl = versions.get(0);
+        assertVersionAttributes(originalCreated, "text/xml", versionEl);
+        assertVersionHasModsTitle(TEST_TITLE, versionEl);
+    }
+
+    @Test
+    public void addVersion_DatastreamWithHistory() throws Exception {
+        repoObjFactory.createFolderObject(parentPid, null);
+        treeIndexer.indexAll(baseAddress);
+
+        DatastreamVersion newV1 = new DatastreamVersion(dsPid);
+        newV1.setContentStream(getModsDocumentStream(TEST_TITLE));
+        newV1.setContentType("text/xml");
+
+        BinaryObject dsObj = service.addVersion(newV1);
+        Date created1 = dsObj.getCreatedDate();
+
+        DatastreamVersion newV2 = new DatastreamVersion(dsPid);
+        newV2.setContentStream(getModsDocumentStream("more titles"));
+        newV2.setContentType("text/xml");
+
+        BinaryObject dsObj2 = service.addVersion(newV2);
+        Date created2 = dsObj2.getCreatedDate();
+
+        DatastreamVersion newV3 = new DatastreamVersion(dsPid);
+        newV3.setContentStream(getModsDocumentStream("lets leave it here"));
+        newV3.setContentType("text/xml");
+
+        BinaryObject dsObjFinal = service.addVersion(newV3);
+
+        Document headDoc = inputStreamToDocument(dsObjFinal.getBinaryStream());
+        assertHasModsTitle("lets leave it here", headDoc);
+
+        // check historic versions
+        PID historyPid = DatastreamPids.getDatastreamHistoryPid(dsPid);
+        BinaryObject dsHistoryObj = repoObjLoader.getBinaryObject(historyPid);
+
+        Document logDoc = inputStreamToDocument(dsHistoryObj.getBinaryStream());
+        List<Element> versions = logDoc.getRootElement().getChildren(DatastreamHistoryLog.VERSION_TAG);
+        assertEquals(2, versions.size());
+
+        Element versionEl = versions.get(0);
+        assertVersionAttributes(created1, "text/xml", versionEl);
+        assertVersionHasModsTitle(TEST_TITLE, versionEl);
+
+        Element versionEl2 = versions.get(1);
+        assertVersionAttributes(created2, "text/xml", versionEl2);
+        assertVersionHasModsTitle("more titles", versionEl2);
+    }
+
+    @Test
+    public void addVersion_NewDatastream_ProvidedTransferSession() throws Exception {
+        WorkObject work = repoObjFactory.createWorkObject(parentPid, null);
+        treeIndexer.indexAll(baseAddress);
+
+        try (BinaryTransferSession session = transferService.getSession(work)) {
+            DatastreamVersion newV = new DatastreamVersion(dsPid);
+            newV.setContentStream(getModsDocumentStream(TEST_TITLE));
+            newV.setContentType("text/xml");
+            newV.setTransferSession(session);
+
+            BinaryObject dsObj = service.addVersion(newV);
+            Document storedDoc = inputStreamToDocument(dsObj.getBinaryStream());
+
+            assertHasModsTitle(TEST_TITLE, storedDoc);
+        }
+    }
+
+    @Test(expected = ObjectTypeMismatchException.class)
+    public void addVersion_NonDatastreamObject() throws Exception {
+        repoObjFactory.createWorkObject(parentPid, null);
+        treeIndexer.indexAll(baseAddress);
+
+        DatastreamVersion newV = new DatastreamVersion(parentPid);
+        newV.setContentStream(getModsDocumentStream(TEST_TITLE));
+        newV.setContentType("text/xml");
+
+        service.addVersion(newV);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void addVersion_NonDatastreamPid() throws Exception {
+        DatastreamVersion newV = new DatastreamVersion(parentPid);
+        newV.setContentStream(getModsDocumentStream(TEST_TITLE));
+        newV.setContentType("text/xml");
+
+        service.addVersion(newV);
+    }
+
+    private InputStream getModsDocumentStream(String title) throws Exception {
+        Document document = new Document()
+                .addContent(new Element("mods", MODS_V3_NS)
+                .addContent(new Element("titleInfo", MODS_V3_NS)
+                        .addContent(new Element("title", MODS_V3_NS).setText(title))));
+
+        return convertDocumentToStream(document);
+    }
+
+    private InputStream convertDocumentToStream(Document doc) throws IOException {
+        ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+        new XMLOutputter(Format.getPrettyFormat()).output(doc, outStream);
+        return new ByteArrayInputStream(outStream.toByteArray());
+    }
+
+    private void assertHasModsTitle(String expected, Document doc) {
+        assertHasModsTitle(expected, doc.getRootElement());
+    }
+
+    private void assertVersionHasModsTitle(String expected, Element versionEl) {
+        assertHasModsTitle(expected, versionEl.getChild("mods", MODS_V3_NS));
+    }
+
+    private void assertHasModsTitle(String expected, Element modsEl) {
+        String titleVal = modsEl.getChild("titleInfo", MODS_V3_NS)
+                .getChildText("title", MODS_V3_NS);
+        assertEquals(expected, titleVal);
+    }
+
+    private Document inputStreamToDocument(InputStream docStream) throws Exception{
+        return SecureXMLFactory.createSAXBuilder().build(docStream);
+    }
+
+    private void assertVersionAttributes(Date expectedTime, String expectedType, Element versionEl) {
+        String created = versionEl.getAttributeValue(DatastreamHistoryLog.CREATED_ATTR);
+        assertEquals(expectedTime, DateTimeUtil.parseUTCToDate(created));
+        String contentType = versionEl.getAttributeValue(DatastreamHistoryLog.CONTENT_TYPE_ATTR);
+        assertEquals(expectedType, contentType);
+    }
+}

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/versioning/VersionedDatastreamServiceIT.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/versioning/VersionedDatastreamServiceIT.java
@@ -15,6 +15,7 @@
  */
 package edu.unc.lib.dl.persist.services.versioning;
 
+import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.DCR_PACKAGING_NS;
 import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.MODS_V3_NS;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
@@ -180,7 +181,7 @@ public class VersionedDatastreamServiceIT {
         BinaryObject dsHistoryObj = repoObjLoader.getBinaryObject(historyPid);
 
         Document logDoc = inputStreamToDocument(dsHistoryObj.getBinaryStream());
-        List<Element> versions = logDoc.getRootElement().getChildren(DatastreamHistoryLog.VERSION_TAG);
+        List<Element> versions = listVersions(logDoc);
         assertEquals(1, versions.size());
 
         Element versionEl = versions.get(0);
@@ -221,7 +222,7 @@ public class VersionedDatastreamServiceIT {
         BinaryObject dsHistoryObj = repoObjLoader.getBinaryObject(historyPid);
 
         Document logDoc = inputStreamToDocument(dsHistoryObj.getBinaryStream());
-        List<Element> versions = logDoc.getRootElement().getChildren(DatastreamHistoryLog.VERSION_TAG);
+        List<Element> versions = listVersions(logDoc);
         assertEquals(2, versions.size());
 
         Element versionEl = versions.get(0);
@@ -310,5 +311,10 @@ public class VersionedDatastreamServiceIT {
         assertEquals(expectedTime, DateTimeUtil.parseUTCToDate(created));
         String contentType = versionEl.getAttributeValue(DatastreamHistoryLog.CONTENT_TYPE_ATTR);
         assertEquals(expectedType, contentType);
+    }
+
+    private List<Element> listVersions(Document logDoc) {
+        return logDoc.getRootElement()
+                .getChildren(DatastreamHistoryLog.VERSION_TAG, DCR_PACKAGING_NS);
     }
 }

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/versioning/VersionedDatastreamServiceIT.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/versioning/VersionedDatastreamServiceIT.java
@@ -19,6 +19,7 @@ import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.DCR_PACKAGING_NS;
 import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.MODS_V3_NS;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -199,14 +200,14 @@ public class VersionedDatastreamServiceIT {
         newV1.setContentType("text/xml");
 
         BinaryObject dsObj = service.addVersion(newV1);
-        Date created1 = dsObj.getCreatedDate();
+        Date version1Date = dsObj.getCreatedDate();
 
         DatastreamVersion newV2 = new DatastreamVersion(dsPid);
         newV2.setContentStream(getModsDocumentStream("more titles"));
         newV2.setContentType("text/xml");
 
         BinaryObject dsObj2 = service.addVersion(newV2);
-        Date created2 = dsObj2.getCreatedDate();
+        Date version2Date = dsObj2.getLastModified();
 
         DatastreamVersion newV3 = new DatastreamVersion(dsPid);
         newV3.setContentStream(getModsDocumentStream("lets leave it here"));
@@ -217,6 +218,9 @@ public class VersionedDatastreamServiceIT {
         Document headDoc = inputStreamToDocument(dsObjFinal.getBinaryStream());
         assertHasModsTitle("lets leave it here", headDoc);
 
+        assertNotEquals("Second version timestamp should not match head version",
+                version2Date, dsObjFinal.getLastModified());
+
         // check historic versions
         PID historyPid = DatastreamPids.getDatastreamHistoryPid(dsPid);
         BinaryObject dsHistoryObj = repoObjLoader.getBinaryObject(historyPid);
@@ -226,11 +230,11 @@ public class VersionedDatastreamServiceIT {
         assertEquals(2, versions.size());
 
         Element versionEl = versions.get(0);
-        assertVersionAttributes(created1, "text/xml", versionEl);
+        assertVersionAttributes(version1Date, "text/xml", versionEl);
         assertVersionHasModsTitle(TEST_TITLE, versionEl);
 
         Element versionEl2 = versions.get(1);
-        assertVersionAttributes(created2, "text/xml", versionEl2);
+        assertVersionAttributes(version2Date, "text/xml", versionEl2);
         assertVersionHasModsTitle("more titles", versionEl2);
     }
 

--- a/persistence/src/test/resources/spring-test/import-job-it.xml
+++ b/persistence/src/test/resources/spring-test/import-job-it.xml
@@ -13,14 +13,18 @@
         <constructor-arg value="edu.unc.lib.dl.acl.fcrepo4.AccessControlServiceImpl" />
     </bean>
     
+    <bean id="versionedDatastreamService" class="edu.unc.lib.dl.persist.services.versioning.VersionedDatastreamService" >
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
+        <property name="binaryTransferService" ref="binaryTransferService" />
+    </bean>
+    
     <bean id="updateService" class="edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService" >
         <property name="aclService" ref="aclService" />
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
         <property name="operationsMessageSender" ref="operationsMessageSender" />
         <property name="modsValidator" ref="modsValidator" />
-        <property name="transferService" ref="binaryTransferService" />
-    </bean>
-    
-    <bean id="binaryTransferService" class="edu.unc.lib.dl.persist.services.transfer.BinaryTransferServiceImpl">
+        <property name="versionedDatastreamService" ref="versionedDatastreamService" />
     </bean>
 </beans>

--- a/services-camel/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel/src/main/webapp/WEB-INF/service-context.xml
@@ -318,13 +318,20 @@
             </bean>
         </property>
     </bean>
+    
+    <bean id="versionedDatastreamService" class="edu.unc.lib.dl.persist.services.versioning.VersionedDatastreamService" >
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
+        <property name="binaryTransferService" ref="binaryTransferService" />
+    </bean>
 
     <bean id="updateDescriptionService" class="edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService">
         <property name="aclService" ref="aclService" />
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
         <property name="operationsMessageSender" ref="operationsMessageSender" />
         <property name="modsValidator" ref="modsValidator" />
-        <property name="transferService" ref="binaryTransferService" />
+        <property name="versionedDatastreamService" ref="versionedDatastreamService" />
     </bean>
     
     <bean id="importXMLProcessor" class="edu.unc.lib.dl.services.camel.importxml.ImportXMLProcessor">

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solr/AbstractSolrProcessorIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solr/AbstractSolrProcessorIT.java
@@ -22,6 +22,7 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.io.InputStream;
 import java.net.URI;
 
 import org.apache.camel.Exchange;
@@ -31,7 +32,6 @@ import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
-import org.apache.tika.io.IOUtils;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -138,8 +138,7 @@ public abstract class AbstractSolrProcessorIT {
         return contentFile.toPath().toUri();
     }
 
-    protected URI makeContentUriFromResource(String resourcePath) throws Exception {
-        return makeContentUri(IOUtils.toString(
-                getClass().getResourceAsStream(resourcePath)));
+    protected InputStream streamResource(String resourcePath) throws Exception {
+        return getClass().getResourceAsStream(resourcePath);
     }
 }

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solr/SolrIngestProcessorIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solr/SolrIngestProcessorIT.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
@@ -33,12 +34,15 @@ import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import edu.unc.lib.dl.acl.util.AgentPrincipals;
 import edu.unc.lib.dl.data.ingest.solr.indexing.DocumentIndexingPipeline;
 import edu.unc.lib.dl.fcrepo4.FileObject;
 import edu.unc.lib.dl.fcrepo4.RepositoryObject;
 import edu.unc.lib.dl.fcrepo4.WorkObject;
+import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService;
 import edu.unc.lib.dl.rdf.Cdr;
 import edu.unc.lib.dl.rdf.CdrAcl;
 import edu.unc.lib.dl.search.solr.model.BriefObjectMetadata;
@@ -59,6 +63,10 @@ public class SolrIngestProcessorIT extends AbstractSolrProcessorIT {
 
     @Autowired
     private DocumentIndexingPipeline solrFullUpdatePipeline;
+    @Autowired
+    private UpdateDescriptionService updateDescriptionService;
+    @Mock
+    private AgentPrincipals agent;
 
     @Before
     public void setUp() throws Exception {
@@ -81,7 +89,8 @@ public class SolrIngestProcessorIT extends AbstractSolrProcessorIT {
         FileObject fileObj = workObj.addDataFile(makeContentUri(CONTENT_TEXT),
                 "text.txt", "text/plain", null, null);
         workObj.setPrimaryObject(fileObj.getPid());
-        workObj.setDescription(makeContentUriFromResource("/datastreams/simpleMods.xml"));
+        InputStream modsStream = streamResource("/datastreams/simpleMods.xml");
+        updateDescriptionService.updateDescription(agent, workObj.getPid(), modsStream);
 
         indexObjectsInTripleStore(rootObj, workObj, fileObj, unitObj, collObj);
 

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solrUpdate/SolrUpdateProcessorIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solrUpdate/SolrUpdateProcessorIT.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
+import java.io.InputStream;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -44,15 +45,18 @@ import org.apache.solr.common.SolrInputDocument;
 import org.jdom2.Document;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.ContextHierarchy;
 
+import edu.unc.lib.dl.acl.util.AgentPrincipals;
 import edu.unc.lib.dl.data.ingest.solr.action.IndexingAction;
 import edu.unc.lib.dl.fcrepo4.AdminUnit;
 import edu.unc.lib.dl.fcrepo4.CollectionObject;
 import edu.unc.lib.dl.fcrepo4.RepositoryObject;
 import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService;
 import edu.unc.lib.dl.search.solr.model.BriefObjectMetadata;
 import edu.unc.lib.dl.search.solr.model.SimpleIdRequest;
 import edu.unc.lib.dl.search.solr.util.FacetConstants;
@@ -76,6 +80,10 @@ public class SolrUpdateProcessorIT extends AbstractSolrProcessorIT {
 
     @Autowired
     private CamelContext cdrServiceSolrUpdate;
+    @Autowired
+    private UpdateDescriptionService updateDescriptionService;
+    @Mock
+    private AgentPrincipals agent;
 
     @Resource(name = "solrIndexingActionMap")
     private Map<IndexingActionType, IndexingAction> solrIndexingActionMap;
@@ -135,7 +143,8 @@ public class SolrUpdateProcessorIT extends AbstractSolrProcessorIT {
 
     @Test
     public void testUpdateDescription() throws Exception {
-        collObj.setDescription(makeContentUriFromResource("/datastreams/simpleMods.xml"));
+        InputStream modsStream = streamResource("/datastreams/simpleMods.xml");
+        updateDescriptionService.updateDescription(agent, collObj.getPid(), modsStream);
 
         indexObjectsInTripleStore(rootObj, unitObj, collObj);
 

--- a/services-camel/src/test/resources/import-xml-it-context.xml
+++ b/services-camel/src/test/resources/import-xml-it-context.xml
@@ -89,19 +89,13 @@
         </property>
     </bean>
     
-    <bean id="aclService" class="org.mockito.Mockito" factory-method="mock">
-        <constructor-arg value="edu.unc.lib.dl.acl.fcrepo4.AccessControlServiceImpl" />
-    </bean>
-    
-    <bean id="binaryTransferService" class="edu.unc.lib.dl.persist.services.transfer.BinaryTransferServiceImpl">
-    </bean>
-    
-    <bean id="updateDescriptionService" class="edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService">
+    <bean id="updateDescriptionService" class="edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService" >
         <property name="aclService" ref="aclService" />
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
         <property name="operationsMessageSender" ref="operationsMessageSender" />
+        <property name="versionedDatastreamService" ref="versionedDatastreamService" />
         <property name="modsValidator" ref="modsValidator" />
-        <property name="transferService" ref="binaryTransferService" />
     </bean>
     
     <bean id="importXMLProcessor" class="edu.unc.lib.dl.services.camel.importxml.ImportXMLProcessor">

--- a/services-camel/src/test/resources/spring-test/cdr-client-container.xml
+++ b/services-camel/src/test/resources/spring-test/cdr-client-container.xml
@@ -81,5 +81,37 @@
     <bean id="txManager" class="edu.unc.lib.dl.fcrepo4.TransactionManager">
         <property name="client" ref="fcrepoClient" />
     </bean>
+    
+    <bean id="aclService" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.acl.fcrepo4.AccessControlServiceImpl" />
+    </bean>
+    
+    <bean id="storageLocationManager" class="edu.unc.lib.dl.persist.services.storage.StorageLocationTestHelper"
+            factory-method="createLocationManagerWithBasicConfig">
+        <constructor-arg ref="repositoryObjectLoader" />
+    </bean>
+    
+    <bean id="binaryTransferService" class="edu.unc.lib.dl.persist.services.transfer.BinaryTransferServiceImpl">
+        <property name="storageLocationManager" ref="storageLocationManager" />
+    </bean>
+    
+    <bean id="versionedDatastreamService" class="edu.unc.lib.dl.persist.services.versioning.VersionedDatastreamService" >
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
+        <property name="binaryTransferService" ref="binaryTransferService" />
+    </bean>
+    
+    <bean id="operationsMessageSender" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.services.OperationsMessageSender" />
+    </bean>
+
+    <bean id="updateDescriptionService" class="edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService" >
+        <property name="aclService" ref="aclService" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
+        <property name="operationsMessageSender" ref="operationsMessageSender" />
+        <property name="validate" value="false" />
+        <property name="versionedDatastreamService" ref="versionedDatastreamService" />
+    </bean>
 
 </beans>

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/DatastreamController.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/DatastreamController.java
@@ -92,7 +92,9 @@ public class DatastreamController {
                 fedoraContentService.streamEventLog(pid, principals, download, response);
             } else {
                 fedoraContentService.streamData(pid, datastream, principals, download, response);
-                recordDownloadEvent(pid, datastream, principals, request);
+                if (datastream == null || DatastreamType.ORIGINAL_FILE.getId().equals(datastream)) {
+                    recordDownloadEvent(pid, datastream, principals, request);
+                }
             }
         } catch (IOException e) {
             log.error("Problem retrieving {} for {}", pid.toString(), datastream, e);

--- a/services/src/main/webapp/WEB-INF/service-context.xml
+++ b/services/src/main/webapp/WEB-INF/service-context.xml
@@ -297,12 +297,19 @@
       <property name="operationsMessageSender" ref="operationsMessageSender" />
   </bean>
   
+  <bean id="versionedDatastreamService" class="edu.unc.lib.dl.persist.services.versioning.VersionedDatastreamService" >
+      <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+      <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
+      <property name="binaryTransferService" ref="binaryTransferService" />
+  </bean>
+  
   <bean id="updateDescriptionService" class="edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService" >
       <property name="aclService" ref="aclService" />
       <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+      <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
       <property name="operationsMessageSender" ref="operationsMessageSender" />
       <property name="modsValidator" ref="modsValidator" />
-      <property name="transferService" ref="binaryTransferService" />
+      <property name="versionedDatastreamService" ref="versionedDatastreamService" />
   </bean>
   
   <bean id="emailHandler" class="edu.unc.lib.persist.services.EmailHandler">

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/UpdateDescriptionIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/UpdateDescriptionIT.java
@@ -16,7 +16,6 @@
 package edu.unc.lib.dl.cdr.services.rest.modify;
 
 import static edu.unc.lib.dl.acl.util.Permission.editDescription;
-import static edu.unc.lib.dl.persist.services.storage.StorageLocationTestHelper.createLocationManagerWithBasicConfig;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -45,10 +44,9 @@ import org.springframework.test.web.servlet.MvcResult;
 import edu.unc.lib.dl.acl.exception.AccessRestrictionException;
 import edu.unc.lib.dl.acl.util.AccessGroupSet;
 import edu.unc.lib.dl.fcrepo4.ContentObject;
-import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
 import edu.unc.lib.dl.fedora.ContentPathFactory;
 import edu.unc.lib.dl.fedora.PID;
-import edu.unc.lib.dl.persist.services.transfer.BinaryTransferServiceImpl;
+import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService;
 
 /**
  *
@@ -61,18 +59,16 @@ import edu.unc.lib.dl.persist.services.transfer.BinaryTransferServiceImpl;
     @ContextConfiguration("/update-description-it-servlet.xml")
 })
 public class UpdateDescriptionIT extends AbstractAPIIT {
-    @Autowired
-    private RepositoryObjectLoader repoObjLoader;
     @Mock
     private ContentPathFactory pathFactory;
     @Autowired
-    private BinaryTransferServiceImpl transferService;
+    private UpdateDescriptionService updateDescriptionService;
 
     @Before
     public void setup() throws Exception {
         initMocks(this);
 
-        transferService.setStorageLocationManager(createLocationManagerWithBasicConfig(repoObjLoader));
+        updateDescriptionService.setValidate(true);
     }
 
     @Test

--- a/services/src/test/resources/edit-title-it-servlet.xml
+++ b/services/src/test/resources/edit-title-it-servlet.xml
@@ -39,18 +39,6 @@
         <property name="operationsMessageSender" ref="operationsMessageSender" />
     </bean>
 
-    <bean id="aclService" class="org.mockito.Mockito" factory-method="mock">
-        <constructor-arg value="edu.unc.lib.dl.acl.fcrepo4.AccessControlServiceImpl" />
-    </bean>
-
-    <bean id="updateDescriptionService" class="edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService" >
-        <property name="aclService" ref="aclService" />
-        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
-        <property name="operationsMessageSender" ref="operationsMessageSender" />
-        <property name="modsValidator" ref="modsValidator" />
-        <property name="transferService" ref="binaryTransferService" />
-    </bean>
-
     <bean id="contentPathFactory" class="edu.unc.lib.dl.fedora.ContentPathFactory"
           init-method="init">
         <property name="cacheMaxSize" value="0" />

--- a/services/src/test/resources/export-xml-it-servlet.xml
+++ b/services/src/test/resources/export-xml-it-servlet.xml
@@ -38,10 +38,6 @@
         <property name="repoObjLoader" ref="repositoryObjectLoader" />
     </bean>
     
-    <bean id="aclService" class="org.mockito.Mockito" factory-method="mock">
-        <constructor-arg value="edu.unc.lib.dl.acl.fcrepo4.AccessControlServiceImpl" />
-    </bean>
-    
     <bean id="emailHandler" class="org.mockito.Mockito" factory-method="mock">
         <constructor-arg value="edu.unc.lib.persist.services.EmailHandler" />
     </bean>

--- a/services/src/test/resources/retrieve-mods-it-servlet.xml
+++ b/services/src/test/resources/retrieve-mods-it-servlet.xml
@@ -32,25 +32,6 @@
 
     <context:component-scan resource-pattern="**/RetrieveMODSController*" base-package="edu.unc.lib.dl.cdr.services.rest"/>
     
-    <bean id="versionedDatastreamService" class="edu.unc.lib.dl.persist.services.versioning.VersionedDatastreamService" >
-        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
-        <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
-        <property name="binaryTransferService" ref="binaryTransferService" />
-    </bean>
-    
-    <bean id="operationsMessageSender" class="org.mockito.Mockito" factory-method="mock">
-        <constructor-arg value="edu.unc.lib.dl.services.OperationsMessageSender" />
-    </bean>
-    
-    <bean id="updateService" class="edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService" >
-        <property name="aclService" ref="aclService" />
-        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
-        <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
-        <property name="operationsMessageSender" ref="operationsMessageSender" />
-        <property name="validate" value="false" />
-        <property name="versionedDatastreamService" ref="versionedDatastreamService" />
-    </bean>
-    
     <bean id="modsRetrievalService" class="edu.unc.lib.dl.cdr.services.processing.MODSRetrievalService">
         <property name="aclService" ref="aclService" />
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />

--- a/services/src/test/resources/retrieve-mods-it-servlet.xml
+++ b/services/src/test/resources/retrieve-mods-it-servlet.xml
@@ -32,6 +32,25 @@
 
     <context:component-scan resource-pattern="**/RetrieveMODSController*" base-package="edu.unc.lib.dl.cdr.services.rest"/>
     
+    <bean id="versionedDatastreamService" class="edu.unc.lib.dl.persist.services.versioning.VersionedDatastreamService" >
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
+        <property name="binaryTransferService" ref="binaryTransferService" />
+    </bean>
+    
+    <bean id="operationsMessageSender" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.services.OperationsMessageSender" />
+    </bean>
+    
+    <bean id="updateService" class="edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService" >
+        <property name="aclService" ref="aclService" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
+        <property name="operationsMessageSender" ref="operationsMessageSender" />
+        <property name="validate" value="false" />
+        <property name="versionedDatastreamService" ref="versionedDatastreamService" />
+    </bean>
+    
     <bean id="modsRetrievalService" class="edu.unc.lib.dl.cdr.services.processing.MODSRetrievalService">
         <property name="aclService" ref="aclService" />
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />

--- a/services/src/test/resources/spring-test/cdr-client-container.xml
+++ b/services/src/test/resources/spring-test/cdr-client-container.xml
@@ -98,6 +98,26 @@
         <property name="client" ref="fcrepoClient" />
     </bean>
     
+    <bean id="aclService" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.acl.fcrepo4.AccessControlServiceImpl" />
+    </bean>
+    
+    <bean id="versionedDatastreamService" class="edu.unc.lib.dl.persist.services.versioning.VersionedDatastreamService" >
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
+        <property name="binaryTransferService" ref="binaryTransferService" />
+    </bean>
+
+    <bean id="updateDescriptionService" class="edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService" >
+        <property name="aclService" ref="aclService" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
+        <property name="operationsMessageSender" ref="operationsMessageSender" />
+        <property name="validate" value="false" />
+        <property name="versionedDatastreamService" ref="versionedDatastreamService" />
+        <property name="modsValidator" ref="modsValidator" />
+    </bean>
+    
     <bean id="jmsTemplate" class="org.mockito.Mockito" factory-method="mock">
         <constructor-arg value="org.springframework.jms.core.JmsTemplate" />
     </bean>

--- a/services/src/test/resources/update-description-it-servlet.xml
+++ b/services/src/test/resources/update-description-it-servlet.xml
@@ -31,19 +31,4 @@
     <mvc:annotation-driven/>
 
     <context:component-scan resource-pattern="**/UpdateDescriptionController*" base-package="edu.unc.lib.dl.cdr.services.rest.modify"/>
-    
-    <bean id="updateDescriptionService" class="edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService">
-        <property name="aclService" ref="aclService" />
-        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
-        <property name="operationsMessageSender" ref="operationsMessageSender" />
-        <property name="modsValidator" ref="modsValidator" />
-        <property name="transferService" ref="binaryTransferService" />
-    </bean>
-    
-    <bean id="binaryTransferService" class="edu.unc.lib.dl.persist.services.transfer.BinaryTransferServiceImpl">
-    </bean>
-    
-    <bean id="aclService" class="org.mockito.Mockito" factory-method="mock">
-        <constructor-arg value="edu.unc.lib.dl.acl.fcrepo4.AccessControlServiceImpl" />
-    </bean>
 </beans>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2527

* Implements service for updating files which are versioned
* Implements datastream history log for adding textual contents to a history log
* Adds namespace for packaging xml
* Removes contentObject.setDescription in favor of UpdateDescriptionService
  * Service now adds description relations, transfers binaries, employs versioning, and is more configurable
* IngestContentObjectJob now uses UpdateDescriptionService for setting mods
  * Transfer of mods now takes place during this job
* Adds method for getting creation timestamp of objects