### PR TITLE
BXC-2647 - Fix move operation

### DIFF
--- a/access/src/main/webapp/WEB-INF/access-fedora-context.xml
+++ b/access/src/main/webapp/WEB-INF/access-fedora-context.xml
@@ -65,7 +65,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="${cache.contentPath.maxSize}" />
         <property name="cacheTimeToLive" value="${cache.contentPath.timeToLive}" />
-        <property name="queryService" ref="sparqlQueryService" />
+        <property name="fcrepoClient" ref="fcrepoClient" />
     </bean>
     
     <bean id="objectAclFactory" class="edu.unc.lib.dl.acl.fcrepo4.ObjectAclFactory"

--- a/admin/src/main/webapp/WEB-INF/access-fedora-context.xml
+++ b/admin/src/main/webapp/WEB-INF/access-fedora-context.xml
@@ -49,7 +49,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="${cache.contentPath.maxSize}" />
         <property name="cacheTimeToLive" value="${cache.contentPath.timeToLive}" />
-        <property name="queryService" ref="sparqlQueryService" />
+        <property name="fcrepoClient" ref="fcrepoClient" />
     </bean>
     
     <bean id="objectAclFactory" class="edu.unc.lib.dl.acl.fcrepo4.ObjectAclFactory"

--- a/deposit/src/main/webapp/WEB-INF/service-context.xml
+++ b/deposit/src/main/webapp/WEB-INF/service-context.xml
@@ -186,7 +186,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="${cache.contentPath.maxSize}" />
         <property name="cacheTimeToLive" value="${cache.contentPath.timeToLive}" />
-        <property name="queryService" ref="sparqlQueryService" />
+        <property name="fcrepoClient" ref="fcrepoClient" />
     </bean>
     
     <bean id="objectAclFactory" class="edu.unc.lib.dl.acl.fcrepo4.ObjectAclFactory"

--- a/deposit/src/test/resources/spring-test/cdr-client-container.xml
+++ b/deposit/src/test/resources/spring-test/cdr-client-container.xml
@@ -78,7 +78,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="100" />
         <property name="cacheTimeToLive" value="100" />
-        <property name="queryService" ref="sparqlQueryService" />
+        <property name="fcrepoClient" ref="fcrepoClient" />
     </bean>
     
     <bean id="objectAclFactory" class="edu.unc.lib.dl.acl.fcrepo4.ObjectAclFactory"

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/ContentPathFactory.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/ContentPathFactory.java
@@ -15,6 +15,8 @@
  */
 package edu.unc.lib.dl.fedora;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -27,6 +29,7 @@ import org.apache.jena.rdf.model.Statement;
 import org.fcrepo.client.FcrepoClient;
 import org.fcrepo.client.FcrepoOperationFailedException;
 import org.fcrepo.client.FcrepoResponse;
