### PR TITLE
BXC-2606 - Solr indexing not found handling

### DIFF
--- a/persistence/src/main/java/edu/unc/lib/dl/services/RunEnhancementsMessageHelpers.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/services/RunEnhancementsMessageHelpers.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.services;
+
+import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.ATOM_NS;
+import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.CDR_MESSAGE_NS;
+
+import org.jdom2.Document;
+import org.jdom2.Element;
+
+import edu.unc.lib.dl.fedora.PID;
+
+/**
+ * @author bbpennel
+ */
+public class RunEnhancementsMessageHelpers {
+
+    private RunEnhancementsMessageHelpers() {
+    }
+
+    /**
+     * Generate the body for a run enhancement request message
+     *
+     * @param userid
+     * @param filePath
+     * @param mimeType
+     * @param force
+     * @return
+     */
+    public static Document makeEnhancementOperationBody(String userid, PID pid, Boolean force) {
+        Document msg = new Document();
+        Element entry = new Element("entry", ATOM_NS);
+        entry.addContent(new Element("author", ATOM_NS)
+                .addContent(new Element("name", ATOM_NS).setText(userid)));
+        entry.addContent(new Element("pid", ATOM_NS).setText(pid.getRepositoryPath()));
+
+        if (force) {
+            Element paramForce = new Element("force", CDR_MESSAGE_NS);
+            paramForce.setText("true");
+        }
+        msg.addContent(entry);
+
+        return msg;
+    }
+}

--- a/persistence/src/main/java/edu/unc/lib/dl/services/RunEnhancementsMessageHelpers.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/services/RunEnhancementsMessageHelpers.java
@@ -24,6 +24,8 @@ import org.jdom2.Element;
 import edu.unc.lib.dl.fedora.PID;
 
 /**
+ * Helper methods for run enhancement messages
+ *
  * @author bbpennel
  */
 public class RunEnhancementsMessageHelpers {

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/BinaryEnhancementProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/BinaryEnhancementProcessor.java
@@ -15,6 +15,8 @@
  */
 package edu.unc.lib.dl.services.camel;
 
+import static edu.unc.lib.dl.rdf.Fcrepo4Repository.Binary;
+import static edu.unc.lib.dl.services.camel.util.CdrFcrepoHeaders.FCREPO_RESOURCE_TYPE;
 import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.ATOM_NS;
 import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
 
@@ -49,6 +51,7 @@ public class BinaryEnhancementProcessor implements Processor {
 
             log.info("Adding enhancement headers for " + pidValue);
             in.setHeader(FCREPO_URI, pidValue);
+            in.setHeader(FCREPO_RESOURCE_TYPE, Binary.getURI());
         }
     }
 }

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/BinaryEnhancementProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/BinaryEnhancementProcessor.java
@@ -16,7 +16,6 @@
 package edu.unc.lib.dl.services.camel;
 
 import static edu.unc.lib.dl.rdf.Fcrepo4Repository.Binary;
-import static edu.unc.lib.dl.services.camel.util.CdrFcrepoHeaders.CdrBinaryMimeType;
 import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.ATOM_NS;
 import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
 
@@ -49,11 +48,9 @@ public class BinaryEnhancementProcessor implements Processor {
             Element body = msgBody.getRootElement();
 
             String pidValue = body.getChild("pid", ATOM_NS).getTextTrim();
-            String mimeType = body.getChild("mimeType", ATOM_NS).getTextTrim();
 
             log.info("Adding enhancement headers for " + pidValue);
             in.setHeader(FCREPO_URI, pidValue);
-            in.setHeader(CdrBinaryMimeType, mimeType);
             in.setHeader(FCREPO_RESOURCE_TYPE, Binary.getURI());
         }
     }

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/BinaryEnhancementProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/BinaryEnhancementProcessor.java
@@ -15,7 +15,6 @@
  */
 package edu.unc.lib.dl.services.camel;
 
-import static edu.unc.lib.dl.rdf.Fcrepo4Repository.Binary;
 import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.ATOM_NS;
 import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
 
