### PR TITLE
BXC-2689 - Refresh transactions

### DIFF
--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/FedoraTransaction.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/FedoraTransaction.java
@@ -67,11 +67,6 @@ public class FedoraTransaction {
         txUri = null;
     }
 
-    public void keepAlive() {
-        //TODO implement clock to extend tx for ~ 1 hour?
-        txManager.keepTransactionAlive(txUri);
-    }
-
     public void cancelAndIgnore() {
         cancelTx();
     }
@@ -99,5 +94,9 @@ public class FedoraTransaction {
             rootTxThread.remove();
             txManager.cancelTransaction(txUri);
         }
+    }
+
+    public TransactionManager getTransactionManager() {
+        return txManager;
     }
 }

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/FedoraTransactionRefresher.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/FedoraTransactionRefresher.java
@@ -23,8 +23,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.slf4j.Logger;
 
-import edu.unc.lib.dl.exceptions.RepositoryException;
-
 /**
  * Utility which keeps a transaction alive for as long as it is needed.
  *
@@ -103,7 +101,8 @@ public class FedoraTransactionRefresher implements Runnable {
      */
     public void interrupt() {
         if (!running.get()) {
-            throw new RepositoryException("Cannot interrupt refresher, it is not running");
+            log.warn("Cannot interrupt refresher for {}, it is not running", txUri);
+            return;
         }
         stop();
         worker.interrupt();

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/FedoraTransactionRefresher.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/FedoraTransactionRefresher.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.fcrepo4;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.net.URI;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.slf4j.Logger;
+
+import edu.unc.lib.dl.exceptions.RepositoryException;
+
+/**
+ * Utility which keeps a transaction alive for as long as it is needed.
+ *
+ * @author bbpennel
+ */
+public class FedoraTransactionRefresher implements Runnable {
+    private static final Logger log = getLogger(FedoraTransactionRefresher.class);
+
+    // max transaction time, 1 day
+    private static long maxTimeToLive = 24 * 60 * 60 * 1000;
+    private static long refreshInterval = 60 * 1000;
+
+    private Thread worker;
+
+    private AtomicBoolean running = new AtomicBoolean(false);
+    private AtomicBoolean stopped = new AtomicBoolean(false);
+
+    private AtomicLong maxEndTime;
+
+    private URI txUri;
+    private TransactionManager txManager;
+
+    /**
+     * Construct a new refresher for the given transaction
+     * @param tx
+     */
+    public FedoraTransactionRefresher(FedoraTransaction tx) {
+        this.txUri = tx.getTxUri();
+        this.txManager = tx.getTransactionManager();
+    }
+
+    /**
+     * Start the refresher
+     */
+    public void start() {
+        worker = new Thread(this);
+        worker.start();
+    }
+
+    @Override
+    public void run() {
+        if (running.get() || stopped.get()) {
+            log.warn("Refresher has already started for transaction {}", txUri);
+            return;
+        }
+
+        log.debug("Starting transaction refresher for {}", txUri);
+        running.set(true);
+        maxEndTime = new AtomicLong(System.currentTimeMillis() + maxTimeToLive);
+
+        while (running.get() && !stopped.get()) {
+            // Check to see if the tx has been kept alive past the max time to live
+            if (System.currentTimeMillis() >= maxEndTime.get()) {
+                break;
+            }
+            // Wait the interval time
+            try {
+                Thread.sleep(refreshInterval);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.debug("Refresher interrupted for transaction {}", txUri);
+            }
+            // Refresh the transaction to keep it alive, unless the refresher is stopped
+            if (!stopped.get()) {
+                txManager.keepTransactionAlive(txUri);
+            }
+        }
+        stopped.set(true);
+        running.set(false);
+        log.debug("Transaction refresher for {} finished after {}ms",
+                txUri, (System.currentTimeMillis() - maxEndTime.get() + maxTimeToLive));
+    }
+
+    /**
+     * Interrupt the refresher immediately
+     */
+    public void interrupt() {
+        if (!running.get()) {
+            throw new RepositoryException("Cannot interrupt refresher, it is not running");
+        }
+        stop();
+        worker.interrupt();
+    }
+
+    /**
+     * Stop the refresher at the next check
+     */
+    public void stop() {
+        stopped.set(true);
+    }
+
+    public boolean isStopped() {
+        return stopped.get();
+    }
+
+    public boolean isRunning() {
+        return running.get();
+    }
+
+    public static void setMaxTimeToLive(long maxTimeToLive) {
+        FedoraTransactionRefresher.maxTimeToLive = maxTimeToLive;
+    }
+
+    public static void setRefreshInterval(long refreshInterval) {
+        FedoraTransactionRefresher.refreshInterval = refreshInterval;
+    }
+
+    public static long getMaxTimeToLive() {
+        return maxTimeToLive;
+    }
+
+    public static long getRefreshInterval() {
+        return refreshInterval;
+    }
+}

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/FedoraTransactionRefresherTest.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/FedoraTransactionRefresherTest.java
@@ -31,8 +31,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
-import edu.unc.lib.dl.exceptions.RepositoryException;
-
 /**
  * @author bbpennel
  */
@@ -123,10 +121,13 @@ public class FedoraTransactionRefresherTest {
         assertFalse(refresher.isRunning());
     }
 
-    @Test(expected = RepositoryException.class)
+    @Test
     public void interruptNotRunning() throws Exception {
         FedoraTransactionRefresher refresher = new FedoraTransactionRefresher(tx);
 
         refresher.interrupt();
+
+        assertFalse(refresher.isStopped());
+        assertFalse(refresher.isRunning());
     }
 }

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/FedoraTransactionRefresherTest.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/FedoraTransactionRefresherTest.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.fcrepo4;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.net.URI;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import edu.unc.lib.dl.exceptions.RepositoryException;
+
+/**
+ * @author bbpennel
+ */
+public class FedoraTransactionRefresherTest {
+
+    @Mock
+    private TransactionManager txManager;
+    @Mock
+    private FedoraTransaction tx;
+
+    private URI txUri;
+
+    private static long originalMaxTimeToLive = FedoraTransactionRefresher.getMaxTimeToLive();
+    private static long originalRefreshInterval = FedoraTransactionRefresher.getRefreshInterval();
+
+    @Before
+    public void setup() {
+        initMocks(this);
+        txUri = URI.create("http://example.com/tx");
+
+        when(tx.getTransactionManager()).thenReturn(txManager);
+        when(tx.getTxUri()).thenReturn(txUri);
+    }
+
+    @After
+    public void cleanup() {
+        FedoraTransactionRefresher.setMaxTimeToLive(originalMaxTimeToLive);
+        FedoraTransactionRefresher.setRefreshInterval(originalRefreshInterval);
+    }
+
+    @Test
+    public void stopBeforeRefresh() throws Exception {
+        FedoraTransactionRefresher.setRefreshInterval(75l);
+
+        FedoraTransactionRefresher refresher = new FedoraTransactionRefresher(tx);
+
+        refresher.start();
+        Thread.sleep(25);
+        refresher.stop();
+        Thread.sleep(100l);
+
+        assertTrue(refresher.isStopped());
+        assertFalse(refresher.isRunning());
+        verify(txManager, never()).keepTransactionAlive(any(URI.class));
+    }
+
+    @Test
+    public void refreshMultipleTimes() throws Exception {
+        FedoraTransactionRefresher.setRefreshInterval(25l);
+
+        FedoraTransactionRefresher refresher = new FedoraTransactionRefresher(tx);
+
+        refresher.start();
+        Thread.sleep(100l);
+        refresher.stop();
+        Thread.sleep(50l);
+
+        assertTrue(refresher.isStopped());
+        assertFalse(refresher.isRunning());
+        verify(txManager, atLeast(3)).keepTransactionAlive(any(URI.class));
+    }
+
+    @Test
+    public void exceedMaxTimeToLive() throws Exception {
+        FedoraTransactionRefresher.setRefreshInterval(25l);
+        FedoraTransactionRefresher.setMaxTimeToLive(100l);
+
+        FedoraTransactionRefresher refresher = new FedoraTransactionRefresher(tx);
+
+        refresher.start();
+        Thread.sleep(125l);
+
+        assertTrue(refresher.isStopped());
+        assertFalse(refresher.isRunning());
+        verify(txManager, atLeast(3)).keepTransactionAlive(any(URI.class));
+    }
+
+    @Test
+    public void interruptRunning() throws Exception {
+        FedoraTransactionRefresher refresher = new FedoraTransactionRefresher(tx);
+
+        refresher.start();
+        Thread.sleep(25);
+        refresher.interrupt();
+        Thread.sleep(25);
+
+        assertTrue(refresher.isStopped());
+        assertFalse(refresher.isRunning());
+    }
+
+    @Test(expected = RepositoryException.class)
+    public void interruptNotRunning() throws Exception {
+        FedoraTransactionRefresher refresher = new FedoraTransactionRefresher(tx);
+
+        refresher.interrupt();
+    }
+}


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2689

*  Perform periodic refresh of transactions during ingest of work objects to address timeouts during ingest of large files
* Adds an utility for refreshing transactions in a background thread