+import org.slf4j.Logger;
 
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -49,6 +52,7 @@ import edu.unc.lib.dl.util.RDFModelUtil;
  *
  */
 public class ContentPathFactory {
+    private static final Logger log = getLogger(ContentPathFactory.class);
 
     private static int MAX_NESTING = 256;
 
@@ -131,7 +135,9 @@ public class ContentPathFactory {
                 if (memberStmt == null) {
                     throw new OrphanedObjectException("Object " + pid + " is not the member of any object");
                 }
-                return PIDs.get(memberStmt.getResource().getURI());
+                PID parentPid = PIDs.get(memberStmt.getResource().getURI());
+                log.debug("Loaded child to parent relation to cache for {} => {}", pid.getId(), parentPid.getId());
+                return parentPid;
             } catch (FcrepoOperationFailedException e) {
                 throw ClientFaultResolver.resolve(e);
             } catch (IOException e) {

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/fedora/ContentPathFactoryIT.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/fedora/ContentPathFactoryIT.java
@@ -70,8 +70,6 @@ public class ContentPathFactoryIT extends AbstractFedoraIT {
 
     @Test
     public void testGetAncestorPids() throws Exception {
-        treeIndexer.indexAll(baseAddress);
-
         List<PID> ancestors = pathFactory.getAncestorPids(collObj.getPid());
 
         assertEquals("Incorrect number of ancestors", 2, ancestors.size());
@@ -82,8 +80,6 @@ public class ContentPathFactoryIT extends AbstractFedoraIT {
     @Test(expected = NotFoundException.class)
     public void testObjectNotFound() throws Exception {
         PID pid = pidMinter.mintContentPid();
-
-        treeIndexer.indexAll(baseAddress);
 
         pathFactory.getAncestorPids(pid);
     }
@@ -96,8 +92,6 @@ public class ContentPathFactoryIT extends AbstractFedoraIT {
         Path contentPath = Files.createTempFile("test", ".txt");
         FileObject fileObj = work.addDataFile(contentPath.toUri(), "file", "text/plain", null, null);
         BinaryObject binObj = fileObj.getOriginalFile();
-
-        treeIndexer.indexAll(baseAddress);
 
         List<PID> ancestors = pathFactory.getAncestorPids(binObj.getPid());
 
@@ -124,8 +118,6 @@ public class ContentPathFactoryIT extends AbstractFedoraIT {
         contentRoot.addMember(adminUnit2);
 
         adminUnit2.addMember(collObj);
-
-        treeIndexer.indexAll(baseAddress);
 
         // Wait for cache to expire and then check that the new path is retrieved
         TimeUnit.MILLISECONDS.sleep(200);

--- a/fcrepo-clients/src/test/resources/spring-test/cdr-client-container.xml
+++ b/fcrepo-clients/src/test/resources/spring-test/cdr-client-container.xml
@@ -87,7 +87,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="100" />
         <property name="cacheTimeToLive" value="100" />
-        <property name="queryService" ref="sparqlQueryService" />
+        <property name="fcrepoClient" ref="fcrepoClient" />
     </bean>
     
     <bean id="txManager" class="edu.unc.lib.dl.fcrepo4.TransactionManager">

--- a/metadata/src/main/java/edu/unc/lib/dl/exceptions/ObjectHierarchyException.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/exceptions/ObjectHierarchyException.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.exceptions;
+
+/**
+ * Exception indicating that an invalid membership hierarchy was encountered
+ *
+ * @author bbpennel
+ */
+public class ObjectHierarchyException extends RepositoryException {
+    private static final long serialVersionUID = 1L;
+
+    public ObjectHierarchyException(String message) {
+        super(message);
+    }
+
+    public ObjectHierarchyException(Throwable ex) {
+        super(ex);
+    }
+
+    public ObjectHierarchyException(String message, Throwable ex) {
+        super(message, ex);
+    }
+}

--- a/migration-util/src/main/resources/spring/service-context.xml
+++ b/migration-util/src/main/resources/spring/service-context.xml
@@ -111,7 +111,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="100" />
         <property name="cacheTimeToLive" value="100" />
-        <property name="queryService" ref="sparqlQueryService" />
+        <property name="fcrepoClient" ref="fcrepoClient" />
     </bean>
     
     <bean id="txManager" class="edu.unc.lib.dl.fcrepo4.TransactionManager">

--- a/migration-util/src/test/resources/spring-test/cdr-client-container.xml
+++ b/migration-util/src/test/resources/spring-test/cdr-client-container.xml
@@ -104,7 +104,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="100" />
         <property name="cacheTimeToLive" value="100" />
-        <property name="queryService" ref="sparqlQueryService" />
+        <property name="fcrepoClient" ref="fcrepoClient" />
     </bean>
     
     <bean id="txManager" class="edu.unc.lib.dl.fcrepo4.TransactionManager">

--- a/persistence/src/test/resources/spring-test/acl-service-context.xml
+++ b/persistence/src/test/resources/spring-test/acl-service-context.xml
@@ -33,7 +33,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="0" />
         <property name="cacheTimeToLive" value="0" />
-        <property name="queryService" ref="sparqlQueryService" />
+        <property name="fcrepoClient" ref="fcrepoClient" />
     </bean>
     
     <bean id="inheritedPermissionEvaluator" class="edu.unc.lib.dl.acl.fcrepo4.InheritedPermissionEvaluator">

--- a/persistence/src/test/resources/spring-test/staff-role-service-container.xml
+++ b/persistence/src/test/resources/spring-test/staff-role-service-container.xml
@@ -10,7 +10,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="200" />
         <property name="cacheTimeToLive" value="2000" />
-        <property name="queryService" ref="sparqlQueryService" />
+        <property name="fcrepoClient" ref="fcrepoClient" />
     </bean>
     
     <bean id="objectAclFactory" class="edu.unc.lib.dl.acl.fcrepo4.ObjectAclFactory"

--- a/services-camel/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel/src/main/webapp/WEB-INF/service-context.xml
@@ -93,7 +93,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="${cache.contentPath.maxSize}" />
         <property name="cacheTimeToLive" value="${cache.contentPath.timeToLive}" />
-        <property name="queryService" ref="sparqlQueryService" />
+        <property name="fcrepoClient" ref="fcrepoClient" />
     </bean>
     
     <bean id="objectAclFactory" class="edu.unc.lib.dl.acl.fcrepo4.ObjectAclFactory"

--- a/services-camel/src/main/webapp/WEB-INF/solr-indexing-context.xml
+++ b/services-camel/src/main/webapp/WEB-INF/solr-indexing-context.xml
@@ -371,6 +371,7 @@
         <entry key="UPDATE_ACCESS" value-ref="updateAccessControlAction" />
         <entry key="UPDATE_ACCESS_TREE" value-ref="updateAccessTreeAction" />
         <entry key="MOVE" value-ref="moveObjectsAction" />
+        <entry key="UPDATE_PATH" value-ref="updatePathAction" />
         <entry key="ADD_SET_TO_PARENT" value-ref="addSetToParentAction" />
         <entry key="UPDATE_TYPE" value-ref="updateTypeAction" />
         <entry key="UPDATE_TYPE_TREE" value-ref="updateTypeTreeAction" />

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solr/AbstractSolrProcessorIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solr/AbstractSolrProcessorIT.java
@@ -16,6 +16,7 @@
 package edu.unc.lib.dl.services.camel.solr;
 
 import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.AUTHENTICATED_PRINC;
+import static edu.unc.lib.dl.fcrepo4.RepositoryPaths.getContentRootPid;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
 import static org.mockito.Matchers.eq;
@@ -101,9 +102,11 @@ public abstract class AbstractSolrProcessorIT {
     protected Message message;
 
     protected void generateBaseStructure() throws Exception {
-        PID rootPid = pidMinter.mintContentPid();
-        repositoryObjectFactory.createContentRootObject(rootPid.getRepositoryUri(), null);
-        rootObj = repositoryObjectLoader.getContentRootObject(rootPid);
+        URI contentRootUri = getContentRootPid().getRepositoryUri();
+        if (!repositoryObjectFactory.objectExists(contentRootUri)) {
+            repositoryObjectFactory.createContentRootObject(contentRootUri, null);
+        }
+        rootObj = repositoryObjectLoader.getContentRootObject(getContentRootPid());
 
         PID unitPid = pidMinter.mintContentPid();
         Model unitModel = ModelFactory.createDefaultModel();

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solrUpdate/SolrUpdateProcessorIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solrUpdate/SolrUpdateProcessorIT.java
@@ -117,7 +117,7 @@ public class SolrUpdateProcessorIT extends AbstractSolrProcessorIT {
 
         processor.process(exchange);
 
-        assertTrue(notify.matches(3l, TimeUnit.SECONDS));
+        assertTrue(notify.matches(6l, TimeUnit.SECONDS));
 
         server.commit();
 
@@ -242,12 +242,19 @@ public class SolrUpdateProcessorIT extends AbstractSolrProcessorIT {
         makeIndexingMessage(rootObj, null, RECURSIVE_ADD);
         processor.process(exchange);
 
-        notify.matches(3l, TimeUnit.SECONDS);
+        notify.matches(5l, TimeUnit.SECONDS);
 
         server.commit();
 
+        NotifyBuilder notifyDel = new NotifyBuilder(cdrServiceSolrUpdate)
+                .whenCompleted(1)
+                .create();
+
         makeIndexingMessage(unitObj, null, DELETE_SOLR_TREE);
         processor.process(exchange);
+
+        notifyDel.matches(5l, TimeUnit.SECONDS);
+
         server.commit();
 
         assertNotNull("Root must still be present", getSolrMetadata(rootObj));

--- a/services-camel/src/test/resources/solr-indexing-it-context.xml
+++ b/services-camel/src/test/resources/solr-indexing-it-context.xml
@@ -28,7 +28,7 @@
     <bean id="contentPathFactory" class="edu.unc.lib.dl.fedora.ContentPathFactory"
             init-method="init">
         <property name="cacheMaxSize" value="100" />
-        <property name="cacheTimeToLive" value="100" />
+        <property name="cacheTimeToLive" value="1000" />
         <property name="fcrepoClient" ref="fcrepoClient" />
     </bean>
     

--- a/services-camel/src/test/resources/solr-indexing-it-context.xml
+++ b/services-camel/src/test/resources/solr-indexing-it-context.xml
@@ -29,7 +29,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="100" />
         <property name="cacheTimeToLive" value="100" />
-        <property name="queryService" ref="sparqlQueryService" />
+        <property name="fcrepoClient" ref="fcrepoClient" />
     </bean>
     
     <bean id="objectAclFactory" class="edu.unc.lib.dl.acl.fcrepo4.ObjectAclFactory"

--- a/services/src/main/webapp/WEB-INF/access-fedora-context.xml
+++ b/services/src/main/webapp/WEB-INF/access-fedora-context.xml
@@ -21,7 +21,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="${cache.contentPath.maxSize}" />
         <property name="cacheTimeToLive" value="${cache.contentPath.timeToLive}" />
-        <property name="queryService" ref="sparqlQueryService" />
+        <property name="fcrepoClient" ref="fcrepoClient" />
     </bean>
     
     <bean id="objectAclFactory" class="edu.unc.lib.dl.acl.fcrepo4.ObjectAclFactory"

--- a/services/src/test/resources/edit-title-it-servlet.xml
+++ b/services/src/test/resources/edit-title-it-servlet.xml
@@ -43,6 +43,6 @@
           init-method="init">
         <property name="cacheMaxSize" value="0" />
         <property name="cacheTimeToLive" value="2000" />
-        <property name="queryService" ref="sparqlQueryService" />
+        <property name="fcrepoClient" ref="fcrepoClient" />
     </bean>
 </beans>

--- a/services/src/test/resources/spring-test/acl-service-context.xml
+++ b/services/src/test/resources/spring-test/acl-service-context.xml
@@ -33,7 +33,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="0" />
         <property name="cacheTimeToLive" value="0" />
-        <property name="queryService" ref="sparqlQueryService" />
+        <property name="fcrepoClient" ref="fcrepoClient" />
     </bean>
     
     <bean id="inheritedPermissionEvaluator" class="edu.unc.lib.dl.acl.fcrepo4.InheritedPermissionEvaluator">

--- a/services/src/test/resources/update-staff-it-servlet.xml
+++ b/services/src/test/resources/update-staff-it-servlet.xml
@@ -50,7 +50,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="200" />
         <property name="cacheTimeToLive" value="200" />
-        <property name="queryService" ref="sparqlQueryService" />
+        <property name="fcrepoClient" ref="fcrepoClient" />
     </bean>
     
     <bean id="objectAclFactory" class="edu.unc.lib.dl.acl.fcrepo4.ObjectAclFactory"

--- a/static/js/admin/src/action/MoveObjectsAction.js
+++ b/static/js/admin/src/action/MoveObjectsAction.js
@@ -32,10 +32,10 @@ define('MoveObjectsAction', ['jquery'], function($) {
 					+ " object" + (action.context.targets.length > 1? "s" : "") 
 					+ " to " + destTitle);
 			
-			action.context.targets.forEach(moved => {
+			$.each(action.context.targets, function() {
 				action.context.actionHandler.addEvent({
 					action : 'RefreshResult',
-					target : moved,
+					target : this,
 					waitForUpdate: true,
 					statusText : 'Moving...',
 					afterUpdate: function(resultObject) {

--- a/static/js/admin/src/action/RefreshResultAction.js
+++ b/static/js/admin/src/action/RefreshResultAction.js
@@ -2,7 +2,9 @@ define('RefreshResultAction', ['jquery', 'RemoteStateChangeMonitor'], function($
 	function RefreshResultAction(context) {
 		// target - ResultObject or array of ResultObjects to refresh
 		// waitForUpdate - If true, updating will be delayed until the _version_ field stored by the server no longer matches the one in the page state.
+		// afterUpdate - function to perform after the expected update completes
 		// clearOverlay - if true, result entry overlay will be removed when the task is complete
+		// statusText - message to display while refreshing. Default is "Refreshing..."
 		this.context = context;
 	};
 	
@@ -18,7 +20,11 @@ define('RefreshResultAction', ['jquery', 'RemoteStateChangeMonitor'], function($
 	
 	RefreshResultAction.prototype.refreshObject = function(resultObject) {
 		resultObject.updateOverlay('open');
-		resultObject.setStatusText('Refreshing...');
+		if (this.context.statusText === undefined) {
+			resultObject.setStatusText('Refreshing...');
+		} else {
+			resultObject.setStatusText(this.context.statusText);
+		}
 		
 		if (this.context.waitForUpdate) {
 			this.refreshAfterUpdate(resultObject);
@@ -35,7 +41,11 @@ define('RefreshResultAction', ['jquery', 'RemoteStateChangeMonitor'], function($
 			},
 			'checkStatusTarget' : this,
 			'statusChanged' : function(data) {
-				self.refreshData(resultObject);
+				if (self.context.afterUpdate !== undefined) {
+					self.context.afterUpdate.call(self, resultObject);
+				} else {
+					self.refreshData(resultObject);
+				}
 			},
 			'statusChangedTarget' : this, 
 			'checkStatusAjax' : {


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2647

* Fixes to move action in admin ui to fix error and cause refreshing/clearing of moved items
* Refactor of ContentPathFactory to pull parent info from fedora rather than triple store. Solr indexing after move operations was happening before the triple store was updated almost every time, resulting in needing to reindex objects for the move operation to appear complete.