### PR TITLE
BXC-2537/2638 - Deposit migrated timestamps and deposit links

### DIFF
--- a/deposit/src/main/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJob.java
@@ -630,7 +630,14 @@ public class IngestContentObjectsJob extends AbstractDepositJob {
             aResc.addProperty(DC.title, label);
         }
         if (!skipDepositLink) {
-            aResc.addProperty(Cdr.originalDeposit, depositResc);
+            if (dResc.hasProperty(CdrDeposit.originalDeposit)) {
+                // Assign deposit record from provided original deposit resource
+                aResc.addProperty(Cdr.originalDeposit,
+                        dResc.getProperty(CdrDeposit.originalDeposit).getResource());
+            } else {
+                // default to linking to the current deposit since no override provided
+                aResc.addProperty(Cdr.originalDeposit, depositResc);
+            }
         }
     }
 

--- a/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJobIT.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJobIT.java
@@ -31,6 +31,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -78,6 +79,7 @@ import edu.unc.lib.dl.rdf.Premis;
 import edu.unc.lib.dl.rdf.Prov;
 import edu.unc.lib.dl.test.AclModelBuilder;
 import edu.unc.lib.dl.test.RepositoryObjectTreeIndexer;
+import edu.unc.lib.dl.util.DateTimeUtil;
 import edu.unc.lib.dl.util.DepositStatusFactory;
 import edu.unc.lib.dl.util.RedisWorkerConstants.DepositField;
 import edu.unc.lib.dl.util.RedisWorkerConstants.JobField;