@@ -36,7 +35,6 @@ import edu.unc.lib.dl.services.camel.util.MessageUtil;
  */
 public class BinaryEnhancementProcessor implements Processor {
     private static final Logger log = LoggerFactory.getLogger(BinaryEnhancementProcessor.class);
-    public static final String FCREPO_RESOURCE_TYPE = "org.fcrepo.jms.resourceType";
 
     @Override
     public void process(final Exchange exchange) throws Exception {
@@ -51,7 +49,6 @@ public class BinaryEnhancementProcessor implements Processor {
 
             log.info("Adding enhancement headers for " + pidValue);
             in.setHeader(FCREPO_URI, pidValue);
-            in.setHeader(FCREPO_RESOURCE_TYPE, Binary.getURI());
         }
     }
 }

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/enhancements/EnhancementRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/enhancements/EnhancementRouter.java
@@ -15,24 +15,19 @@
  */
 package edu.unc.lib.dl.services.camel.enhancements;
 
-import static edu.unc.lib.dl.rdf.Cdr.AdminUnit;
-import static edu.unc.lib.dl.rdf.Cdr.Collection;
-import static edu.unc.lib.dl.rdf.Cdr.ContentRoot;
-import static edu.unc.lib.dl.rdf.Cdr.DescriptiveMetadata;
-import static edu.unc.lib.dl.rdf.Cdr.FileObject;
-import static edu.unc.lib.dl.rdf.Cdr.Folder;
-import static edu.unc.lib.dl.rdf.Cdr.Work;
 import static edu.unc.lib.dl.rdf.Fcrepo4Repository.Binary;
 import static edu.unc.lib.dl.services.camel.util.CdrFcrepoHeaders.CdrBinaryPath;
 import static edu.unc.lib.dl.services.camel.util.CdrFcrepoHeaders.CdrEnhancementSet;
+import static org.apache.camel.LoggingLevel.DEBUG;
 import static org.apache.camel.LoggingLevel.INFO;
 
-import edu.unc.lib.dl.services.camel.BinaryEnhancementProcessor;
 import org.apache.camel.BeanInject;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.PropertyInject;
 import org.apache.camel.builder.RouteBuilder;
 
