### PR TITLE
BXC-2622 - Register updates to longleaf 

### DIFF
--- a/deposit/src/main/java/edu/unc/lib/deposit/work/DepositSupervisor.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/work/DepositSupervisor.java
@@ -45,7 +45,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import edu.unc.lib.deposit.CleanupDepositJob;
 import edu.unc.lib.deposit.fcrepo4.IngestContentObjectsJob;
 import edu.unc.lib.deposit.fcrepo4.IngestDepositRecordJob;
-import edu.unc.lib.deposit.fcrepo4.RegisterToLongleafJob;
 import edu.unc.lib.deposit.fcrepo4.StaffOnlyPermissionJob;
 import edu.unc.lib.deposit.normalize.AssignStorageLocationsJob;
 import edu.unc.lib.deposit.normalize.BagIt2N3BagJob;
@@ -676,9 +675,9 @@ public class DepositSupervisor implements WorkerListener {
         }
 
         // Register files to longleaf
-        if (!successfulJobs.contains(RegisterToLongleafJob.class.getName())) {
-            return makeJob(RegisterToLongleafJob.class, depositUUID);
-        }
+//        if (!successfulJobs.contains(RegisterToLongleafJob.class.getName())) {
+//            return makeJob(RegisterToLongleafJob.class, depositUUID);
+//        }
 
         return null;
     }

--- a/deposit/src/main/java/edu/unc/lib/deposit/work/DepositSupervisor.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/work/DepositSupervisor.java
@@ -674,11 +674,6 @@ public class DepositSupervisor implements WorkerListener {
             return makeJob(IngestContentObjectsJob.class, depositUUID);
         }
 
-        // Register files to longleaf
-//        if (!successfulJobs.contains(RegisterToLongleafJob.class.getName())) {
-//            return makeJob(RegisterToLongleafJob.class, depositUUID);
-//        }
-
         return null;
     }
 

--- a/deposit/src/main/webapp/WEB-INF/deposit-jobs-context.xml
+++ b/deposit/src/main/webapp/WEB-INF/deposit-jobs-context.xml
@@ -287,9 +287,4 @@
         <property name="ingestSourceManager" ref="ingestSourceManager" />
         <property name="statusKeysExpireSeconds" value="${status.keys.expire.seconds:3600}"/>
     </bean>
-
-    <bean id="RegisterToLongleafJob" class="edu.unc.lib.deposit.fcrepo4.RegisterToLongleafJob"
-          scope="prototype">
-        <property name="longleafBaseCommand" value="${longleaf.baseCommand}" />
-    </bean>
 </beans>

--- a/services-camel/pom.xml
+++ b/services-camel/pom.xml
@@ -60,6 +60,11 @@
         <groupId>org.apache.activemq</groupId>
         <artifactId>activemq-client</artifactId>
     </dependency>
