### PR TITLE
Have page scroll to the top when user goes to a new route

### DIFF
--- a/static/js/vue-cdr-access/src/router.js
+++ b/static/js/vue-cdr-access/src/router.js
@@ -25,5 +25,8 @@ export default new Router({
       name: 'collectionBrowse',
       component: collectionBrowse
     }
-  ]
+  ],
+  scrollBehavior (to, from, savedPosition) {
+    return { x: 0, y: 0 }
+  }
 });


### PR DESCRIPTION
Have page scroll to the top when user goes to a new route. Most notably, clicking to the next page from the pagination component would leave you at the bottom of the page.