+import edu.unc.lib.dl.rdf.Cdr;
+import edu.unc.lib.dl.services.camel.BinaryEnhancementProcessor;
 import edu.unc.lib.dl.services.camel.BinaryMetadataProcessor;
 
 /**
@@ -56,50 +51,40 @@ public class EnhancementRouter extends RouteBuilder {
 
     @Override
     public void configure() throws Exception {
-        from("direct-vm:enhancements.fedora")
-            .routeId("QueueEnhancementsFromFedora")
-            .log(INFO, "Queuing enhancements from Fedora message for ${headers[CamelFcrepoUri]}")
-            .to("{{cdr.enhancement.stream.camel}}");
-
         from("{{cdr.enhancement.stream.camel}}")
             .routeId("ProcessEnhancementQueue")
-            .setHeader(CdrEnhancementSet, constant(DEFAULT_ENHANCEMENTS))
             .process(enProcessor)
-            .log(INFO, "Processing queued enhancements ${headers[CdrEnhancementSet]} for ${headers[CamelFcrepoUri]}")
+            .log(INFO, "Got ${headers[CamelFcrepoUri]}")
             .to("fcrepo:{{fcrepo.baseUrl}}?preferInclude=ServerManaged&accept=text/turtle")
-            .multicast()
-            .to("direct:process.binary", "direct:process.solr");
+            .choice()
+                // Process binary enhancement requests
+                .when(simple("${headers[org.fcrepo.jms.resourceType]} contains '" + Binary.getURI() + "'"))
+                    .log(DEBUG, "Processing binary ${headers[CamelFcrepoUri]}")
+                    .setHeader(CdrEnhancementSet, constant(DEFAULT_ENHANCEMENTS))
+                    .to("direct:process.binary")
+                // Process all other content object enhancement requests
+                .when(simple("${headers[org.fcrepo.jms.resourceType]} contains '"
+                        + Cdr.DepositRecord.getURI() + "'"))
+                    .log(DEBUG, "Ignoring update of ${headers[CamelFcrepoUri]}")
+                .otherwise()
+                    .log(DEBUG, "Processing enhancements for non-binary ${headers[CamelFcrepoUri]}")
+                    .to("direct-vm:solrIndexing")
+            .end();
 
         from("direct:process.binary")
             .routeId("ProcessOriginalBinary")
-            .filter(simple("${headers[CamelFcrepoUri]} ends with '/original_file'"
-                    + " && ${headers[org.fcrepo.jms.resourceType]} contains '" + Binary.getURI() + "'"))
+            .filter(simple("${headers[CamelFcrepoUri]} ends with '/original_file'"))
+            .log(INFO, "Processing queued enhancements ${headers[CdrEnhancementSet]} for ${headers[CamelFcrepoUri]}")
             .threads(enhancementThreads, enhancementThreads, "CdrEnhancementThread")
             .process(mdProcessor)
             .filter(header(CdrBinaryPath).isNotNull())
-            .to("direct:process.enhancements");
+            .multicast()
+            .to("direct:process.enhancements", "direct-vm:solrIndexing");
 
         from("direct:process.enhancements")
             .routeId("AddBinaryEnhancements")
             .split(simple("${headers[CdrEnhancementSet]}"))
                 .log(LoggingLevel.INFO, "Calling enhancement direct-vm:process.enhancement.${body}")
                 .toD("direct-vm:process.enhancement.${body}");
-
-        from("direct:process.solr")
-            .routeId("IngestSolrIndexing")
-            .log(LoggingLevel.INFO, "Requesting solr indexing of ${headers[CamelFcrepoUri]}"
-                    + " with types ${headers[org.fcrepo.jms.resourceType]}")
-            .filter(simple("${headers[org.fcrepo.jms.resourceType]} contains '" + Work.getURI() + "'"
-                    + " || ${headers[org.fcrepo.jms.resourceType]} contains '" + FileObject.getURI() + "'"
-                    + " || ${headers[org.fcrepo.jms.resourceType]} contains '" + Folder.getURI() + "'"
-                    + " || ${headers[org.fcrepo.jms.resourceType]} contains '" + Collection.getURI() + "'"
-                    + " || ${headers[org.fcrepo.jms.resourceType]} contains '" + AdminUnit.getURI() + "'"
-                    + " || ${headers[org.fcrepo.jms.resourceType]} contains '" + ContentRoot.getURI() + "'"
-                    ))
-            // Filter out descriptive md separately because camel simple filters don't support basic () operators
-            .filter(simple("${headers[org.fcrepo.jms.resourceType]} not contains '"
-                    + DescriptiveMetadata.getURI() + "'"))
-                .log(LoggingLevel.INFO, "Ingest solr indexing for ${headers[CamelFcrepoUri]}")
-                .to("direct-vm:solrIndexing");
     }
 }

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/enhancements/EnhancementRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/enhancements/EnhancementRouter.java
@@ -62,11 +62,13 @@ public class EnhancementRouter extends RouteBuilder {
                     .log(DEBUG, "Processing binary ${headers[CamelFcrepoUri]}")
                     .setHeader(CdrEnhancementSet, constant(DEFAULT_ENHANCEMENTS))
                     .to("direct:process.binary")
-                // Process all other content object enhancement requests
-                .when(simple("${headers[org.fcrepo.jms.resourceType]} contains '"
-                        + Cdr.DepositRecord.getURI() + "'"))
-                    .log(DEBUG, "Ignoring update of ${headers[CamelFcrepoUri]}")
-                .otherwise()
+                .when(simple("${headers[org.fcrepo.jms.resourceType]} contains '" + Cdr.Work.getURI() + "'"
+                        + " || ${headers[org.fcrepo.jms.resourceType]} contains '" + Cdr.FileObject.getURI() + "'"
+                        + " || ${headers[org.fcrepo.jms.resourceType]} contains '" + Cdr.Folder.getURI() + "'"
+                        + " || ${headers[org.fcrepo.jms.resourceType]} contains '" + Cdr.Collection.getURI() + "'"
+                        + " || ${headers[org.fcrepo.jms.resourceType]} contains '" + Cdr.AdminUnit.getURI() + "'"
+                        + " || ${headers[org.fcrepo.jms.resourceType]} contains '" + Cdr.ContentRoot.getURI() + "'"
+                        ))
                     .log(DEBUG, "Processing enhancements for non-binary ${headers[CamelFcrepoUri]}")
                     .to("direct-vm:solrIndexing")
             .end();

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/enhancements/EnhancementRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/enhancements/EnhancementRouter.java
@@ -54,7 +54,6 @@ public class EnhancementRouter extends RouteBuilder {
         from("{{cdr.enhancement.stream.camel}}")
             .routeId("ProcessEnhancementQueue")
             .process(enProcessor)
-            .log(INFO, "Got ${headers[CamelFcrepoUri]}")
             .to("fcrepo:{{fcrepo.baseUrl}}?preferInclude=ServerManaged&accept=text/turtle")
             .choice()
                 // Process binary enhancement requests

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/routing/MetaServicesRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/routing/MetaServicesRouter.java
@@ -49,6 +49,6 @@ public class MetaServicesRouter extends RouteBuilder {
                 .log("Performing enhancements for ${headers[org.fcrepo.jms.identifier]}")
                 .delay(simple("{{cdr.enhancement.postIndexingDelay}}"))
                 .removeHeaders("CamelHttp*")
-                .to("direct-vm:enhancements.fedora");
+                .to("{{cdr.enhancement.stream.camel}}");
     }
 }

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/solr/SolrIngestProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/solr/SolrIngestProcessor.java
@@ -16,6 +16,7 @@
 
 package edu.unc.lib.dl.services.camel.solr;
 
+import static edu.unc.lib.dl.services.camel.util.CdrFcrepoHeaders.FCREPO_RESOURCE_TYPE;
 import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
 
 import java.util.concurrent.TimeUnit;
@@ -31,6 +32,9 @@ import edu.unc.lib.dl.data.ingest.solr.indexing.DocumentIndexingPackage;
 import edu.unc.lib.dl.data.ingest.solr.indexing.DocumentIndexingPackageFactory;
 import edu.unc.lib.dl.data.ingest.solr.indexing.DocumentIndexingPipeline;
 import edu.unc.lib.dl.data.ingest.solr.indexing.SolrUpdateDriver;
+import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.rdf.Fcrepo4Repository;
 import edu.unc.lib.dl.util.IndexingActionType;
 
 /**
@@ -60,15 +64,24 @@ public class SolrIngestProcessor implements Processor {
     @Override
     public void process(Exchange exchange) throws Exception {
         final Message in = exchange.getIn();
-        String fcrepoBinaryUri = (String) in.getHeader(FCREPO_URI);
+        String fcrepoUri = (String) in.getHeader(FCREPO_URI);
+
+        PID targetPid = PIDs.get(fcrepoUri);
+        String resourceTypes = (String) in.getHeader(FCREPO_RESOURCE_TYPE);
+
+        // for binaries, need to index the file object which contains it
+        if (resourceTypes != null && resourceTypes.contains(Fcrepo4Repository.Binary.getURI())) {
+            targetPid = PIDs.get(targetPid.getId());
+        }
 
         int retryAttempt = 0;
 
         while (true) {
             try {
-                SolrUpdateRequest updateRequest = new SolrUpdateRequest(fcrepoBinaryUri, IndexingActionType.ADD);
+                SolrUpdateRequest updateRequest = new SolrUpdateRequest(
+                        targetPid.getRepositoryPath(), IndexingActionType.ADD);
 
-                DocumentIndexingPackage dip = factory.createDip(updateRequest.getPid());
+                DocumentIndexingPackage dip = factory.createDip(targetPid);
                 updateRequest.setDocumentIndexingPackage(dip);
 
                 pipeline.process(dip);
@@ -82,7 +95,7 @@ public class SolrIngestProcessor implements Processor {
 
                 retryAttempt++;
                 log.info("Unable to update solr for {}. Retrying, attempt {}",
-                        fcrepoBinaryUri, retryAttempt);
+                        fcrepoUri, retryAttempt);
                 TimeUnit.MILLISECONDS.sleep(retryDelay);
             }
         }

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/solr/SolrRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/solr/SolrRouter.java
@@ -20,6 +20,8 @@ import org.apache.camel.BeanInject;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.builder.RouteBuilder;
 
+import edu.unc.lib.dl.fedora.NotFoundException;
+
 /**
  * Router which triggers the full indexing of individual objects to Solr.
  *
@@ -32,6 +34,12 @@ public class SolrRouter extends RouteBuilder {
 
     @Override
     public void configure() throws Exception {
+        onException(NotFoundException.class)
+        .redeliveryDelay("{{cdr.enhancement.solr.error.retryDelay:500}}")
+        .maximumRedeliveries("{{cdr.enhancement.solr.error.maxRedeliveries:10}}")
+        .backOffMultiplier("{{cdr.enhancement.solr.error.backOffMultiplier:2}}")
+        .retryAttemptedLogLevel(LoggingLevel.DEBUG);
+
         onException(Exception.class)
             .redeliveryDelay("{{error.retryDelay}}")
             .maximumRedeliveries("{{error.maxRedeliveries}}")

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/solrUpdate/SolrUpdateRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/solrUpdate/SolrUpdateRouter.java
@@ -21,6 +21,8 @@ import org.apache.camel.BeanInject;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.builder.RouteBuilder;
 
+import edu.unc.lib.dl.fedora.NotFoundException;
+
 /**
  * Route for performing solr updates for update requests.
  *
@@ -33,6 +35,12 @@ public class SolrUpdateRouter extends RouteBuilder {
 
     @Override
     public void configure() throws Exception {
+        onException(NotFoundException.class)
+        .redeliveryDelay("{{cdr.enhancement.solr.error.retryDelay:500}}")
+        .maximumRedeliveries("{{cdr.enhancement.solr.error.maxRedeliveries:10}}")
+        .backOffMultiplier("{{cdr.enhancement.solr.error.backOffMultiplier:2}}")
+        .retryAttemptedLogLevel(LoggingLevel.DEBUG);
+
         onException(Exception.class)
         .redeliveryDelay("{{error.retryDelay}}")
         .maximumRedeliveries("{{error.maxRedeliveries}}")

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/util/CdrFcrepoHeaders.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/util/CdrFcrepoHeaders.java
@@ -36,4 +36,6 @@ public abstract class CdrFcrepoHeaders {
     public static final String CdrUpdateAction = "CdrUpdateAction";
 
     public static final String CdrEnhancementSet = "CdrEnhancementSet";
+
+    public static final String FCREPO_RESOURCE_TYPE = "org.fcrepo.jms.resourceType";
 }

--- a/services-camel/src/main/webapp/WEB-INF/solr-indexing-context.xml
+++ b/services-camel/src/main/webapp/WEB-INF/solr-indexing-context.xml
@@ -390,8 +390,7 @@
         <constructor-arg ref="dipFactory" />
         <constructor-arg ref="solrFullUpdatePipeline" />
         <constructor-arg ref="solrUpdateDriver" />
-        <constructor-arg value="${error.maxRedeliveries}" />
-        <constructor-arg value="${error.retryDelay}" />
+        <constructor-arg ref="repositoryObjectLoader" />
     </bean>
     
     <bean id="cdrEventToSolrUpdateProcessor" class="edu.unc.lib.dl.services.camel.solr.CdrEventToSolrUpdateProcessor">

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/BinaryEnhancementProcessorTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/BinaryEnhancementProcessorTest.java
@@ -15,7 +15,15 @@
  */
 package edu.unc.lib.dl.services.camel;
 
