### PR TITLE
BXC3 - Exception handler fix

### DIFF
--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/TripleStoreMonitorRestController.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/TripleStoreMonitorRestController.java
@@ -94,7 +94,7 @@ public class TripleStoreMonitorRestController implements ServletContextAware {
 		}
 	}
 	
-	@ExceptionHandler()
+	@ExceptionHandler(MulgaraDown.class)
 	@ResponseStatus(value=HttpStatus.INTERNAL_SERVER_ERROR,reason="Mulgara is down")
 	public void mulgaraDown() { }
 	


### PR DESCRIPTION
Was throwing a configuration error when mulgara was down since the `@ExceptionHandler` requires parameter.