+    <dependency>
+        <groupId>org.apache.camel</groupId>
+        <artifactId>camel-sjms</artifactId>
+        <version>${camel.version}</version>
+    </dependency>
 
     <dependency>
         <groupId>commons-io</groupId>

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/BinaryMetadataProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/BinaryMetadataProcessor.java
@@ -67,7 +67,10 @@ public class BinaryMetadataProcessor implements Processor {
 
         if (binObj.getContentUri() != null) {
             Model model = ModelFactory.createDefaultModel();
-            model.read(in.getBody(InputStream.class), null, "Turtle");
+            InputStream bodyStream = in.getBody(InputStream.class);
+            // Reset the body inputstream in case it was already read elsewhere due to multicasting
+            bodyStream.reset();
+            model.read(bodyStream, null, "Turtle");
             Resource resc = model.getResource(binPid.getRepositoryPath());
             String binaryMimeType = resc.getProperty(hasMimeType).getObject().toString();
 

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/enhancements/EnhancementRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/enhancements/EnhancementRouter.java
@@ -88,6 +88,11 @@ public class EnhancementRouter extends RouteBuilder {
             .end();
 
         from("direct:process.binary")
+            .routeId("ProcessBinary")
+            .multicast()
+            .to("direct-vm:filter.longleaf", "direct:process.original");
+
+        from("direct:process.original")
             .routeId("ProcessOriginalBinary")
             .filter(simple("${headers[CamelFcrepoUri]} ends with '/original_file'"))
                 .setHeader(CdrEnhancementSet, constant(DEFAULT_ENHANCEMENTS))

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/longleaf/LongleafAggregationStrategy.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/longleaf/LongleafAggregationStrategy.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.services.camel.longleaf;
+
+import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.processor.aggregate.AggregationStrategy;
+
+/**
+ * Aggregation strategy for combining messages into a batch for longleaf processing
+ *
+ * @author bbpennel
+ */
+public class LongleafAggregationStrategy implements AggregationStrategy {
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Exchange aggregate(Exchange oldExchange, Exchange newExchange) {
+        String binaryUri = (String) newExchange.getIn().getHeader(FCREPO_URI);
+        if (oldExchange == null) {
+            List<String> list = new ArrayList<>();
+            list.add(binaryUri);
+            newExchange.getIn().setBody(list);
+            return newExchange;
+        } else {
+            List<String> list = oldExchange.getIn().getBody(List.class);
+            list.add(binaryUri);
+            return oldExchange;
+        }
+    }
+}

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/longleaf/LongleafRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/longleaf/LongleafRouter.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.services.camel.longleaf;
+
+import org.apache.camel.BeanInject;
+import org.apache.camel.LoggingLevel;
+import org.apache.camel.builder.RouteBuilder;
+
+/**
+ * Router for longleaf operations
+ *
+ * @author bbpennel
+ */
+public class LongleafRouter extends RouteBuilder {
+
+    @BeanInject(value = "registerLongleafProcessor")
+    private RegisterToLongleafProcessor registerProcessor;
+
+    @Override
+    public void configure() throws Exception {
+        from("direct-vm:filter.longleaf")
+            .filter().method(RegisterToLongleafProcessor.class, "registerableBinary")
+            .log(LoggingLevel.DEBUG, "Queuing ${headers[CamelFcrepoUri]} for registration to longleaf")
+            .to("sjms:register.longleaf?transacted=true");
+
+        from("sjms-batch:register.longleaf?completionTimeout={{longleaf.register.completionTimeout}}"
+                + "&completionSize={{longleaf.register.completionSize}}"
+                + "&consumerCount={{longleaf.register.consumers}}"
+                + "&aggregationStrategy=#longleafAggregationStrategy"
+                + "&connectionFactory=jmsFactory")
+            .log(LoggingLevel.DEBUG, "Processing batch of longleaf registrations")
+            .bean(registerProcessor);
+    }
+
+}

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/longleaf/RegisterToLongleafProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/longleaf/RegisterToLongleafProcessor.java
@@ -34,6 +34,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.mutable.MutableInt;
 import org.fcrepo.client.FcrepoClient;
 import org.fcrepo.client.FcrepoOperationFailedException;
 import org.fcrepo.client.FcrepoResponse;
@@ -75,7 +76,8 @@ public class RegisterToLongleafProcessor implements Processor {
     private FcrepoClient fcrepoClient;
 
     /**
-     * The exchange here is expected to be a batch message with one or more
+     * The exchange here is expected to be a batch message containing a List
+     * of binary PIDs for registration, in string form.
      */
     @SuppressWarnings("unchecked")
     @Override
@@ -143,7 +145,7 @@ public class RegisterToLongleafProcessor implements Processor {
         long start = System.currentTimeMillis();
 
         StringBuilder sb = new StringBuilder();
-        final int[] cntArray = { 0 };
+        MutableInt cnt = new MutableInt(0);
         digestsMap.entrySet().forEach(digestGroup -> {
             Map<URI, String> digestToPath = digestGroup.getValue();
             if (digestToPath.size() == 0) {
@@ -156,11 +158,11 @@ public class RegisterToLongleafProcessor implements Processor {
                     .append(' ')
                     .append(Paths.get(manifestEntry.getKey()).toString())
                     .append('\n');
-                cntArray[0]++;
+                cnt.increment();
             });
         });
 
-        int entryCount = cntArray[0];
+        int entryCount = cnt.getValue();
         // Nothing to register
         if (sb.length() == entryCount) {
             return;

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/longleaf/RegisterToLongleafProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/longleaf/RegisterToLongleafProcessor.java
@@ -1,0 +1,251 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.services.camel.longleaf;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
+import static org.apache.commons.lang3.StringUtils.substringAfterLast;
+import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.URI;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+import org.apache.commons.lang3.StringUtils;
+import org.fcrepo.client.FcrepoClient;
+import org.fcrepo.client.FcrepoOperationFailedException;
+import org.fcrepo.client.FcrepoResponse;
+import org.fcrepo.client.FedoraHeaderConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import edu.unc.lib.dl.fcrepo4.BinaryObject;
+import edu.unc.lib.dl.fcrepo4.ClientFaultResolver;
+import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
+import edu.unc.lib.dl.fcrepo4.RepositoryPathConstants;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.fedora.ServiceException;
+import edu.unc.lib.dl.model.DatastreamType;
+
+/**
+ * Processor which registers binaries in longleaf
+ *
+ * @author bbpennel
+ * @author smithjp
+ */
+public class RegisterToLongleafProcessor implements Processor {
+    private static final Logger log = LoggerFactory.getLogger(RegisterToLongleafProcessor.class);
+    private static final Logger longleafLog = LoggerFactory.getLogger("longleaf");
+
+    public static final List<String> REGISTERABLE_IDS = asList(
+            DatastreamType.MD_DESCRIPTIVE.getId(),
+            DatastreamType.MD_DESCRIPTIVE_HISTORY.getId(),
+            DatastreamType.MD_EVENTS.getId(),
+            DatastreamType.ORIGINAL_FILE.getId(),
+            DatastreamType.TECHNICAL_METADATA.getId()
+        );
+
+    private String longleafBaseCommand;
+
+    private RepositoryObjectLoader repoObjLoader;
+
+    private FcrepoClient fcrepoClient;
+
+    /**
+     * The exchange here is expected to be a batch message with one or more
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public void process(Exchange exchange) throws Exception {
+        Message aggrMsg = exchange.getIn();
+
+        // Key is the digest key, value is a map of storage uri to digest value
+        Map<String, Map<URI, String>> digestsMap = new HashMap<>();
+        Map<URI, String> md5Map = new HashMap<>();
+        Map<URI, String> sha1Map = new HashMap<>();
+        digestsMap.put("md5", md5Map);
+        digestsMap.put("sha1", sha1Map);
+
+        List<String> messages = aggrMsg.getBody(List.class);
+        for (String fcrepoUri : messages) {
+            try {
+                PID pid = PIDs.get(fcrepoUri);
+                BinaryObject binObj = repoObjLoader.getBinaryObject(pid);
+
+                String md5 = trimFedoraDigest(binObj.getMd5Checksum(), ":");
+                String sha1 = trimFedoraDigest(binObj.getSha1Checksum(), ":");
+                URI storageUri = binObj.getContentUri();
+
+                if (md5 != null) {
+                    md5Map.put(storageUri, md5);
+                }
+                if (sha1 != null) {
+                    sha1Map.put(storageUri, sha1);
+                }
+                if (md5 == null && sha1 == null) {
+                    sha1Map.put(storageUri, calculateSha1(pid));
+                }
+            } catch (Exception e) {
+                log.error("Failed to add {} to batch for regisration to longleaf", fcrepoUri, e);
+            }
+        }
+
+        registerFiles(digestsMap);
+    }
+
+    private String calculateSha1(PID pid) {
+        try (FcrepoResponse response = fcrepoClient.head(pid.getRepositoryUri())
+                .addHeader(FedoraHeaderConstants.WANT_DIGEST, "sha")
+                .perform()) {
+            String digestVal = response.getHeaderValue(FedoraHeaderConstants.DIGEST);
+            if (digestVal == null) {
+                throw new ServiceException("Failed to calculate sha1 for " + pid.getRepositoryPath());
+            } else {
+                return trimFedoraDigest(digestVal, "=");
+            }
+        } catch (IOException e) {
+            throw new ServiceException(e);
+        } catch (FcrepoOperationFailedException e) {
+            ClientFaultResolver.resolve(e);
+            return null;
+        }
+    }
+
+    /**
+     * Executes longleaf register command for a batch of files with digests
+     *
+     * @param digestsMap mapping of digest algorithms to paths plus digest values
+     */
+    private void registerFiles(Map<String, Map<URI, String>> digestsMap) {
+        long start = System.currentTimeMillis();
+
+        StringBuilder sb = new StringBuilder();
+        final int[] cntArray = { 0 };
+        digestsMap.entrySet().forEach(digestGroup -> {
+            Map<URI, String> digestToPath = digestGroup.getValue();
+            if (digestToPath.size() == 0) {
+                return;
+            }
+            sb.append(digestGroup.getKey()).append(":\n");
+
+            digestToPath.entrySet().forEach(manifestEntry -> {
+                sb.append(manifestEntry.getValue())
+                    .append(' ')
+                    .append(Paths.get(manifestEntry.getKey()).toString())
+                    .append('\n');
+                cntArray[0]++;
+            });
+        });
+
+        int entryCount = cntArray[0];
+        // Nothing to register
+        if (sb.length() == entryCount) {
+            return;
+        }
+
+        try {
+            // only register binaries with md5sum
+            String longleafCommmand = longleafBaseCommand + " register --force -m @-";
+            log.info("Registering with longleaf: {}", longleafCommmand);
+
+            Process process = Runtime.getRuntime().exec(longleafCommmand);
+            // Pipe the manifest data into the command
+            try (OutputStream pipeOut = process.getOutputStream()) {
+                pipeOut.write(sb.toString().getBytes(UTF_8));
+            }
+
+            int exitVal = process.waitFor();
+
+            // log longleaf output
+            String line;
+            try (BufferedReader in = new BufferedReader(
+                    new InputStreamReader(process.getInputStream()))) {
+                while ((line = in.readLine()) != null) {
+                    longleafLog.info(line);
+                }
+            }
+            try (BufferedReader err = new BufferedReader(
+                    new InputStreamReader(process.getErrorStream()))) {
+                while ((line = err.readLine()) != null) {
+                    longleafLog.error(line);
+                }
+            }
+
+            if (exitVal == 0) {
+                log.info("Successfully registered {} entries to longleaf", entryCount);
+            } else {
+                throw new ServiceException("Failed to register " + entryCount + " entries to Longleaf.  "
+                        + "Check longleaf logs, command returned: " + exitVal);
+            }
+        } catch (IOException e) {
+            log.error("IOException while trying to register batch of {} entries to longleaf", entryCount, e);
+        } catch (InterruptedException e) {
+            log.error("InterruptedException while trying to register {} entries to longleaf", entryCount, e);
+        }
+
+        log.info("Longleaf registration completed in: {} ms", (System.currentTimeMillis() - start));
+    }
+
+    private String trimFedoraDigest(String fedoraDigest, String separator) {
+        if (fedoraDigest == null) {
+            return null;
+        }
+        return substringAfterLast(fedoraDigest, separator);
+    }
+
+    public void setLongleafBaseCommand(String longleafBaseCommand) {
+        this.longleafBaseCommand = longleafBaseCommand;
+    }
+
+    public void setRepositoryObjectLoader(RepositoryObjectLoader repoObjLoader) {
+        this.repoObjLoader = repoObjLoader;
+    }
+
+    public void setFcrepoClient(FcrepoClient fcrepoClient) {
+        this.fcrepoClient = fcrepoClient;
+    }
+
+    /**
+     * @param fcrepuUri uri of object
+     * @return true if the object is a binary that should be registered in longleaf.
+     */
+    public static boolean registerableBinary(Exchange exchange) {
+        String fcrepoUri = (String) exchange.getIn().getHeader(FCREPO_URI);
+        String dsId = StringUtils.substringAfterLast(fcrepoUri, "/");
+
+        if (dsId.equals("fcr:metadata")) {
+            return false;
+        }
+
+        if (REGISTERABLE_IDS.contains(dsId)) {
+            return true;
+        } else {
+            // Also registerable if the datastream is a deposit manifest
+            PID dsPid = PIDs.get(fcrepoUri);
+            return dsPid.getQualifier().equals(RepositoryPathConstants.DEPOSIT_RECORD_BASE);
+        }
+    }
+}

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/routing/MetaServicesRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/routing/MetaServicesRouter.java
@@ -15,7 +15,9 @@
  */
 package edu.unc.lib.dl.services.camel.routing;
 
+import static edu.unc.lib.dl.rdf.Fcrepo4Repository.Binary;
 import static edu.unc.lib.dl.services.camel.util.EventTypes.EVENT_CREATE;
+import static edu.unc.lib.dl.services.camel.util.EventTypes.EVENT_UPDATE;
 
 import org.apache.camel.BeanInject;
 import org.apache.camel.PropertyInject;
@@ -45,10 +47,18 @@ public class MetaServicesRouter extends RouteBuilder {
 
         from("direct:process.enhancement")
             .routeId("ProcessEnhancement")
-            .filter(simple("${headers[org.fcrepo.jms.eventType]} contains '" + EVENT_CREATE + "'"))
-                .log("Performing enhancements for ${headers[org.fcrepo.jms.identifier]}")
-                .delay(simple("{{cdr.enhancement.postIndexingDelay}}"))
-                .removeHeaders("CamelHttp*")
-                .to("{{cdr.enhancement.stream.camel}}");
+            .choice()
+                .when(simple("${headers[org.fcrepo.jms.eventType]} contains '" + EVENT_CREATE + "'"))
+                    .to("direct-vm:process.creation")
+                .when(simple("${headers[org.fcrepo.jms.eventType]} contains '" + EVENT_UPDATE + "'"
+                        + " && ${headers[org.fcrepo.jms.resourceType]} contains '" + Binary.getURI() + "'"))
+                    .to("direct-vm:filter.longleaf")
+            .end();
+
+        from("direct-vm:process.creation")
+            .routeId("ProcessCreation")
+            .delay(simple("{{cdr.enhancement.postIndexingDelay}}"))
+            .removeHeaders("CamelHttp*")
+            .to("{{cdr.enhancement.stream.camel}}");
     }
 }

--- a/services-camel/src/main/webapp/WEB-INF/activemq-context.xml
+++ b/services-camel/src/main/webapp/WEB-INF/activemq-context.xml
@@ -40,4 +40,12 @@
         <property name="defaultDestinationName" value="repository.updates" />
         <property name="pubSubDomain" value="true" />
     </bean>
+    
+    <bean id="sjms" class="org.apache.camel.component.sjms.SjmsComponent">
+        <property name="connectionFactory" ref="pooledConnectionFactory" />
+    </bean>
+    
+    <bean id="sjms-batch" class="org.apache.camel.component.sjms.batch.SjmsBatchComponent">
+        <property name="connectionFactory" ref="pooledConnectionFactory" />
+    </bean>
 </beans>

--- a/services-camel/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel/src/main/webapp/WEB-INF/service-context.xml
@@ -353,6 +353,15 @@
         <property name="transferService" ref="binaryTransferService" />
         <property name="locationManager" ref="storageLocationManager" />
     </bean>
+    
+    <bean id="longleafAggregationStrategy" class="edu.unc.lib.dl.services.camel.longleaf.LongleafAggregationStrategy">
+    </bean>
+    
+    <bean id="registerLongleafProcessor" class="edu.unc.lib.dl.services.camel.longleaf.RegisterToLongleafProcessor">
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="fcrepoClient" ref="fcrepoClient" />
+        <property name="longleafBaseCommand" value="${longleaf.baseCommand}" />
+    </bean>
 
     <!-- Camel contexts -->
 
@@ -374,6 +383,10 @@
     
     <camel:camelContext id="CdrServiceCdrEvents">
         <camel:package>edu.unc.lib.dl.services.camel.cdrEvents</camel:package>
+    </camel:camelContext>
+    
+    <camel:camelContext id="cdrLongleaf">
+        <camel:package>edu.unc.lib.dl.services.camel.longleaf</camel:package>
     </camel:camelContext>
     
     <camel:camelContext id="CdrEnhancements">

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/RegisterToLongleafProcessorIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/RegisterToLongleafProcessorIT.java
@@ -1,0 +1,289 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.services.camel.longleaf;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.io.FileUtils;
+import org.fcrepo.client.FcrepoClient;
+import org.fusesource.hawtbuf.ByteArrayInputStream;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import edu.unc.lib.dl.fcrepo4.BinaryObject;
+import edu.unc.lib.dl.fcrepo4.FileObject;
+import edu.unc.lib.dl.fcrepo4.RepositoryObject;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
+import edu.unc.lib.dl.fcrepo4.RepositoryPIDMinter;
+import edu.unc.lib.dl.fcrepo4.WorkObject;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.model.DatastreamPids;
+import edu.unc.lib.dl.persist.api.storage.StorageLocation;
+import edu.unc.lib.dl.persist.api.storage.StorageLocationManager;
+import edu.unc.lib.dl.persist.api.transfer.BinaryTransferService;
+import edu.unc.lib.dl.persist.api.transfer.BinaryTransferSession;
+import edu.unc.lib.dl.test.TestHelper;
+
+/**
+ * @author bbpennel
+ * @author smithjp
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextHierarchy({
+    @ContextConfiguration("/spring-test/test-fedora-container.xml"),
+    @ContextConfiguration("/spring-test/cdr-client-container.xml")
+})
+public class RegisterToLongleafProcessorIT {
+    private static final String TEXT1_BODY = "Some content";
+    private static final String TEXT1_SHA1 = DigestUtils.sha1Hex(TEXT1_BODY);
+    private static final String TEXT1_MD5 = DigestUtils.md5Hex(TEXT1_BODY);
+    private static final String TEXT2_BODY = "Another content file";
+    private static final String TEXT2_SHA1 = DigestUtils.sha1Hex(TEXT2_BODY);
+    private static final String TEXT2_MD5 = DigestUtils.md5Hex(TEXT2_BODY);
+    private static final String TEXT3_BODY = "Probably some metadata";
+    private static final String TEXT3_MD5 = DigestUtils.md5Hex(TEXT3_BODY);
+    private static final String TEXT4_BODY = "Maybe some more metadata";
+    private static final String TEXT4_MD5 = DigestUtils.md5Hex(TEXT4_BODY);
+
+    @Rule
+    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    @Autowired
+    private String baseAddress;
+    @Autowired
+    private RepositoryObjectFactory repoObjFactory;
+    @Autowired
+    private RepositoryObjectLoader repoObjLoader;
+    @Autowired
+    private RepositoryPIDMinter pidMinter;
+    @Autowired
+    private FcrepoClient fcrepoClient;
+    @Autowired
+    private StorageLocationManager locManager;
+    @Autowired
+    private BinaryTransferService transferService;
+    private BinaryTransferSession transferSession;
+
+    private String longleafScript;
+    private String outputPath;
+    private String outputText;
+    private List<String> output;
+
+    private RegisterToLongleafProcessor processor;
+
+    @Before
+    public void init() throws Exception {
+        TestHelper.setContentBase(baseAddress);
+        tmpFolder.create();
+
+        processor = new RegisterToLongleafProcessor();
+        processor.setFcrepoClient(fcrepoClient);
+        processor.setRepositoryObjectLoader(repoObjLoader);
+        outputPath = tmpFolder.newFile().getPath();
+        output = null;
+        longleafScript = getLongleafScript(outputPath);
+        processor.setLongleafBaseCommand(longleafScript);
+
+        StorageLocation loc = locManager.getStorageLocationById("loc1");
+        transferSession = transferService.getSession(loc);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        transferSession.close();
+    }
+
+    @Test
+    public void registerSingleFileWithSha1() throws Exception {
+        FileObject fileObj = repoObjFactory.createFileObject(null);
+        BinaryObject origBin = createOriginalBinary(fileObj, TEXT1_BODY, TEXT1_SHA1, null);
+
+        Exchange exchange = createBatchExchange(origBin);
+        processor.process(exchange);
+
+        readOutput();
+        assertRegisterCalled(1);
+        assertManifestEntry("sha1", TEXT1_SHA1, origBin.getContentUri());
+    }
+
+    @Test
+    public void registerWorkWithMetadataUsingMd5() throws Exception {
+        WorkObject workObj = repoObjFactory.createWorkObject(null);
+        PID workPid = workObj.getPid();
+        BinaryObject modsBin = createBinary(DatastreamPids.getMdDescriptivePid(workPid),
+                TEXT2_BODY, null, TEXT2_MD5);
+        URI modsStorageUri = modsBin.getContentUri();
+        BinaryObject modsHistoryBin = createBinary(DatastreamPids.getDatastreamHistoryPid(modsBin.getPid()),
+                TEXT3_BODY, null, TEXT3_MD5);
+        URI modsHistoryStorageUri = modsHistoryBin.getContentUri();
+        BinaryObject premisBin = createBinary(DatastreamPids.getMdEventsPid(workPid),
+                TEXT4_BODY, null, TEXT4_MD5);
+        URI premisStorageUri = premisBin.getContentUri();
+
+        PID filePid = pidMinter.mintContentPid();
+        PID originalPid = DatastreamPids.getOriginalFilePid(filePid);
+        URI storageUri = transferSession.transfer(originalPid, streamString(TEXT1_BODY));
+        FileObject fileObj = workObj.addDataFile(filePid, storageUri, "original", "text/plain", null, TEXT1_MD5, null);
+        BinaryObject origBin = fileObj.getOriginalFile();
+
+        Exchange exchange = createBatchExchange(modsBin, modsHistoryBin, premisBin, origBin);
+        processor.process(exchange);
+
+        readOutput();
+        assertRegisterCalled(1);
+        assertManifestEntry("md5", TEXT1_MD5, storageUri);
+        assertManifestEntry("md5", TEXT2_MD5, modsStorageUri);
+        assertManifestEntry("md5", TEXT3_MD5, modsHistoryStorageUri);
+        assertManifestEntry("md5", TEXT4_MD5, premisStorageUri);
+    }
+
+    @Test
+    public void registerFileWithFitsAndMultipleDigests() throws Exception {
+        FileObject fileObj = repoObjFactory.createFileObject(null);
+        BinaryObject origBin = createOriginalBinary(fileObj, TEXT1_BODY, TEXT1_SHA1, TEXT1_MD5);
+
+        BinaryObject techBin = createBinary(DatastreamPids.getTechnicalMetadataPid(fileObj.getPid()),
+                TEXT2_BODY, TEXT2_SHA1, TEXT2_MD5);
+
+        Exchange exchange = createBatchExchange(origBin, techBin);
+        processor.process(exchange);
+
+        readOutput();
+        assertRegisterCalled(1);
+        assertManifestEntry("sha1", TEXT1_SHA1, origBin.getContentUri());
+        assertManifestEntry("md5", TEXT1_MD5, origBin.getContentUri());
+        assertManifestEntry("sha1", TEXT2_SHA1, techBin.getContentUri());
+        assertManifestEntry("md5", TEXT2_MD5, techBin.getContentUri());
+    }
+
+    @Test
+    public void registerSingleFileWithNoDigest() throws Exception {
+        FileObject fileObj = repoObjFactory.createFileObject(null);
+        BinaryObject origBin = createOriginalBinary(fileObj, TEXT1_BODY, null, null);
+
+        Exchange exchange = createBatchExchange(origBin);
+        processor.process(exchange);
+
+        readOutput();
+        assertRegisterCalled(1);
+        assertManifestEntry("sha1", TEXT1_SHA1, origBin.getContentUri());
+    }
+
+    private BinaryObject createBinary(PID binPid, String content, String sha1, String md5) {
+        URI storageUri = transferSession.transfer(binPid, streamString(content));
+        return repoObjFactory.createOrUpdateBinary(binPid, storageUri, "text.txt", "text/plain", sha1, md5, null);
+    }
+
+    private BinaryObject createOriginalBinary(FileObject fileObj, String content, String sha1, String md5) {
+        PID originalPid = DatastreamPids.getOriginalFilePid(fileObj.getPid());
+        URI storageUri = transferSession.transfer(originalPid, streamString(content));
+        return fileObj.addOriginalFile(storageUri, "original.txt", "plain/text", sha1, md5);
+    }
+
+    private String getLongleafScript(String outputPath) throws Exception {
+        String scriptContent = "#!/usr/bin/env bash"
+                + "\necho $@ >> " + outputPath
+                + "\necho \"$(</dev/stdin)\" >> " + outputPath;
+        File longleafScript = File.createTempFile("longleaf", ".sh");
+
+        FileUtils.write(longleafScript, scriptContent, "UTF-8");
+
+        longleafScript.deleteOnExit();
+
+        Set<PosixFilePermission> ownerExecutable = PosixFilePermissions.fromString("r-x------");
+        Files.setPosixFilePermissions(longleafScript.toPath(), ownerExecutable);
+
+        return longleafScript.getAbsolutePath();
+    }
+
+    private void assertRegisterCalled(int expectedCount) {
+        int count = 0;
+        for (String line : output) {
+            if (("register --force -m @-").equals(line)) {
+                count++;
+            }
+        }
+
+        assertEquals(expectedCount, count);
+    }
+
+    private void assertManifestEntry(String alg, String expectedDigest, URI storageUri) {
+        int algIndex = output.indexOf(alg + ":");
+        assertNotEquals("Expected digest algorithm " + alg + " not found in manifest", -1, algIndex);
+
+        String expectedPath = Paths.get(storageUri).toString();
+        for (int i = algIndex + 1; i < output.size(); i++) {
+            String line = output.get(i);
+            if (line.matches("\\S+:")) {
+                break;
+            }
+            if (line.matches(expectedDigest + " +" + expectedPath)) {
+                return;
+            }
+        }
+        fail("Did not find entry for " + alg + " "
+                + expectedDigest + " " + expectedPath + " in manifest:\n" + outputText);
+    }
+
+    private InputStream streamString(String text) {
+        return new ByteArrayInputStream(text.getBytes(UTF_8));
+    }
+
+    private void readOutput() throws IOException {
+        outputText = FileUtils.readFileToString(new File(outputPath), UTF_8);
+        output = Arrays.asList(outputText.split("\n"));
+    }
+
+    private Exchange createBatchExchange(RepositoryObject... objects) {
+        Exchange exchange = mock(Exchange.class);
+        Message msg = mock(Message.class);
+        when(exchange.getIn()).thenReturn(msg);
+        when(msg.getBody(List.class)).thenReturn(Arrays.stream(objects)
+                .map(ro -> ro.getPid().getRepositoryPath())
+                .collect(Collectors.toList()));
+        return exchange;
+    }
+}

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/RegisterToLongleafProcessorTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/RegisterToLongleafProcessorTest.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.services.camel.longleaf;
+
+import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.junit.Before;
+import org.junit.Test;
+
+import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fcrepo4.RepositoryPIDMinter;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.model.DatastreamPids;
+
+/**
+ * @author bbpennel
+ */
+public class RegisterToLongleafProcessorTest {
+    private RepositoryPIDMinter pidMinter;
+    private PID filePid;
+
+    @Before
+    public void setup() {
+        pidMinter = new RepositoryPIDMinter();
+        filePid = pidMinter.mintContentPid();
+    }
+
+    @Test
+    public void registerableBinaryOriginal() throws Exception {
+        PID binPid = DatastreamPids.getOriginalFilePid(filePid);
+        Exchange exchange = createIndividualExchange(binPid);
+        assertTrue(RegisterToLongleafProcessor.registerableBinary(exchange));
+    }
+
+    @Test
+    public void registerableBinaryMdDescriptive() throws Exception {
+        PID binPid = DatastreamPids.getMdDescriptivePid(filePid);
+        Exchange exchange = createIndividualExchange(binPid);
+        assertTrue(RegisterToLongleafProcessor.registerableBinary(exchange));
+    }
+
+    @Test
+    public void registerableBinaryMdDescriptiveHistory() throws Exception {
+        PID binPid = DatastreamPids.getMdDescriptivePid(filePid);
+        binPid = DatastreamPids.getDatastreamHistoryPid(binPid);
+        Exchange exchange = createIndividualExchange(binPid);
+        assertTrue(RegisterToLongleafProcessor.registerableBinary(exchange));
+    }
+
+    @Test
+    public void registerableBinaryMdEvents() throws Exception {
+        PID binPid = DatastreamPids.getMdEventsPid(filePid);
+        Exchange exchange = createIndividualExchange(binPid);
+        assertTrue(RegisterToLongleafProcessor.registerableBinary(exchange));
+    }
+
+    @Test
+    public void registerableBinaryTechMd() throws Exception {
+        PID binPid = DatastreamPids.getTechnicalMetadataPid(filePid);
+        Exchange exchange = createIndividualExchange(binPid);
+        assertTrue(RegisterToLongleafProcessor.registerableBinary(exchange));
+    }
+
+    @Test
+    public void registerableBinaryManifest() throws Exception {
+        PID depositPid = pidMinter.mintDepositRecordPid();
+        PID binPid = DatastreamPids.getDepositManifestPid(depositPid, "mets.xml");
+        Exchange exchange = createIndividualExchange(binPid);
+        assertTrue(RegisterToLongleafProcessor.registerableBinary(exchange));
+    }
+
+    @Test
+    public void registerableBinaryJp2() throws Exception {
+        PID binPid = PIDs.get(filePid.getRepositoryPath() + "/data/jp2");
+        Exchange exchange = createIndividualExchange(binPid);
+        assertFalse(RegisterToLongleafProcessor.registerableBinary(exchange));
+    }
+
+    @Test
+    public void registerableBinaryManifestMetadata() throws Exception {
+        PID depositPid = pidMinter.mintDepositRecordPid();
+        PID binPid = DatastreamPids.getDepositManifestPid(depositPid, "mets.xml");
+        PID mdPid = PIDs.get(binPid.getRepositoryPath() + "/fcr:metadata");
+        Exchange exchange = createIndividualExchange(mdPid);
+        assertFalse(RegisterToLongleafProcessor.registerableBinary(exchange));
+    }
+
+    private Exchange createIndividualExchange(PID pid) throws Exception {
+        Exchange exchange = mock(Exchange.class);
+        Message msg = mock(Message.class);
+        when(exchange.getIn()).thenReturn(msg);
+        when(msg.getHeader(FCREPO_URI)).thenReturn(pid.getRepositoryPath());
+        return exchange;
+    }
+}

--- a/services-camel/src/test/resources/enhancement-router-it-config.properties
+++ b/services-camel/src/test/resources/enhancement-router-it-config.properties
@@ -73,3 +73,7 @@ conductor.solr.maxThreads=3
 conductor.solr.beforeExecuteDelay=50
 conductor.solr.beforeUpdateDelay=0
 conductor.solr.recoverableDelay=30000
+
+longleaf.register.consumers=1
+longleaf.register.completionTimeout=1000
+longleaf.register.completionSize=1

--- a/services-camel/src/test/resources/enhancement-router-it-context.xml
+++ b/services-camel/src/test/resources/enhancement-router-it-context.xml
@@ -58,6 +58,10 @@
     <bean id="fulltextProcessor" class="org.mockito.Mockito" factory-method="mock">
         <constructor-arg value="edu.unc.lib.dl.services.camel.fulltext.FulltextProcessor" />
     </bean>
+    
+    <bean id="registerLongleafProcessor" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.services.camel.longleaf.RegisterToLongleafProcessor" />
+    </bean>
 
     <camel:camelContext id="cdrServiceImageEnhancements">
         <camel:package>edu.unc.lib.dl.services.camel.images</camel:package>
@@ -69,6 +73,21 @@
     
     <camel:camelContext id="cdrServiceSolr">
         <camel:package>edu.unc.lib.dl.services.camel.solr</camel:package>
+    </camel:camelContext>
+    
+    <bean id="longleafAggregationStrategy" class="edu.unc.lib.dl.services.camel.longleaf.LongleafAggregationStrategy">
+    </bean>
+    
+    <bean id="sjms" class="org.apache.camel.component.sjms.SjmsComponent">
+        <property name="connectionFactory" ref="jmsFactory" />
+    </bean>
+    
+    <bean id="sjms-batch" class="org.apache.camel.component.sjms.batch.SjmsBatchComponent">
+        <property name="connectionFactory" ref="jmsFactory" />
+    </bean>
+    
+    <camel:camelContext id="cdrLongleaf">
+        <camel:package>edu.unc.lib.dl.services.camel.longleaf</camel:package>
     </camel:camelContext>
     
     <camel:camelContext id="cdrEnhancements">

--- a/services-camel/src/test/resources/logback-test.xml
+++ b/services-camel/src/test/resources/logback-test.xml
@@ -6,6 +6,8 @@
       <pattern>%relative %-5level [%thread] %logger{20} - %msg%n</pattern>
     </encoder>
   </appender>
+  <logger name="org.apache.camel" level="ERROR"/>
+  <logger name="org.apache.activemq" level="ERROR"/>
   <root level="WARN">
     <appender-ref ref="CONSOLE"/>
   </root>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2622

* Support registration of binary updates and creations to longleaf via camel routes.
* Registration to longleaf performed in batches
* Deposit longleaf registration job switched into camel processor

Depends on:
https://github.com/UNC-Libraries/longleaf-preservation/pull/26