### PR TITLE
BXC-2624 - Fix deposit cleanup failures

### DIFF
--- a/deposit/src/main/java/edu/unc/lib/deposit/CleanupDepositJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/CleanupDepositJob.java
@@ -74,7 +74,7 @@ public class CleanupDepositJob extends AbstractDepositJob {
             Files.delete(cFile.toPath());
             LOG.info("Deleted file: {}", cFile.getAbsoluteFile());
         } catch (NoSuchFileException e) {
-            LOG.warn("Cannot cleanup file {}, it does not exist", uri);
+            LOG.debug("Cannot cleanup file {}, it does not exist", uri);
         } catch (IOException e) {
             LOG.error("Cannot delete a staged file: " + uri.toString(), e);
         }

--- a/deposit/src/main/java/edu/unc/lib/deposit/validate/ValidateFileAvailabilityJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/validate/ValidateFileAvailabilityJob.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import edu.unc.lib.deposit.work.AbstractDepositJob;
 import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.persist.api.ingest.IngestSource;
 import edu.unc.lib.dl.persist.api.ingest.IngestSourceManager;
 import edu.unc.lib.dl.persist.api.ingest.UnknownIngestSourceException;
 import edu.unc.lib.dl.rdf.CdrDeposit;
@@ -73,9 +74,13 @@ public class ValidateFileAvailabilityJob extends AbstractDepositJob {
             try {
                 URI manifestURI = URI.create(entry.getValue());
                 // If no ingest source can be found for the file, then file not available
-                sourceManager.getIngestSourceForUri(manifestURI);
+                IngestSource source = sourceManager.getIngestSourceForUri(manifestURI);
+                if (!source.exists(manifestURI)) {
+                    log.debug("Failed find staged file {} in deposit {}", href, getDepositUUID());
+                    badlyStagedFiles.add(href);
+                }
             } catch (UnknownIngestSourceException e) {
-                log.debug("Failed find staged file {} in deposit {}", href, getDepositUUID(), e);
+                log.debug("Could not determine staging location for {} in deposit {}", href, getDepositUUID(), e);
                 badlyStagedFiles.add(href);
             }
 

--- a/deposit/src/test/java/edu/unc/lib/deposit/CleanupDepositJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/CleanupDepositJobTest.java
@@ -31,6 +31,8 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.io.File;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -199,6 +201,21 @@ public class CleanupDepositJobTest extends AbstractDepositJobTest {
         job.run();
 
         // Mainly ensuring that no error occurs when there is nothing to delete
+        assertDepositCleanedUp();
+    }
+
+    @Test
+    public void cleanupFileAlreadyRemovedTest() throws Exception {
+        addIngestedFilesToModel();
+        Files.delete(Paths.get(stagingPath, "project/folderA/ingested"));
+
+        when(ingestSource.isReadOnly()).thenReturn(false);
+        when(sourceManager.getIngestSourceForUri(any(URI.class))).thenReturn(ingestSource);
+
+        job.run();
+
+        assertIngestedFilesEmptyFoldersDeleted(stagingFolder);
+
         assertDepositCleanedUp();
     }
 

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/persist/api/ingest/IngestSource.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/persist/api/ingest/IngestSource.java
@@ -87,6 +87,14 @@ public interface IngestSource {
     boolean isValidUri(URI uri);
 
     /**
+     * Returns true if the provided URI exists within this ingest source
+     *
+     * @param uri
+     * @return
+     */
+    boolean exists(URI uri);
+
+    /**
      * List the potential candidates for ingest from this source location.
      *
      * @return

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/ingest/FilesystemIngestSource.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/ingest/FilesystemIngestSource.java
@@ -149,11 +149,21 @@ public class FilesystemIngestSource implements IngestSource {
         for (String pattern : patterns) {
             PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + baseString + "/" + pattern + "*");
             if (matcher.matches(path)) {
-                return path.toFile().exists();
+                return true;
             }
         }
 
         return false;
+    }
+
+    @Override
+    public boolean exists(URI uri) {
+        Path path = Paths.get(uri).normalize();
+        if (!path.startsWith(basePath)) {
+            return false;
+        }
+
+        return Files.exists(path);
     }
 
     @Override
@@ -249,7 +259,7 @@ public class FilesystemIngestSource implements IngestSource {
     public URI resolveRelativePath(String relative) {
         Path candidatePath = basePath.resolve(relative).normalize();
 
-        if (!isValidPath(candidatePath)) {
+        if (!isValidPath(candidatePath) || Files.notExists(candidatePath)) {
             throw new InvalidIngestSourceCandidateException("Invalid ingest source path " + relative);
         }
 

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/ingest/IngestSourceTestHelper.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/ingest/IngestSourceTestHelper.java
@@ -48,14 +48,16 @@ public class IngestSourceTestHelper {
     private IngestSourceTestHelper() {
     }
 
-    public static void addBagToSource(Path ingestSourcePath) throws Exception {
+    public static Path addBagToSource(Path ingestSourcePath) throws Exception {
         String bagName = "bag_with_files";
-        addBagToSource(ingestSourcePath, bagName, bagName);
+        return addBagToSource(ingestSourcePath, bagName, bagName);
     }
 
-    public static void addBagToSource(Path ingestSourcePath, String bagName, String destName) throws Exception {
+    public static Path addBagToSource(Path ingestSourcePath, String bagName, String destName) throws Exception {
         File original = new File("src/test/resources/ingestSources/" + bagName);
-        FileUtils.copyDirectory(original, ingestSourcePath.resolve(destName).toFile());
+        Path bagPath = ingestSourcePath.resolve(destName);
+        FileUtils.copyDirectory(original, bagPath.toFile());
+        return bagPath;
     }
 
     public static IngestSourceCandidate findCandidateByPath(String patternMatched,


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2624

* Resolves failures in the deposit cleanup job when a file record in a deposit does not exist, which is the result of the file having been moved during the transfer.
* Splits checking if a file exists within an ingest source out from checking if a uri is valid within that source. This is what caused the cleanup jobs to fail.
* Adds related testing.