-import edu.unc.lib.dl.test.TestHelper;
+import static edu.unc.lib.dl.rdf.Fcrepo4Repository.Binary;
+import static edu.unc.lib.dl.services.camel.util.CdrFcrepoHeaders.FCREPO_RESOURCE_TYPE;
+import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.ATOM_NS;
+import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.jdom2.Document;
@@ -26,14 +34,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mock;
 
-import static edu.unc.lib.dl.rdf.Fcrepo4Repository.Binary;
-import static edu.unc.lib.dl.services.camel.util.CdrFcrepoHeaders.CdrBinaryMimeType;
-import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.ATOM_NS;
-import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
+import edu.unc.lib.dl.test.TestHelper;
 
 /**
  *
@@ -76,8 +77,7 @@ public class BinaryEnhancementProcessorTest {
         processor.process(exchange);
 
         verify(message).setHeader(FCREPO_URI, RESC_URI);
-        verify(message).setHeader(CdrBinaryMimeType, "text/plain");
-        verify(message).setHeader("org.fcrepo.jms.resourceType", Binary.getURI());
+        verify(message).setHeader(FCREPO_RESOURCE_TYPE, Binary.getURI());
     }
 
     @Test
@@ -87,8 +87,7 @@ public class BinaryEnhancementProcessorTest {
         processor.process(exchange);
 
         verify(message).setHeader(FCREPO_URI, RESC_URI);
-        verify(message).setHeader(CdrBinaryMimeType, "image/png");
-        verify(message).setHeader("org.fcrepo.jms.resourceType", Binary.getURI());
+        verify(message).setHeader(FCREPO_RESOURCE_TYPE, Binary.getURI());
     }
 
     @Test
@@ -99,8 +98,7 @@ public class BinaryEnhancementProcessorTest {
         processor.process(exchange);
 
         verify(message, never()).setHeader(FCREPO_URI, RESC_URI);
-        verify(message, never()).setHeader(CdrBinaryMimeType, "image/png");
-        verify(message, never()).setHeader("org.fcrepo.jms.resourceType", Binary.getURI());
+        verify(message, never()).setHeader(FCREPO_RESOURCE_TYPE, Binary.getURI());
     }
 
     private void setMessageBody(String mimeType) {

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/routing/MetaServicesRouterTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/routing/MetaServicesRouterTest.java
@@ -77,7 +77,7 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
 
     @Test
     public void testEventTypeFilter() throws Exception {
-        getMockEndpoint("mock:direct:process.binary").expectedMessageCount(0);
+        getMockEndpoint("mock:{{cdr.enhancement.stream.camel}}").expectedMessageCount(0);
         getMockEndpoint("mock:direct:process.solr").expectedMessageCount(0);
 
         createContext(PROCESS_ENHANCEMENT_ROUTE);
@@ -92,7 +92,7 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
 
     @Test
     public void testEventTypeFilterValid() throws Exception {
-        getMockEndpoint("mock:direct-vm:enhancements.fedora").expectedMessageCount(1);
+        getMockEndpoint("mock:{{cdr.enhancement.stream.camel}}").expectedMessageCount(1);
 
         createContext(PROCESS_ENHANCEMENT_ROUTE);
         Map<String, Object> headers = createEvent(FILE_ID, Binary.getURI());

--- a/services-camel/src/test/resources/config.properties
+++ b/services-camel/src/test/resources/config.properties
@@ -51,6 +51,9 @@ cdr.triplesupdate.stream.camel=direct-vm:index.start
 cdr.destroy.stream=direct-vm:index.start
 cdr.destroy.stream.camel=direct-vm:index.start
 
+cdr.enhancement.stream=direct-vm:repository.enhancements
+cdr.enhancement.stream.camel=direct-vm:repository.enhancements
+
 # The camel URI for handling reindexing events.
 triplestore.reindex.stream=activemq:queue:triplestore.reindex
 reindexing.stream=activemq:queue:reindexing

--- a/services-camel/src/test/resources/metaservices-context.xml
+++ b/services-camel/src/test/resources/metaservices-context.xml
@@ -13,6 +13,14 @@
         http://camel.apache.org/schema/spring
         http://camel.apache.org/schema/spring/camel-spring.xsd">
     
+    <bean id="properties" class="org.apache.camel.component.properties.PropertiesComponent">
+        <property name="location" value="classpath:config.properties"/>
+    </bean>
+    
+    <bean id="bridgePropertyPlaceholder" class="org.apache.camel.spring.spi.BridgePropertyPlaceholderConfigurer">
+        <property name="location" value="classpath:config.properties"/>
+    </bean>
+    
     <bean id="binaryMetadataProcessor" class="org.mockito.Mockito" factory-method="mock">
         <constructor-arg value="edu.unc.lib.dl.services.camel.BinaryMetadataProcessor" />
     </bean>

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/processing/RunEnhancementsService.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/processing/RunEnhancementsService.java
@@ -16,13 +16,11 @@
 package edu.unc.lib.dl.cdr.services.processing;
 
 import static edu.unc.lib.dl.model.DatastreamType.ORIGINAL_FILE;
-import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.ATOM_NS;
-import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.CDR_MESSAGE_NS;
+import static edu.unc.lib.dl.services.RunEnhancementsMessageHelpers.makeEnhancementOperationBody;
 
 import java.util.List;
 
 import org.jdom2.Document;
-import org.jdom2.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -116,25 +114,9 @@ public class RunEnhancementsService {
             return;
         }
 
-        String filePath = DatastreamPids.getOriginalFilePid(pid).toString();
-        Document msg = makeEnhancementOperationBody(username, filePath, force);
+        PID originalPid = DatastreamPids.getOriginalFilePid(pid);
+        Document msg = makeEnhancementOperationBody(username, originalPid, force);
         messageSender.sendMessage(msg);
-    }
-
-    private Document makeEnhancementOperationBody(String userid, String filePath, Boolean force) {
-        Document msg = new Document();
-        Element entry = new Element("entry", ATOM_NS);
-        entry.addContent(new Element("author", ATOM_NS)
-                .addContent(new Element("name", ATOM_NS).setText(userid)));
-        entry.addContent(new Element("pid", ATOM_NS).setText(filePath));
-
-        if (force) {
-            Element paramForce = new Element("force", CDR_MESSAGE_NS);
-            paramForce.setText("true");
-        }
-        msg.addContent(entry);
-
-        return msg;
     }
 
     public void setRepositoryObjectLoader(RepositoryObjectLoader repositoryObjectLoader) {

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/processing/RunEnhancementsService.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/processing/RunEnhancementsService.java
@@ -117,18 +117,16 @@ public class RunEnhancementsService {
         }
 
         String filePath = DatastreamPids.getOriginalFilePid(pid).toString();
-        Document msg = makeEnhancementOperationBody(username,
-                filePath, originalDs.getMimetype(), force);
+        Document msg = makeEnhancementOperationBody(username, filePath, force);
         messageSender.sendMessage(msg);
     }
 
-    private Document makeEnhancementOperationBody(String userid, String filePath, String mimeType, Boolean force) {
+    private Document makeEnhancementOperationBody(String userid, String filePath, Boolean force) {
         Document msg = new Document();
         Element entry = new Element("entry", ATOM_NS);
         entry.addContent(new Element("author", ATOM_NS)
                 .addContent(new Element("name", ATOM_NS).setText(userid)));
         entry.addContent(new Element("pid", ATOM_NS).setText(filePath));
-        entry.addContent(new Element("mimeType", ATOM_NS).setText(mimeType));
 
         if (force) {
             Element paramForce = new Element("force", CDR_MESSAGE_NS);

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/RunEnhancementsIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/RunEnhancementsIT.java
@@ -136,7 +136,7 @@ public class RunEnhancementsIT extends AbstractAPIIT {
 
         verify(messageSender).sendMessage(docCaptor.capture());
         Document msgDoc = docCaptor.getValue();
-        assertMessageValues(msgDoc, fileObj.getOriginalFile().getPid(), "image/png");
+        assertMessageValues(msgDoc, fileObj.getOriginalFile().getPid(), USER_NAME);
     }
 
     @Test
@@ -158,7 +158,7 @@ public class RunEnhancementsIT extends AbstractAPIIT {
 
         verify(messageSender).sendMessage(docCaptor.capture());
         Document msgDoc = docCaptor.getValue();
-        assertMessageValues(msgDoc, fileObj.getOriginalFile().getPid(), "image/png");
+        assertMessageValues(msgDoc, fileObj.getOriginalFile().getPid(), USER_NAME);
     }
 
     @Test
@@ -203,12 +203,13 @@ public class RunEnhancementsIT extends AbstractAPIIT {
         when(queryLayer.getObjectById(any(SimpleIdRequest.class))).thenReturn(md);
     }
 
-    private void assertMessageValues(Document msgDoc, PID expectedPid, String expectedType) {
+    private void assertMessageValues(Document msgDoc, PID expectedPid, String expectedAuthor) {
         Element entry = msgDoc.getRootElement();
         String pidString = entry.getChildText("pid", ATOM_NS);
-        String mimetype = entry.getChildText("mimeType", ATOM_NS);
+        String author = entry.getChild("author", ATOM_NS)
+                             .getChildText("name", ATOM_NS);
 
         assertEquals(expectedPid, PIDs.get(pidString));
-        assertEquals(expectedType, mimetype);
+        assertEquals(expectedAuthor, author);
     }
 }


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2606

* Improves handling of NotFoundExceptions during solr indexing, particular of newly ingested objects after running enhancements
* Should resolve issues where derivatives were not showing up for works, but were for the file where the derivatives came from
* Relies on enhancement pipeline to set mimetype header rather than receiving from run enhancements service
* Removes no longer needed intermediate route bridging fedora to enhancement queue