@@ -89,6 +91,10 @@ import edu.unc.lib.dl.util.SoftwareAgentConstants.SoftwareAgent;
  *
  */
 public class IngestContentObjectsJobIT extends AbstractFedoraDepositJobIT {
+
+    static {
+        System.setProperty("fcrepo.properties.management", "relaxed");
+    }
 
     private static final String INGESTOR_PRINC = "ingestor";
     private static final String DEPOSITOR_NAME = "boxy_depositor";
@@ -780,6 +786,81 @@ public class IngestContentObjectsJobIT extends AbstractFedoraDepositJobIT {
         FolderObject folder3 = repoObjLoader.getFolderObject(folderObj3Pid);
         Resource f3DepositResc = folder3.getResource().getProperty(Cdr.originalDeposit).getResource();
         assertEquals(deposit3Pid.getRepositoryPath(), f3DepositResc.getURI());
+    }
+
+    private final static String CREATED_STRING = "2011-10-04T20:36:44.902Z";
+    private final static String LAST_MODIFIED_STRING = "2013-10-06T10:16:44.111Z";
+    private final static Date CREATED_DATE = DateTimeUtil.parseUTCToDate(CREATED_STRING);
+    private final static Date LAST_MODIFIED_DATE = DateTimeUtil.parseUTCToDate(LAST_MODIFIED_STRING);
+
+    @Test
+    public void overrideTimestampsTest() throws Exception {
+        Map<String, String> status = new HashMap<>();
+        status.put(DepositField.containerId.name(), RepositoryPaths.getContentRootPid().getRepositoryPath());
+        status.put(DepositField.permissionGroups.name(), "adminGroup");
+        status.put(DepositField.overrideTimestamps.name(), "true");
+        depositStatusFactory.save(depositUUID, status);
+
+        Model model = job.getWritableModel();
+        Bag depBag = model.createBag(depositPid.getRepositoryPath());
+
+        PID unitPid = pidMinter.mintContentPid();
+        Bag unitBag = model.createBag(unitPid.getRepositoryPath());
+        unitBag.addProperty(RDF.type, Cdr.AdminUnit);
+        unitBag.addLiteral(CdrDeposit.lastModifiedTime, LAST_MODIFIED_STRING);
+        unitBag.addLiteral(CdrDeposit.createTime, CREATED_STRING);
+        depBag.add(unitBag);
+
+        PID collPid = pidMinter.mintContentPid();
+        Bag collBag = model.createBag(collPid.getRepositoryPath());
+        collBag.addProperty(RDF.type, Cdr.Collection);
+        collBag.addLiteral(CdrDeposit.lastModifiedTime, LAST_MODIFIED_STRING);
+        collBag.addLiteral(CdrDeposit.createTime, CREATED_STRING);
+        unitBag.add(collBag);
+
+        PID folderPid = pidMinter.mintContentPid();
+        Bag folderBag = model.createBag(folderPid.getRepositoryPath());
+        folderBag.addProperty(RDF.type, Cdr.Folder);
+        folderBag.addLiteral(CdrDeposit.lastModifiedTime, LAST_MODIFIED_STRING);
+        folderBag.addLiteral(CdrDeposit.createTime, CREATED_STRING);
+        collBag.add(folderBag);
+
+        PID workPid = pidMinter.mintContentPid();
+        Bag workBag = model.createBag(workPid.getRepositoryPath());
+        workBag.addProperty(RDF.type, Cdr.Work);
+        workBag.addLiteral(CdrDeposit.lastModifiedTime, LAST_MODIFIED_STRING);
+        workBag.addLiteral(CdrDeposit.createTime, CREATED_STRING);
+        folderBag.add(workBag);
+
+        PID filePid = addFileObject(workBag, FILE1_LOC, FILE1_MIMETYPE, FILE1_SHA1, FILE1_MD5);
+        Resource fileResc = model.getResource(filePid.getRepositoryPath());
+        fileResc.addLiteral(CdrDeposit.lastModifiedTime, LAST_MODIFIED_STRING);
+        fileResc.addLiteral(CdrDeposit.createTime, CREATED_STRING);
+        workBag.add(fileResc);
+
+        job.closeModel();
+
+        job.run();
+
+        treeIndexer.indexAll(baseAddress);
+
+        AdminUnit unitObj = repoObjLoader.getAdminUnit(unitPid);
+        assertTimestamps(CREATED_DATE, LAST_MODIFIED_DATE, unitObj);
+        CollectionObject collObj = repoObjLoader.getCollectionObject(collPid);
+        assertTimestamps(CREATED_DATE, LAST_MODIFIED_DATE, collObj);
+        FolderObject folderObj = repoObjLoader.getFolderObject(folderPid);
+        assertTimestamps(CREATED_DATE, LAST_MODIFIED_DATE, folderObj);
+        WorkObject workObj = repoObjLoader.getWorkObject(workPid);
+        assertTimestamps(CREATED_DATE, LAST_MODIFIED_DATE, workObj);
+        FileObject fileObj = repoObjLoader.getFileObject(filePid);
+        assertTimestamps(CREATED_DATE, LAST_MODIFIED_DATE, fileObj);
+    }
+
+    private void assertTimestamps(Date expectedCreated, Date expectedModified, ContentObject obj) {
+        assertEquals("Date created for " + obj.getPid().getId() + " did not match expected value",
+                expectedCreated, obj.getCreatedDate());
+        assertEquals("Last modifed for " + obj.getPid().getId() + " did not match expected value",
+                expectedModified, obj.getLastModified());
     }
 
     private void assertBinaryProperties(FileObject fileObj, String loc, String mimetype,

--- a/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/RegisterToLongleafJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/RegisterToLongleafJobTest.java
@@ -15,21 +15,12 @@
  */
 package edu.unc.lib.deposit.fcrepo4;
 
-import edu.unc.lib.dl.fcrepo4.BinaryObject;
-import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
-import edu.unc.lib.dl.fedora.PID;
-import edu.unc.lib.dl.rdf.Cdr;
-import edu.unc.lib.dl.rdf.CdrDeposit;
-import org.apache.commons.io.FileUtils;
-import org.apache.jena.query.Dataset;
-import org.apache.jena.rdf.model.*;
-import org.apache.jena.tdb.TDBFactory;
-import org.apache.jena.vocabulary.RDF;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.mockito.Mock;
+import static edu.unc.lib.dl.test.TestHelpers.setField;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.net.URI;
@@ -38,13 +29,29 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
-import static edu.unc.lib.dl.test.TestHelpers.setField;
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import org.apache.commons.io.FileUtils;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.rdf.model.Bag;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.tdb.TDBFactory;
+import org.apache.jena.vocabulary.RDF;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mock;
+
+import edu.unc.lib.dl.fcrepo4.BinaryObject;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.rdf.Cdr;
+import edu.unc.lib.dl.rdf.CdrDeposit;
+import edu.unc.lib.dl.util.RedisWorkerConstants.DepositField;
 
 public class RegisterToLongleafJobTest extends AbstractDepositJobTest {
     @Rule
@@ -83,6 +90,7 @@ public class RegisterToLongleafJobTest extends AbstractDepositJobTest {
         job.setDepositDirectory(depositDir);
         setField(job, "repoObjLoader", repoObjLoader);
         setField(job, "dataset", dataset);
+        setField(job, "depositStatusFactory", depositStatusFactory);
 
         outputPath = tmpFolder.newFile().getPath();
         longleafScript = getLongleafScript(outputPath);
@@ -103,6 +111,10 @@ public class RegisterToLongleafJobTest extends AbstractDepositJobTest {
         when(repoObjLoader.getBinaryObject(any(PID.class))).thenReturn(destinationObj);
         desitnationUri = URI.create(FILE_SCHEME + LOC1_ID + "/event_log");
         when(destinationObj.getContentUri()).thenReturn(desitnationUri);
+
+        Map<String, String> depositStatus = new HashMap<>();
+        depositStatus.put(DepositField.excludeDepositRecord.name(), "false");
+        when(depositStatusFactory.get(anyString())).thenReturn(depositStatus);
     }
 
     @Test

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/persist/api/ingest/DepositData.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/persist/api/ingest/DepositData.java
@@ -44,6 +44,7 @@ public class DepositData {
     private PackagingType packagingType;
     private String depositMethod;
     private boolean staffOnly;
+    private boolean overrideTimestamps;
 
     public DepositData(InputStream inputStream, String filename, String mimeType, PackagingType packagingType,
             String depositMethod, AgentPrincipals depositingAgent) {
@@ -262,5 +263,16 @@ public class DepositData {
      */
     public void setStaffOnly(boolean staffOnly) {
         this.staffOnly = staffOnly;
+    }
+
+    /**
+     * @return true if the deposit should attempt to override timestamps when specified
+     */
+    public boolean getOverrideTimestamps() {
+        return overrideTimestamps;
+    }
+
+    public void setOverrideTimestamps(boolean overrideTimestamps) {
+        this.overrideTimestamps = overrideTimestamps;
     }
 }

--- a/metadata/src/main/java/edu/unc/lib/dl/util/RedisWorkerConstants.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/util/RedisWorkerConstants.java
@@ -36,7 +36,7 @@ public class RedisWorkerConstants {
         createTime, startTime, endTime, ingestedOctets, ingestedObjects, directory, lock, submitTime,
         depositorEmail, packagingType, packageProfile, metsType, permissionGroups, depositMd5, depositSlug,
         errorMessage, stackTrace, excludeDepositRecord, publishObjects, fileMimetype, priority, sourceUri,
-        extras, ingestInprogress, accessionNumber, mediaId, storageLocation, staffOnly;
+        extras, ingestInprogress, accessionNumber, mediaId, storageLocation, staffOnly, overrideTimestamps;
     }
 
     public static enum JobField {

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/MigrationConstants.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/MigrationConstants.java
@@ -89,8 +89,12 @@ public class MigrationConstants {
     }
 
     public static PID convertBxc3RefToPid(String bxc3Uri) {
+        return convertBxc3RefToPid("content", bxc3Uri);
+    }
+
+    public static PID convertBxc3RefToPid(String qualifier, String bxc3Uri) {
         String uuid = substringAfter(bxc3Uri, "/");
-        return PIDs.get(uuid);
+        return PIDs.get(qualifier, uuid);
     }
 
     public static final String PREMIS_DS = "MD_EVENTS";

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformer.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformer.java
@@ -34,6 +34,7 @@ import static edu.unc.lib.dcr.migration.fcrepo3.FoxmlDocumentHelpers.ORIGINAL_DS
 import static edu.unc.lib.dcr.migration.fcrepo3.FoxmlDocumentHelpers.getObjectModel;
 import static edu.unc.lib.dcr.migration.fcrepo3.FoxmlDocumentHelpers.listDatastreamVersions;
 import static edu.unc.lib.dcr.migration.paths.PathIndex.ORIGINAL_TYPE;
+import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.DEPOSIT_RECORD_BASE;
 import static edu.unc.lib.dl.rdf.CdrDeposit.stagingLocation;
 import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.DC_NS;
 import static edu.unc.lib.dl.xml.SecureXMLFactory.createSAXBuilder;
@@ -198,7 +199,7 @@ public class ContentObjectTransformer extends RecursiveAction {
         if (originalDepStmt == null) {
             return;
         }
-        PID originalDepPid = convertBxc3RefToPid(originalDepStmt.getResource());
+        PID originalDepPid = convertBxc3RefToPid(DEPOSIT_RECORD_BASE, originalDepStmt.getResource().getURI());
         depResc.addProperty(CdrDeposit.originalDeposit, createResource(originalDepPid.getRepositoryPath()));
     }
 

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/deposit/DepositSubmissionService.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/deposit/DepositSubmissionService.java
@@ -67,6 +67,7 @@ public class DepositSubmissionService {
         DepositData depositData = new DepositData(null, null, BAG_WITH_N3,
                 BXC3_TO_5_MIGRATION_UTIL.getLabel(), principals);
         depositData.setDepositorEmail(depositorName + EMAIL_SUFFIX);
+        depositData.setOverrideTimestamps(true);
 
         PreconstructedDepositHandler depositHandler = new PreconstructedDepositHandler(depositPid);
         depositHandler.setDepositStatusFactory(depositStatusFactory);

--- a/migration-util/src/test/java/edu/unc/lib/dcr/migration/deposit/DepositSubmissionServiceTest.java
+++ b/migration-util/src/test/java/edu/unc/lib/dcr/migration/deposit/DepositSubmissionServiceTest.java
@@ -97,6 +97,7 @@ public class DepositSubmissionServiceTest {
         assertEquals(DEPOSITOR + EMAIL_SUFFIX, status.get(DepositField.depositorEmail.name()));
         assertEquals(destinationPid.getId(), status.get(DepositField.containerId.name()));
         assertEquals(Priority.normal.name(), status.get(DepositField.priority.name()));
+        assertEquals(true, Boolean.parseBoolean(status.get(DepositField.overrideTimestamps.name())));
 
         assertEquals(DepositState.unregistered.name(), status.get(DepositField.state.name()));
         assertEquals(DepositAction.register.name(), status.get(DepositField.actionRequest.name()));

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/ingest/AbstractDepositHandler.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/ingest/AbstractDepositHandler.java
@@ -132,6 +132,7 @@ public abstract class AbstractDepositHandler implements DepositHandler {
         status.put(DepositField.accessionNumber.name(), deposit.getAccessionNumber());
         status.put(DepositField.mediaId.name(), deposit.getMediaId());
         status.put(DepositField.staffOnly.name(), String.valueOf(deposit.getStaffOnly()));
+        status.put(DepositField.overrideTimestamps.name(), String.valueOf(deposit.getOverrideTimestamps()));
 
         if (deposit.getFilename() != null) {
             // Resolve filename to just the name portion of the value, in case of modifiers


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2638
https://jira.lib.unc.edu/browse/BXC-2537

* Applies created/modified timestamps supplied in a deposit if the overrideTimestamps flag if provided
* Overrides the deposit record link on objects in an ingest if one was set in the deposit model
    * fixes a bug where the deposit id had the wrong pid type
* Fixes issue with longleaf registration which occurs when a deposit does not create a deposit record