### PR TITLE
BXC-2687 - Deposit SHA1s

### DIFF
--- a/deposit/src/main/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJob.java
@@ -66,6 +66,7 @@ public class TransferBinariesToStorageJob extends AbstractDepositJob {
      *
      */
     public TransferBinariesToStorageJob() {
+        this.rollbackDatasetOnFailure = false;
     }
 
     /**
@@ -74,6 +75,7 @@ public class TransferBinariesToStorageJob extends AbstractDepositJob {
      */
     public TransferBinariesToStorageJob(String uuid, String depositUUID) {
         super(uuid, depositUUID);
+        this.rollbackDatasetOnFailure = false;
     }
 
     @Override

--- a/deposit/src/main/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJob.java
@@ -91,6 +91,7 @@ public class TransferBinariesToStorageJob extends AbstractDepositJob {
 
     private void transferBinaries(Resource resc, BinaryTransferSession transferSession) {
         PID objPid = PIDs.get(resc.toString());
+        log.debug("Preparing to transfer binaries for {}", objPid);
 
         Set<Resource> rescTypes = resc.listProperties(RDF.type).toList().stream()
                 .map(Statement::getResource).collect(toSet());
@@ -129,7 +130,9 @@ public class TransferBinariesToStorageJob extends AbstractDepositJob {
 
             if (!isObjectCompleted(originalPid)) {
                 URI stagingUri = URI.create(resc.getProperty(CdrDeposit.stagingLocation).getString());
+                log.debug("Transferring original file from {} for {}", stagingUri, originalPid);
                 URI storageUri = transferSession.transfer(originalPid, stagingUri);
+                log.debug("Finished transferring original file from {} to {}", stagingUri, storageUri);
                 resc.addLiteral(CdrDeposit.storageUri, storageUri.toString());
                 markObjectCompleted(originalPid);
             }
@@ -147,6 +150,7 @@ public class TransferBinariesToStorageJob extends AbstractDepositJob {
                     PID dsHistoryPid = getDatastreamHistoryPid(modsPid);
                     URI stagingUri = stagingPath.toUri();
                     URI storageUri = transferSession.transfer(dsHistoryPid, stagingUri);
+                    log.debug("Finished transferring MODS history file from {} to {}", stagingUri, storageUri);
                     resc.addLiteral(CdrDeposit.descriptiveHistoryStorageUri, storageUri.toString());
                     markObjectCompleted(modsPid);
                 }
@@ -161,6 +165,7 @@ public class TransferBinariesToStorageJob extends AbstractDepositJob {
             if (!isObjectCompleted(fitsPid)) {
                 URI stagingUri = getTechMdPath(objPid, false).toUri();
                 URI storageUri = transferSession.transfer(fitsPid, stagingUri);
+                log.debug("Finished transferring techmd file from {} to {}", stagingUri, storageUri);
                 resc.addLiteral(CdrDeposit.fitsStorageUri, storageUri.toString());
                 markObjectCompleted(fitsPid);
             }
@@ -182,6 +187,7 @@ public class TransferBinariesToStorageJob extends AbstractDepositJob {
 
             if (!isObjectCompleted(manifestPid)) {
                 URI storageUri = transferSession.transfer(manifestPid, manifestUri);
+                log.debug("Finished transferring manifest file from {} to {}", manifestUri, storageUri);
                 resc.addLiteral(CdrDeposit.storageUri, storageUri.toString());
                 markObjectCompleted(manifestPid);
             }

--- a/deposit/src/main/java/edu/unc/lib/deposit/validate/FixityCheckJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/validate/FixityCheckJob.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.deposit.validate;
+
+import static edu.unc.lib.dl.rdf.CdrDeposit.stagingLocation;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import edu.unc.lib.deposit.work.AbstractDepositJob;
+import edu.unc.lib.dl.event.PremisEventBuilder;
+import edu.unc.lib.dl.event.PremisLogger;
+import edu.unc.lib.dl.exceptions.InvalidChecksumException;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.rdf.Premis;
+import edu.unc.lib.dl.util.DigestAlgorithm;
+import edu.unc.lib.dl.util.MultiDigestInputStreamWrapper;
+import edu.unc.lib.dl.util.SoftwareAgentConstants.SoftwareAgent;
+
+/**
+ * Calculates digests for staged files, performing a fixity check if existing
+ * digests were provided with the deposit.
+ *
+ * @author bbpennel
+ */
+public class FixityCheckJob extends AbstractDepositJob {
+    private static final Logger log = LoggerFactory.getLogger(FixityCheckJob.class);
+
+    private static final Collection<DigestAlgorithm> REQUIRED_ALGS = Collections.singleton(
+            DigestAlgorithm.DEFAULT_ALGORITHM);
+
+    public FixityCheckJob(String uuid, String depositUUID) {
+        super(uuid, depositUUID);
+    }
+
+    @Override
+    public void runJob() {
+        log.debug("Performing FixityCheckJob for deposit {}", depositUUID);
+        Model model = getWritableModel();
+
+        List<Entry<PID, String>> stagingList = getPropertyPairList(model, stagingLocation);
+        for (Entry<PID, String> stagingEntry : stagingList) {
+            PID rescPid = stagingEntry.getKey();
+            String stagedPath = stagingEntry.getValue();
+            URI stagedUri = URI.create(stagedPath);
+
+            Resource objResc = model.getResource(rescPid.getRepositoryPath());
+
+            try (InputStream fStream = Files.newInputStream(Paths.get(stagedUri))) {
+                log.debug("Calculating digests for {}", stagedUri);
+                MultiDigestInputStreamWrapper digestWrapper = new MultiDigestInputStreamWrapper(
+                        fStream, getDigestsForResource(objResc), REQUIRED_ALGS);
+                digestWrapper.checkFixity();
+                recordDigestsForResource(rescPid, objResc, digestWrapper.getDigests());
+            } catch (InvalidChecksumException e) {
+                failJob(String.format("Fixity check failed for %s belonging to %s",
+                        stagedUri, objResc.getURI()),
+                        e.getMessage());
+            } catch (IOException e) {
+                failJob(e, "Failed to read file {0} for fixity check", stagedUri);
+            }
+        }
+    }
+
+    private Map<DigestAlgorithm, String> getDigestsForResource(Resource resc) {
+        Map<DigestAlgorithm, String> digests = new HashMap<>();
+        for (DigestAlgorithm algorithm : DigestAlgorithm.values()) {
+            if (resc.hasProperty(algorithm.getDepositProperty())) {
+                digests.put(algorithm, resc.getProperty(algorithm.getDepositProperty()).getString());
+            }
+        }
+        return digests;
+    }
+
+    private void recordDigestsForResource(PID pid, Resource resc, Map<DigestAlgorithm, String> digests) {
+        List<String> details = new ArrayList<>();
+        // Store newly calculate digests into deposit model
+        digests.forEach((alg, digest) -> {
+            if (resc.hasProperty(alg.getDepositProperty())) {
+                log.debug("{} fixity check for {} passed with value {}", alg.getName(), resc.getURI(), digest);
+            } else {
+                log.debug("Storing {} digest for {} with value {}", alg.getName(), resc.getURI(), digest);
+                resc.addLiteral(alg.getDepositProperty(), digest);
+            }
+            details.add(alg.getName().toUpperCase() + " checksum calculated: " + digest);
+        });
+
+        // Store event for calculation of checksums
+        PremisLogger premisDepositLogger = getPremisLogger(pid);
+        PremisEventBuilder builder = premisDepositLogger.buildEvent(Premis.MessageDigestCalculation)
+                .addSoftwareAgent(SoftwareAgent.depositService.getFullname());
+        details.forEach(builder::addEventDetail);
+        builder.write();
+    }
+}

--- a/deposit/src/main/java/edu/unc/lib/deposit/validate/FixityCheckJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/validate/FixityCheckJob.java
@@ -85,8 +85,10 @@ public class FixityCheckJob extends AbstractDepositJob {
                 MultiDigestInputStreamWrapper digestWrapper = new MultiDigestInputStreamWrapper(
                         fStream, getDigestsForResource(objResc), REQUIRED_ALGS);
                 digestWrapper.checkFixity();
+                log.debug("Verified fixity of {}", stagedUri);
                 recordDigestsForResource(rescPid, objResc, digestWrapper.getDigests());
                 markObjectCompleted(rescPid);
+                log.debug("Completed fixity recording for {}", stagedUri);
             } catch (InvalidChecksumException e) {
                 failJob(String.format("Fixity check failed for %s belonging to %s",
                         stagedUri, objResc.getURI()),

--- a/deposit/src/main/java/edu/unc/lib/deposit/work/AbstractDepositJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/work/AbstractDepositJob.java
@@ -131,6 +131,8 @@ public abstract class AbstractDepositJob implements Runnable {
 
     private String depositJobId;
 
+    protected boolean rollbackDatasetOnFailure = true;
+
     @Autowired
     private Dataset dataset;
 
@@ -164,7 +166,11 @@ public abstract class AbstractDepositJob implements Runnable {
             }
         } catch (Exception e) {
             if (dataset.isInTransaction()) {
-                dataset.abort();
+                if (rollbackDatasetOnFailure) {
+                    dataset.abort();
+                } else {
+                    dataset.commit();
+                }
             }
             throw e;
         } finally {

--- a/deposit/src/main/java/edu/unc/lib/deposit/work/AbstractDepositJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/work/AbstractDepositJob.java
@@ -167,8 +167,10 @@ public abstract class AbstractDepositJob implements Runnable {
         } catch (Exception e) {
             if (dataset.isInTransaction()) {
                 if (rollbackDatasetOnFailure) {
+                    log.debug("Aborting deposit model changes for {} after failure", depositUUID);
                     dataset.abort();
                 } else {
+                    log.debug("Committing deposit model changes for {} after failure", depositUUID);
                     dataset.commit();
                 }
             }

--- a/deposit/src/main/java/edu/unc/lib/deposit/work/DepositSupervisor.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/work/DepositSupervisor.java
@@ -55,6 +55,7 @@ import edu.unc.lib.deposit.normalize.Simple2N3BagJob;
 import edu.unc.lib.deposit.normalize.UnpackDepositJob;
 import edu.unc.lib.deposit.transfer.TransferBinariesToStorageJob;
 import edu.unc.lib.deposit.validate.ExtractTechnicalMetadataJob;
+import edu.unc.lib.deposit.validate.FixityCheckJob;
 import edu.unc.lib.deposit.validate.PackageIntegrityCheckJob;
 import edu.unc.lib.deposit.validate.ValidateContentModelJob;
 import edu.unc.lib.deposit.validate.ValidateDescriptionJob;
@@ -640,6 +641,11 @@ public class DepositSupervisor implements WorkerListener {
         // Virus Scan
         if (!successfulJobs.contains(VirusScanJob.class.getName())) {
             return makeJob(VirusScanJob.class, depositUUID);
+        }
+
+        // Verify/calculate checksums
+        if (!successfulJobs.contains(FixityCheckJob.class.getName())) {
+            return makeJob(FixityCheckJob.class, depositUUID);
         }
 
         // Extract technical metadata

--- a/deposit/src/main/webapp/WEB-INF/deposit-jobs-context.xml
+++ b/deposit/src/main/webapp/WEB-INF/deposit-jobs-context.xml
@@ -193,6 +193,10 @@
         <property name="clamScan" ref="clamScan" />
     </bean>
     
+    <bean id="FixityCheckJob" class="edu.unc.lib.deposit.validate.FixityCheckJob"
+        scope="prototype">
+    </bean>
+    
     <bean id="ValidateDestinationJob" class="edu.unc.lib.deposit.validate.ValidateDestinationJob"
         scope="prototype">
     </bean>

--- a/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/AbstractDepositJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/AbstractDepositJobTest.java
@@ -22,6 +22,8 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 import org.apache.jena.query.Dataset;
@@ -100,6 +102,8 @@ public class AbstractDepositJobTest {
     @Mock
     protected FedoraTransaction tx;
 
+    private Set<String> completedIds;
+
     @Before
     public void initBase() throws Exception {
         initMocks(this);
@@ -135,6 +139,18 @@ public class AbstractDepositJobTest {
                         invocation.getArgumentAt(0, Exception.class));
             }
         }).when(tx).cancel(any(Exception.class));
+
+        completedIds = new HashSet<>();
+
+        doAnswer(invocation -> {
+            String objId = invocation.getArgumentAt(1, String.class);
+            completedIds.add(objId);
+            return null;
+        }).when(jobStatusFactory).addObjectCompleted(anyString(), anyString());
+        when(jobStatusFactory.objectIsCompleted(anyString(), anyString())).thenAnswer(invocation -> {
+            String objId = invocation.getArgumentAt(1, String.class);
+            return completedIds.contains(objId);
+        });
     }
 
     protected PID makePid() {

--- a/deposit/src/test/java/edu/unc/lib/deposit/validate/ExtractTechnicalMetadataJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/validate/ExtractTechnicalMetadataJobTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -54,7 +53,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
 import edu.unc.lib.deposit.fcrepo4.AbstractDepositJobTest;
-import edu.unc.lib.deposit.work.JobFailedException;
 import edu.unc.lib.dl.event.PremisEventBuilder;
 import edu.unc.lib.dl.event.PremisLogger;
 import edu.unc.lib.dl.event.PremisLoggerFactory;
@@ -62,7 +60,6 @@ import edu.unc.lib.dl.fcrepo4.RepositoryPathConstants;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.rdf.Cdr;
 import edu.unc.lib.dl.rdf.CdrDeposit;
-import edu.unc.lib.dl.rdf.Premis;
 import edu.unc.lib.dl.test.SelfReturningAnswer;
 import edu.unc.lib.dl.util.DepositConstants;
 
@@ -166,7 +163,6 @@ public class ExtractTechnicalMetadataJobTest extends AbstractDepositJobTest {
         job.run();
 
         verifyFileResults(filePid, IMAGE_MIMETYPE, IMAGE_FORMAT, IMAGE_MD5, IMAGE_FILEPATH, 1);
-        verify(premisLogger).buildEvent(eq(Premis.MessageDigestCalculation));
     }
 
     @Test
@@ -247,17 +243,6 @@ public class ExtractTechnicalMetadataJobTest extends AbstractDepositJobTest {
         verifyFileResults(filePid, IMAGE_MIMETYPE, IMAGE_FORMAT, IMAGE_MD5, IMAGE_FILEPATH, 1);
     }
 
-    @Test(expected = JobFailedException.class)
-    public void md5MismatchTest() throws Exception {
-        respondWithFile("/fitsReports/imageReport.xml");
-
-        // Providing incorrect checksum value
-        addFileObject(depositBag, IMAGE_FILEPATH, null, "111111111111");
-        job.closeModel();
-
-        job.run();
-    }
-
     @Test
     public void resumeJobTest() throws Exception {
         respondWithFile("/fitsReports/imageReport.xml");
@@ -322,13 +307,6 @@ public class ExtractTechnicalMetadataJobTest extends AbstractDepositJobTest {
         assertEquals(identifier, filePid.getRepositoryPath());
 
         Element premisObjCharsEl = premisObjEl.getChild("objectCharacteristics", PREMIS_V3_NS);
-
-        String checksum = premisObjCharsEl.getChild("fixity", PREMIS_V3_NS)
-                .getChildText("messageDigest", PREMIS_V3_NS);
-        assertEquals("Checksum not recorded in premis report", expectedChecksum, checksum);
-
-        assertEquals("Checksum not set in deposit model", expectedChecksum,
-                fileResc.getProperty(CdrDeposit.md5sum).getString());
 
         // Test that the size property is set and a numeric value
         Long.parseLong(premisObjCharsEl.getChildText("size", PREMIS_V3_NS));

--- a/deposit/src/test/java/edu/unc/lib/deposit/validate/FixityCheckJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/validate/FixityCheckJobTest.java
@@ -67,8 +67,6 @@ public class FixityCheckJobTest extends AbstractDepositJobTest {
 
     private File stagingDir;
 
-
-
     @Before
     public void setup() throws Exception {
         pidMinter = new RepositoryPIDMinter();

--- a/deposit/src/test/java/edu/unc/lib/deposit/validate/FixityCheckJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/validate/FixityCheckJobTest.java
@@ -1,0 +1,271 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.deposit.validate;
+
+import static edu.unc.lib.dl.test.TestHelpers.setField;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.jena.rdf.model.Bag;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.vocabulary.RDF;
+import org.jgroups.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+
+import edu.unc.lib.deposit.fcrepo4.AbstractDepositJobTest;
+import edu.unc.lib.deposit.work.JobFailedException;
+import edu.unc.lib.dl.event.PremisLoggerFactory;
+import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fcrepo4.RepositoryPIDMinter;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.rdf.Cdr;
+import edu.unc.lib.dl.rdf.CdrDeposit;
+import edu.unc.lib.dl.rdf.Premis;
+import edu.unc.lib.dl.util.DigestAlgorithm;
+
+/**
+ * @author bbpennel
+ */
+public class FixityCheckJobTest extends AbstractDepositJobTest {
+    private static final String CONTENT1 = "Something to digest";
+    private static final String CONTENT1_MD5 = "7afbf05666feeebe7fbbf1c9071584e6";
+    private static final String CONTENT1_SHA1 = "23d51c61a578a8cb00c5eec6b29c12b7da15c8de";
+    private static final String CONTENT2 = "Boxy eats a checksum";
+    private static final String CONTENT2_MD5 = "d4568cb41bf223e418cfd4f23b1a385b";
+    private static final String CONTENT2_SHA1 = "f14b0716d448386a4f0671112097c55fc0d91313";
+
+    private RepositoryPIDMinter pidMinter;
+
+    private FixityCheckJob job;
+
+    private File stagingDir;
+
+    @Before
+    public void setup() throws Exception {
+        pidMinter = new RepositoryPIDMinter();
+
+        premisLoggerFactory = new PremisLoggerFactory();
+        premisLoggerFactory.setPidMinter(pidMinter);
+
+        job = new FixityCheckJob(jobUUID, depositUUID);
+        setField(job, "dataset", dataset);
+        setField(job, "premisLoggerFactory", premisLoggerFactory);
+        setField(job, "depositsDirectory", depositsDirectory);
+        job.init();
+
+        stagingDir = tmpFolder.newFolder("staged");
+    }
+
+    @Test
+    public void depositWithNoDigests() throws Exception {
+        Model model = job.getWritableModel();
+        Bag depBag = model.createBag(depositPid.getRepositoryPath());
+
+        String stagingPath = stageFile(CONTENT1);
+        PID filePid = addFileObject(depBag, stagingPath);
+        job.closeModel();
+
+        job.run();
+
+        Model resultModel = job.getReadOnlyModel();
+        Resource fileResc = resultModel.getResource(filePid.getRepositoryPath());
+        assertTrue(fileResc.hasProperty(CdrDeposit.sha1sum, CONTENT1_SHA1));
+
+        assertChecksumEvent(filePid, DigestAlgorithm.SHA1, CONTENT1_SHA1);
+    }
+
+    @Test
+    public void depositWithValidSha1() throws Exception {
+        Model model = job.getWritableModel();
+        Bag depBag = model.createBag(depositPid.getRepositoryPath());
+
+        String stagingPath = stageFile(CONTENT1);
+        PID filePid = addFileObject(depBag, stagingPath);
+        addDigest(model, filePid, DigestAlgorithm.SHA1, CONTENT1_SHA1);
+        job.closeModel();
+
+        job.run();
+
+        Model resultModel = job.getReadOnlyModel();
+        Resource fileResc = resultModel.getResource(filePid.getRepositoryPath());
+        assertTrue(fileResc.hasProperty(CdrDeposit.sha1sum, CONTENT1_SHA1));
+
+        assertChecksumEvent(filePid, DigestAlgorithm.SHA1, CONTENT1_SHA1);
+    }
+
+    @Test
+    public void depositWithInvalidSha1() throws Exception {
+        Model model = job.getWritableModel();
+        Bag depBag = model.createBag(depositPid.getRepositoryPath());
+
+        String stagingPath = stageFile(CONTENT1);
+        PID filePid = addFileObject(depBag, stagingPath);
+        addDigest(model, filePid, DigestAlgorithm.SHA1, "ohsha");
+        job.closeModel();
+
+        try {
+            job.run();
+            fail("Expected job to fail");
+        } catch (JobFailedException e) {
+            assertTrue(e.getMessage().contains("Fixity check failed for " + stagingPath));
+            assertTrue(e.getDetails().contains("Checksum mismatch, computed SHA1"));
+        }
+    }
+
+    @Test
+    public void depositWithValidMd5() throws Exception {
+        Model model = job.getWritableModel();
+        Bag depBag = model.createBag(depositPid.getRepositoryPath());
+
+        String stagingPath = stageFile(CONTENT1);
+        PID filePid = addFileObject(depBag, stagingPath);
+        addDigest(model, filePid, DigestAlgorithm.MD5, CONTENT1_MD5);
+        job.closeModel();
+
+        job.run();
+
+        // Both the provided md5 and the computed sha1 must be present
+        Model resultModel = job.getReadOnlyModel();
+        Resource fileResc = resultModel.getResource(filePid.getRepositoryPath());
+        assertTrue(fileResc.hasProperty(CdrDeposit.sha1sum, CONTENT1_SHA1));
+        assertTrue(fileResc.hasProperty(CdrDeposit.md5sum, CONTENT1_MD5));
+
+        assertChecksumEvent(filePid, DigestAlgorithm.SHA1, CONTENT1_SHA1);
+        assertChecksumEvent(filePid, DigestAlgorithm.MD5, CONTENT1_MD5);
+    }
+
+    @Test
+    public void depositWithInvalidMd5() throws Exception {
+        Model model = job.getWritableModel();
+        Bag depBag = model.createBag(depositPid.getRepositoryPath());
+
+        String stagingPath = stageFile(CONTENT1);
+        PID filePid = addFileObject(depBag, stagingPath);
+        addDigest(model, filePid, DigestAlgorithm.MD5, "mdwhat");
+        job.closeModel();
+
+        try {
+            job.run();
+            fail("Expected job to fail");
+        } catch (JobFailedException e) {
+            assertTrue(e.getMessage().contains("Fixity check failed for " + stagingPath));
+            assertTrue(e.getDetails().contains("Checksum mismatch, computed MD5"));
+        }
+    }
+
+    @Test
+    public void depositWithNoFiles() throws Exception {
+        Model model = job.getWritableModel();
+        Bag depBag = model.createBag(depositPid.getRepositoryPath());
+
+        Bag folderBag = addFolderObject(depBag);
+        PID folderPid = PIDs.get(folderBag.getURI());
+        job.closeModel();
+
+        job.run();
+
+        Model resultModel = job.getReadOnlyModel();
+        Resource folderResc = resultModel.getResource(folderPid.getRepositoryPath());
+        assertFalse(folderResc.hasProperty(CdrDeposit.sha1sum));
+    }
+
+    @Test
+    public void depositMultipleFilesWithValidDigests() throws Exception {
+        Model model = job.getWritableModel();
+        Bag depBag = model.createBag(depositPid.getRepositoryPath());
+
+        String stagingPath1 = stageFile(CONTENT1);
+        PID filePid1 = addFileObject(depBag, stagingPath1);
+        addDigest(model, filePid1, DigestAlgorithm.MD5, CONTENT1_MD5);
+        addDigest(model, filePid1, DigestAlgorithm.SHA1, CONTENT1_SHA1);
+        String stagingPath2 = stageFile(CONTENT2);
+        PID filePid2 = addFileObject(depBag, stagingPath2);
+        addDigest(model, filePid2, DigestAlgorithm.MD5, CONTENT2_MD5);
+        job.closeModel();
+
+        job.run();
+
+        // Both the provided md5 and the computed sha1 must be present
+        Model resultModel = job.getReadOnlyModel();
+        Resource fileResc1 = resultModel.getResource(filePid1.getRepositoryPath());
+        assertTrue(fileResc1.hasProperty(CdrDeposit.sha1sum, CONTENT1_SHA1));
+        assertTrue(fileResc1.hasProperty(CdrDeposit.md5sum, CONTENT1_MD5));
+
+        assertChecksumEvent(filePid1, DigestAlgorithm.SHA1, CONTENT1_SHA1);
+        assertChecksumEvent(filePid1, DigestAlgorithm.MD5, CONTENT1_MD5);
+
+        Resource fileResc2 = resultModel.getResource(filePid2.getRepositoryPath());
+        assertTrue(fileResc2.hasProperty(CdrDeposit.sha1sum, CONTENT2_SHA1));
+        assertTrue(fileResc2.hasProperty(CdrDeposit.md5sum, CONTENT2_MD5));
+
+        assertChecksumEvent(filePid2, DigestAlgorithm.SHA1, CONTENT2_SHA1);
+        assertChecksumEvent(filePid2, DigestAlgorithm.MD5, CONTENT2_MD5);
+    }
+
+    private String stageFile(String content) throws IOException {
+        String fileId = UUID.randomUUID().toString();
+        File stagedFile = new File(stagingDir, fileId);
+        FileUtils.write(stagedFile, content, UTF_8);
+        return stagedFile.toPath().toUri().toString();
+    }
+
+    private PID addFileObject(Bag parent, String stagingLocation) {
+        PID filePid = makePid();
+
+        Resource fileResc = parent.getModel().createResource(filePid.getRepositoryPath());
+        fileResc.addProperty(RDF.type, Cdr.FileObject);
+        fileResc.addProperty(CdrDeposit.stagingLocation, stagingLocation);
+
+        parent.add(fileResc);
+
+        return filePid;
+    }
+
+    private Bag addFolderObject(Bag parent) {
+        PID folderPid = makePid();
+
+        Bag folderBag = parent.getModel().createBag(folderPid.getRepositoryPath());
+        folderBag.addProperty(RDF.type, Cdr.Folder);
+
+        parent.add(folderBag);
+
+        return folderBag;
+    }
+
+    private void addDigest(Model model, PID filePid, DigestAlgorithm alg, String digest) {
+        Resource fileResc = model.createResource(filePid.getRepositoryPath());
+        fileResc.addLiteral(alg.getDepositProperty(), digest);
+    }
+
+    private void assertChecksumEvent(PID pid, DigestAlgorithm alg, String digest) {
+        Model eventsModel = job.getPremisLogger(pid).getEventsModel();
+        List<Resource> events = eventsModel.listResourcesWithProperty(
+                RDF.type, Premis.MessageDigestCalculation).toList();
+        assertEquals("Unexpected number of premis events", 1, events.size());
+        Resource eventResc = events.get(0);
+        eventResc.hasProperty(Premis.note, alg.getName().toUpperCase() + " checksum calculated: " + digest);
+    }
+}

--- a/metadata/src/main/java/edu/unc/lib/dl/exceptions/InvalidChecksumException.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/exceptions/InvalidChecksumException.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.exceptions;
+
+/**
+ * Exception indicating that a checksum did not match the expected value
+ *
+ * @author bbpennel
+ */
+public class InvalidChecksumException extends RepositoryException {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * @param message
+     */
+    public InvalidChecksumException(String message) {
+        super(message);
+    }
+
+    /**
+     * @param ex
+     */
+    public InvalidChecksumException(Throwable ex) {
+        super(ex);
+    }
+
+    /**
+     * @param message
+     * @param ex
+     */
+    public InvalidChecksumException(String message, Throwable ex) {
+        super(message, ex);
+    }
+
+}

--- a/metadata/src/main/java/edu/unc/lib/dl/exceptions/UnsupportedAlgorithmException.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/exceptions/UnsupportedAlgorithmException.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.exceptions;
+
+/**
+ * Thrown when an unsupported digest algorithm is specified
+ *
+ * @author bbpennel
+ */
+public class UnsupportedAlgorithmException extends RepositoryException {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * @param message
+     * @param ex
+     */
+    public UnsupportedAlgorithmException(String message, Throwable ex) {
+        super(message, ex);
+    }
+
+    /**
+     * @param message
+     */
+    public UnsupportedAlgorithmException(String message) {
+        super(message);
+    }
+
+    /**
+     * @param ex
+     */
+    public UnsupportedAlgorithmException(Throwable ex) {
+        super(ex);
+    }
+
+}

--- a/persistence/src/main/java/edu/unc/lib/dl/util/DigestAlgorithm.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/util/DigestAlgorithm.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.util;
+
+import org.apache.jena.rdf.model.Property;
+
+import edu.unc.lib.dl.rdf.CdrDeposit;
+
+/**
+ * Digest algorithms supported by bxc
+ *
+ * @author bbpennel
+ */
+public enum DigestAlgorithm {
+    SHA1("sha1", CdrDeposit.sha1sum),
+    MD5("md5", CdrDeposit.md5sum);
+
+    public static final DigestAlgorithm DEFAULT_ALGORITHM = DigestAlgorithm.SHA1;
+
+    private final String name;
+    private final Property depositProp;
+
+    private DigestAlgorithm(String name, Property depositProp) {
+        this.depositProp = depositProp;
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Property getDepositProperty() {
+        return depositProp;
+    }
+
+    public static DigestAlgorithm getByDepositProperty(Property depositProp) {
+        for (DigestAlgorithm alg : values()) {
+            if (alg.depositProp.equals(depositProp)) {
+                return alg;
+            }
+        }
+        return null;
+    }
+}

--- a/persistence/src/main/java/edu/unc/lib/dl/util/MultiDigestInputStreamWrapper.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/util/MultiDigestInputStreamWrapper.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.util;
+
+import static org.apache.commons.codec.binary.Hex.encodeHexString;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import edu.unc.lib.dl.exceptions.InvalidChecksumException;
+import edu.unc.lib.dl.exceptions.RepositoryException;
+import edu.unc.lib.dl.exceptions.UnsupportedAlgorithmException;
+
+/**
+ * Wrapper for an InputStream that allows for the computation and evaluation
+ * of multiple digests at once.
+ *
+ * @author bbpennel
+ */
+public class MultiDigestInputStreamWrapper {
+    private final InputStream sourceStream;
+
+    private final Map<DigestAlgorithm, String> algToDigest;
+
+    private final Map<DigestAlgorithm, DigestInputStream> algToDigestStream;
+
+    private boolean streamRetrieved;
+
+    private Map<DigestAlgorithm, String> computedDigests;
+
+    /**
+     * Construct a MultiDigestInputStreamWrapper
+     *
+     * @param sourceStream the original source input stream
+     * @param digests map of provided digests for the input stream
+     * @param wantDigests list of additional digest algorithms to compute for the input stream
+     */
+    public MultiDigestInputStreamWrapper(InputStream sourceStream, Map<DigestAlgorithm, String> digests,
+            Collection<DigestAlgorithm> wantDigests) {
+        this.sourceStream = sourceStream;
+        algToDigest = digests;
+        algToDigestStream = new HashMap<>();
+
+        // Merge the list of wanted digest algorithms with set of provided digests
+        if (wantDigests != null) {
+            for (DigestAlgorithm wantDigest : wantDigests) {
+                if (!algToDigest.containsKey(wantDigest)) {
+                    algToDigest.put(wantDigest, null);
+                }
+            }
+        }
+    }
+
+    /**
+     * Get the InputStream wrapped to produce the requested digests
+     *
+     * @return wrapped input stream
+     */
+    public InputStream getInputStream() {
+        streamRetrieved = true;
+        InputStream digestStream = sourceStream;
+        for (DigestAlgorithm algorithm : algToDigest.keySet()) {
+            try {
+                // Progressively wrap the original stream in layers of digest streams
+                digestStream = new DigestInputStream(
+                        digestStream, MessageDigest.getInstance(algorithm.getName()));
+            } catch (final NoSuchAlgorithmException e) {
+                throw new UnsupportedAlgorithmException("Unsupported digest algorithm: " + algorithm, e);
+            }
+
+            algToDigestStream.put(algorithm, (DigestInputStream) digestStream);
+        }
+        return digestStream;
+    }
+
+    /**
+     * After consuming the inputstream, verify that all of the computed digests
+     * matched the provided digests.
+     *
+     * Note: the wrapped InputStream will be consumed if it has not already been read.
+     *
+     * @throws InvalidChecksumException thrown if any of the digests did not match
+     */
+    public void checkFixity() throws InvalidChecksumException {
+        calculateDigests();
+
+        algToDigest.forEach((algorithm, originalDigest) -> {
+            // Skip any algorithms which were calculated but no digest was provided for verification
+            if (originalDigest == null) {
+                return;
+            }
+            final String computed = computedDigests.get(algorithm);
+
+            if (!originalDigest.equalsIgnoreCase(computed)) {
+                throw new InvalidChecksumException(String.format(
+                        "Checksum mismatch, computed %s digest %s did not match expected value %s",
+                        algorithm, computed, originalDigest));
+            }
+        });
+
+    }
+
+    /**
+     * Returns the list of digests calculated for the wrapped InputStream
+     *
+     * Note: the wrapped InputStream will be consumed if it has not already been read.
+     *
+     * @return list of digests calculated from the wrapped InputStream, in URN format.
+     */
+    public Map<DigestAlgorithm, String> getDigests() {
+        calculateDigests();
+
+        return computedDigests;
+    }
+
+    private void calculateDigests() {
+        if (computedDigests != null) {
+            return;
+        }
+
+        if (!streamRetrieved) {
+            // Stream not previously consumed, consume it now in order to calculate digests
+            try (final InputStream is = getInputStream()) {
+                while (is.read() != -1) {
+                }
+            } catch (final IOException e) {
+                throw new RepositoryException("Failed to read content stream while calculating digests", e);
+            }
+        }
+
+        computedDigests = new HashMap<>();
+        algToDigestStream.forEach((algorithm, digestStream) -> {
+            final String computed = encodeHexString(digestStream.getMessageDigest().digest());
+            computedDigests.put(algorithm, computed);
+        });
+    }
+}


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2687

* Adds a specialized job for verifying fixity and generating a default digest for original files. 
* Removes fixity checking from technical metadata job
* Adds mechanism for preventing rollback of changes to the deposit model when a job fails. Enabled this for the transfer binaries job.