### PR TITLE
BXC-2718 - Generate missing migrated deposit records

### DIFF
--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/ClientFaultResolver.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/ClientFaultResolver.java
@@ -19,6 +19,7 @@ import org.apache.http.HttpStatus;
 import org.fcrepo.client.FcrepoOperationFailedException;
 
 import edu.unc.lib.dl.fedora.AuthorizationException;
+import edu.unc.lib.dl.fedora.ConflictException;
 import edu.unc.lib.dl.fedora.FedoraException;
 import edu.unc.lib.dl.fedora.NotFoundException;
 
@@ -46,6 +47,8 @@ public abstract class ClientFaultResolver {
                 return new AuthorizationException(ex);
             case HttpStatus.SC_NOT_FOUND:
                     return new NotFoundException(ex);
+            case HttpStatus.SC_CONFLICT:
+                    return new ConflictException(ex);
             }
         }
         return new FedoraException(ex);

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/ConflictException.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/ConflictException.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.fedora;
+
+/**
+ * Request failed due to a conflict
+ *
+ * @author bbpennel
+ */
+public class ConflictException extends FedoraException {
+
+    /**
+     * @param e
+     */
+    public ConflictException(Exception e) {
+        super(e);
+    }
+
+    /**
+     * @param message
+     * @param e
+     */
+    public ConflictException(String message, Exception e) {
+        super(message, e);
+    }
+
+    /**
+     * @param message
+     */
+    public ConflictException(String message) {
+        super(message);
+    }
+
+}

--- a/metadata/src/main/java/edu/unc/lib/dl/util/PackagingType.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/util/PackagingType.java
@@ -30,7 +30,8 @@ public enum PackagingType {
     ATOM("http://purl.org/net/sword/terms/Atom"),
     BAG_WITH_N3("http://cdr.unc.edu/BAGIT/profiles/N3"),
     BAGIT("http://purl.org/net/sword/package/BagIt"),
-    DIRECTORY("http://cdr.unc.edu/DirectoryIngest");
+    DIRECTORY("http://cdr.unc.edu/DirectoryIngest"),
+    BXC3_TO_5_MIGRATION("https://library.unc.edu/dcr/packaging/bxc3To5Migration");
 
     private String uri;
 

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformer.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformer.java
@@ -33,6 +33,7 @@ import static edu.unc.lib.dcr.migration.fcrepo3.FoxmlDocumentHelpers.MODS_DS;
 import static edu.unc.lib.dcr.migration.fcrepo3.FoxmlDocumentHelpers.ORIGINAL_DS;
 import static edu.unc.lib.dcr.migration.fcrepo3.FoxmlDocumentHelpers.getObjectModel;
 import static edu.unc.lib.dcr.migration.fcrepo3.FoxmlDocumentHelpers.listDatastreamVersions;
+import static edu.unc.lib.dcr.migration.paths.PathIndex.OBJECT_TYPE;
 import static edu.unc.lib.dcr.migration.paths.PathIndex.ORIGINAL_TYPE;
 import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.DEPOSIT_RECORD_BASE;
 import static edu.unc.lib.dl.rdf.CdrDeposit.stagingLocation;
@@ -60,13 +61,16 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.RecursiveAction;
 
+import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.rdf.model.Bag;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.vocabulary.DC;
 import org.apache.jena.vocabulary.RDF;
 import org.jdom2.Document;
 import org.jdom2.Element;
@@ -83,14 +87,20 @@ import edu.unc.lib.dcr.migration.premis.ContentPremisToRdfTransformer;
 import edu.unc.lib.dl.event.PremisLogger;
 import edu.unc.lib.dl.event.PremisLoggerFactory;
 import edu.unc.lib.dl.exceptions.RepositoryException;
+import edu.unc.lib.dl.fcrepo4.DepositRecord;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
 import edu.unc.lib.dl.fcrepo4.RepositoryPIDMinter;
+import edu.unc.lib.dl.fedora.ConflictException;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.model.DatastreamPids;
 import edu.unc.lib.dl.persist.services.versioning.DatastreamHistoryLog;
 import edu.unc.lib.dl.rdf.Cdr;
 import edu.unc.lib.dl.rdf.CdrDeposit;
+import edu.unc.lib.dl.rdf.Fcrepo4Repository;
 import edu.unc.lib.dl.rdf.Premis;
 import edu.unc.lib.dl.util.DateTimeUtil;
+import edu.unc.lib.dl.util.DepositMethod;
+import edu.unc.lib.dl.util.PackagingType;
 import edu.unc.lib.dl.util.SoftwareAgentConstants.SoftwareAgent;
 
 /**
@@ -105,6 +115,8 @@ public class ContentObjectTransformer extends RecursiveAction {
 
     private static final Logger log = getLogger(ContentObjectTransformer.class);
 
+    private static final Set<PID> createdDepositRecords = ConcurrentHashMap.newKeySet();
+
     private PathIndex pathIndex;
     private DepositModelManager modelManager;
     private boolean topLevelAsUnit;
@@ -112,6 +124,7 @@ public class ContentObjectTransformer extends RecursiveAction {
     private RepositoryPIDMinter pidMinter;
     private DepositDirectoryManager directoryManager;
     private PremisLoggerFactory premisLoggerFactory;
+    private RepositoryObjectFactory repoObjFactory;
 
     private PID originalPid;
     private PID newPid;
@@ -119,6 +132,8 @@ public class ContentObjectTransformer extends RecursiveAction {
     private Resource parentType;
 
     private Document foxml;
+
+    private boolean createMissingDepositRecords;
 
     /**
      *
@@ -169,12 +184,14 @@ public class ContentObjectTransformer extends RecursiveAction {
         Resource depResc = depositModel.getResource(newPid.getRepositoryPath());
 
         populateTimestamps(bxc3Resc, depResc);
-        populateOriginalDeposit(bxc3Resc, depResc);
+        try {
+            populateOriginalDeposit(bxc3Resc, depResc);
+        } catch (IOException e) {
+            throw new RepositoryException("Failed to create deposit record for " + originalPid, e);
+        }
 
         // set patron access
         ACLTransformationHelpers.transformPatronAccess(bxc3Resc, depResc, parentPid);
-
-        // TODO set title, based on dc title and/or label
 
         // copy most recent MODS to deposit directory
         extractMods();
@@ -194,13 +211,49 @@ public class ContentObjectTransformer extends RecursiveAction {
         }
     }
 
-    private void populateOriginalDeposit(Resource bxc3Resc, Resource depResc) {
+    private void populateOriginalDeposit(Resource bxc3Resc, Resource depResc) throws IOException {
         Statement originalDepStmt = bxc3Resc.getProperty(originalDeposit.getProperty());
         if (originalDepStmt == null) {
             return;
         }
         PID originalDepPid = convertBxc3RefToPid(DEPOSIT_RECORD_BASE, originalDepStmt.getResource().getURI());
         depResc.addProperty(CdrDeposit.originalDeposit, createResource(originalDepPid.getRepositoryPath()));
+
+        if (createMissingDepositRecords) {
+            Path depRecPath = pathIndex.getPath(originalDepPid, OBJECT_TYPE);
+            if (depRecPath == null && !createdDepositRecords.contains(originalDepPid)) {
+                Model depRecModel = createDefaultModel();
+                Resource depRecResc = depRecModel.getResource(originalDepPid.getRepositoryPath());
+                depRecResc.addProperty(RDF.type, Cdr.DepositRecord);
+                depRecResc.addLiteral(DC.title, "Deposit Record " + originalDepPid.getId());
+                // Set the date created for the deposit record to that of the object being migrated
+                String val = bxc3Resc.getProperty(FedoraProperty.createdDate.getProperty()).getString();
+                depRecResc.addProperty(Fcrepo4Repository.created, val, XSDDatatype.XSDdateTime);
+                depRecResc.addLiteral(Cdr.depositMethod, DepositMethod.BXC3_TO_5_MIGRATION_UTIL.getLabel());
+                depRecResc.addLiteral(Cdr.depositPackageType, PackagingType.BXC3_TO_5_MIGRATION.getUri());
+
+                Path transformedPremisPath = Files.createTempFile("premis", ".xml");
+                try {
+                    DepositRecord depRecord = repoObjFactory.createDepositRecord(originalDepPid, depRecModel);
+
+                    PremisLogger filePremisLogger = premisLoggerFactory.createPremisLogger(
+                            originalDepPid, transformedPremisPath.toFile());
+
+                    // Add migration event
+                    filePremisLogger.buildEvent(Premis.Ingestion)
+                            .addEventDetail("Deposit record generated by Boxc 3 to 5 migration")
+                            .addSoftwareAgent(SoftwareAgent.migrationUtil.getFullname())
+                            .writeAndClose();
+
+                    PremisLogger repoPremisLogger = premisLoggerFactory.createPremisLogger(depRecord);
+                    repoPremisLogger.createLog(Files.newInputStream(transformedPremisPath));
+                } catch (ConflictException e) {
+                    log.debug("Deposit record {} has already been created", originalDepPid);
+                } finally {
+                    Files.delete(transformedPremisPath);
+                }
+            }
+        }
     }
 
     private void populateContainerObject(Resource bxc3Resc, Resource resourceType, Model depositModel) {
@@ -496,5 +549,13 @@ public class ContentObjectTransformer extends RecursiveAction {
 
     public PID getPid() {
         return originalPid;
+    }
+
+    public void setRepositoryObjectFactory(RepositoryObjectFactory repoObjFactory) {
+        this.repoObjFactory = repoObjFactory;
+    }
+
+    public void setCreateMissingDepositRecords(boolean createMissingDepositRecords) {
+        this.createMissingDepositRecords = createMissingDepositRecords;
     }
 }

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformer.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformer.java
@@ -222,6 +222,8 @@ public class ContentObjectTransformer extends RecursiveAction {
         if (createMissingDepositRecords) {
             Path depRecPath = pathIndex.getPath(originalDepPid, OBJECT_TYPE);
             if (depRecPath == null && !createdDepositRecords.contains(originalDepPid)) {
+                createdDepositRecords.add(originalDepPid);
+                log.info("Generating deposit record for missing referenced deposit {}", originalDepPid.getId());
                 Model depRecModel = createDefaultModel();
                 Resource depRecResc = depRecModel.getResource(originalDepPid.getRepositoryPath());
                 depRecResc.addProperty(RDF.type, Cdr.DepositRecord);

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformerManager.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformerManager.java
@@ -30,6 +30,7 @@ import edu.unc.lib.dcr.migration.deposit.DepositModelManager;
 import edu.unc.lib.dcr.migration.paths.PathIndex;
 import edu.unc.lib.dcr.migration.utils.DisplayProgressUtil;
 import edu.unc.lib.dl.event.PremisLoggerFactory;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
 import edu.unc.lib.dl.fcrepo4.RepositoryPIDMinter;
 import edu.unc.lib.dl.fedora.PID;
 
@@ -45,9 +46,11 @@ public class ContentObjectTransformerManager {
     private DepositModelManager modelManager;
     private boolean topLevelAsUnit;
     private boolean generateIds;
+    private boolean createMissingDepositRecords;
     private RepositoryPIDMinter pidMinter;
     private DepositDirectoryManager directoryManager;
     private PremisLoggerFactory premisLoggerFactory;
+    private RepositoryObjectFactory repoObjFactory;
 
     private BlockingQueue<ContentObjectTransformer> createdTransformers;
     private AtomicInteger totalAdded;
@@ -77,6 +80,8 @@ public class ContentObjectTransformerManager {
         transformer.setPidMinter(pidMinter);
         transformer.setDirectoryManager(directoryManager);
         transformer.setPremisLoggerFactory(premisLoggerFactory);
+        transformer.setRepositoryObjectFactory(repoObjFactory);
+        transformer.setCreateMissingDepositRecords(createMissingDepositRecords);
 
         createdTransformers.add(transformer);
         totalAdded.incrementAndGet();
@@ -137,5 +142,13 @@ public class ContentObjectTransformerManager {
 
     public void setGenerateIds(boolean generateIds) {
         this.generateIds = generateIds;
+    }
+
+    public void setRepositoryObjectFactory(RepositoryObjectFactory repoObjFactory) {
+        this.repoObjFactory = repoObjFactory;
+    }
+
+    public void setCreateMissingDepositRecords(boolean createMissingDepositRecords) {
+        this.createMissingDepositRecords = createMissingDepositRecords;
     }
 }

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/deposit/DepositDirectoryManager.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/deposit/DepositDirectoryManager.java
@@ -29,6 +29,7 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import org.apache.commons.io.FileUtils;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.output.Format;
@@ -70,6 +71,14 @@ public class DepositDirectoryManager {
             Files.createDirectory(eventsDir);
         } catch (IOException e) {
             throw new RepositoryException("Failed to create deposit directory: " + depositDir, e);
+        }
+    }
+
+    public void cleanupDepositDirectory() {
+        try {
+            FileUtils.deleteDirectory(depositDir.toFile());
+        } catch (IOException e) {
+            throw new RepositoryException("Failed to cleanup deposit directory: " + depositDir, e);
         }
     }
 

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/deposit/DepositModelManager.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/deposit/DepositModelManager.java
@@ -90,9 +90,17 @@ public class DepositModelManager {
     }
 
     public synchronized Model getReadModel() {
-        String uri = depositPid.getURI();
         dataset.begin(ReadWrite.READ);
+        String uri = depositPid.getURI();
         return dataset.getNamedModel(uri);
+    }
+
+    public synchronized void removeModel() {
+        String uri = depositPid.getURI();
+        dataset.begin(ReadWrite.WRITE);
+        dataset.removeNamedModel(uri);
+        dataset.commit();
+        dataset.end();
     }
 
     /**

--- a/migration-util/src/test/java/edu/unc/lib/dcr/migration/AbstractTransformationIT.java
+++ b/migration-util/src/test/java/edu/unc/lib/dcr/migration/AbstractTransformationIT.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dcr.migration;
+
+import static edu.unc.lib.dcr.migration.MigrationConstants.toBxc3Uri;
+import static edu.unc.lib.dcr.migration.fcrepo3.ContentModelHelper.FedoraProperty.hasModel;
+import static edu.unc.lib.dcr.migration.fcrepo3.FoxmlDocumentHelpers.PREMIS_DS;
+import static edu.unc.lib.dcr.migration.premis.Premis2Constants.INITIATOR_ROLE;
+import static edu.unc.lib.dcr.migration.premis.Premis2Constants.VIRUS_CHECK_TYPE;
+import static edu.unc.lib.dcr.migration.premis.TestPremisEventHelpers.EVENT_DATE;
+import static edu.unc.lib.dcr.migration.premis.TestPremisEventHelpers.addAgent;
+import static edu.unc.lib.dcr.migration.premis.TestPremisEventHelpers.addEvent;
+import static edu.unc.lib.dcr.migration.premis.TestPremisEventHelpers.createPremisDoc;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.Files.newOutputStream;
+import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.util.Date;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.output.XMLOutputter;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+
+import edu.unc.lib.dcr.migration.fcrepo3.ContentModelHelper.ContentModel;
+import edu.unc.lib.dcr.migration.fcrepo3.FoxmlDocumentBuilder;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.util.DateTimeUtil;
+
+/**
+ * @author bbpennel
+ */
+public abstract class AbstractTransformationIT {
+    static {
+        System.setProperty("fcrepo.properties.management", "relaxed");
+    }
+
+    protected final static Date DEFAULT_CREATED_DATE = DateTimeUtil.parseUTCToDate(
+            FoxmlDocumentBuilder.DEFAULT_CREATED_DATE);
+    protected final static Date DEFAULT_MODIFIED_DATE = DateTimeUtil.parseUTCToDate(
+            FoxmlDocumentBuilder.DEFAULT_LAST_MODIFIED);
+
+    @Rule
+    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    protected Path objectsPath;
+
+    protected Path datastreamsPath;
+
+    protected Path serializeFoxml(PID pid, Document doc) throws IOException {
+        Path xmlPath = objectsPath.resolve("uuid_" + pid.getId());
+        OutputStream outStream = newOutputStream(xmlPath);
+        new XMLOutputter().output(doc, outStream);
+        return xmlPath;
+    }
+
+    protected Model createModelWithTypes(PID pid, ContentModel... models) {
+        Model model = createDefaultModel();
+        Resource resc = model.getResource(toBxc3Uri(pid));
+        for (ContentModel contentModel : models) {
+            resc.addProperty(hasModel.getProperty(), contentModel.getResource());
+        }
+        return model;
+    }
+
+    protected void addPremisLog(PID originalPid) throws IOException {
+        Document premisDoc = createPremisDoc(originalPid);
+        String detail = "virus scan";
+        Element eventEl = addEvent(premisDoc, VIRUS_CHECK_TYPE, detail, EVENT_DATE);
+        addAgent(eventEl, "Name", INITIATOR_ROLE, "virusscanner");
+
+        String premisDsName = "uuid_" + originalPid.getId() + "+" + PREMIS_DS + "+" + PREMIS_DS + ".0";
+        Path xmlPath = datastreamsPath.resolve(premisDsName);
+        OutputStream outStream = newOutputStream(xmlPath);
+        new XMLOutputter().output(premisDoc, outStream);
+    }
+
+    protected Path writeDatastreamFile(PID pid, String dsName, String content) throws IOException {
+        Path dsPath = datastreamsPath.resolve("uuid_" + pid.getId() + "+" + dsName + "+" + dsName + ".0");
+        FileUtils.writeStringToFile(dsPath.toFile(), content, UTF_8);
+        return dsPath;
+    }
+}

--- a/migration-util/src/test/java/edu/unc/lib/dcr/migration/TransformContentCommandIT.java
+++ b/migration-util/src/test/java/edu/unc/lib/dcr/migration/TransformContentCommandIT.java
@@ -1,0 +1,324 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dcr.migration;
+
+import static edu.unc.lib.dcr.migration.MigrationConstants.toBxc3Uri;
+import static edu.unc.lib.dcr.migration.premis.TestPremisEventHelpers.listEventResources;
+import static org.apache.jena.rdf.model.ResourceFactory.createResource;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.jena.rdf.model.Bag;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.vocabulary.RDF;
+import org.jdom2.Document;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import edu.unc.lib.dcr.migration.deposit.DepositModelManager;
+import edu.unc.lib.dcr.migration.fcrepo3.ContentModelHelper.ContentModel;
+import edu.unc.lib.dcr.migration.fcrepo3.ContentModelHelper.Relationship;
+import edu.unc.lib.dcr.migration.fcrepo3.DatastreamVersion;
+import edu.unc.lib.dcr.migration.fcrepo3.FoxmlDocumentBuilder;
+import edu.unc.lib.dcr.migration.fcrepo3.FoxmlDocumentHelpers;
+import edu.unc.lib.dl.event.PremisLogger;
+import edu.unc.lib.dl.fcrepo4.DepositRecord;
+import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
+import edu.unc.lib.dl.fcrepo4.RepositoryPIDMinter;
+import edu.unc.lib.dl.fcrepo4.RepositoryPathConstants;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.rdf.Cdr;
+import edu.unc.lib.dl.rdf.CdrDeposit;
+import edu.unc.lib.dl.rdf.Premis;
+import edu.unc.lib.dl.rdf.Rdf;
+import edu.unc.lib.dl.test.TestHelper;
+import edu.unc.lib.dl.util.SoftwareAgentConstants.SoftwareAgent;
+import picocli.CommandLine;
+
+/**
+ * @author bbpennel
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextHierarchy({
+    @ContextConfiguration("/spring-test/test-fedora-container.xml"),
+    @ContextConfiguration("/spring-test/cdr-client-container.xml")
+})
+public class TransformContentCommandIT extends AbstractTransformationIT {
+    private static final Logger log = getLogger(TransformContentCommandIT.class);
+
+    private static final String BINARY_CONTENT = "Binary stuff";
+    private static final String BINARY_MD5 = "74dec3bdb7c0cda2c3d501c145d73723";
+
+    @Autowired
+    private RepositoryObjectLoader repoObjLoader;
+    @Autowired
+    private RepositoryPIDMinter pidMinter;
+
+    final PrintStream originalOut = System.out;
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    private PID bxc3Pid;
+
+    CommandLine migrationCommand;
+
+    private File tdbDir;
+    private File depositBaseDir;
+
+    private String output;
+
+    @Before
+    public void setUp() throws Exception {
+        TestHelper.setContentBase("http://localhost:48085/rest");
+
+        out.reset();
+        System.setOut(new PrintStream(out));
+
+        datastreamsPath = tmpFolder.newFolder("datastreams").toPath();
+        objectsPath = tmpFolder.newFolder("objects").toPath();
+
+        bxc3Pid = pidMinter.mintContentPid();
+
+        tdbDir = tmpFolder.newFolder("tdb");
+        depositBaseDir = tmpFolder.newFolder("deposits");
+        File dbFile = tmpFolder.newFile("index_db");
+        System.setProperty("dcr.deposit.dir", depositBaseDir.getAbsolutePath());
+        System.setProperty("dcr.tdb.dir", tdbDir.getAbsolutePath());
+        System.setProperty("dcr.migration.index.url", dbFile.toPath().toUri().toString());
+        System.setProperty("dcr.it.tdr.ingestSource", tmpFolder.getRoot().getAbsolutePath());
+
+        migrationCommand = new CommandLine(new MigrationCLI());
+
+        // Set the application context path for the test environment
+        Map<String, CommandLine> subs = migrationCommand.getSubcommands();
+        CommandLine transformCommand = subs.get("tc");
+
+        TransformContentCommand tcCommand = (TransformContentCommand) transformCommand.getCommand();
+        Path contextPath = Paths.get("src", "test", "resources", "spring-test",
+                "cdr-client-container.xml");
+        tcCommand.setApplicationContextPath(contextPath.toUri().toString());
+
+        output = null;
+    }
+
+    @After
+    public void cleanup() {
+        System.setOut(originalOut);
+        System.clearProperty("dcr.tdb.dir");
+        System.clearProperty("dcr.deposit.dir");
+        System.clearProperty("dcr.migration.index.url");
+        System.clearProperty("dcr.it.tdr.ingestSource");
+    }
+
+    @Test
+    public void transformSimpleStructure() throws Exception {
+        PID filePid = pidMinter.mintContentPid();
+        Path dsPath = writeDatastreamFile(filePid, FoxmlDocumentHelpers.ORIGINAL_DS, BINARY_CONTENT);
+        DatastreamVersion ds0 = new DatastreamVersion(BINARY_MD5,
+                FoxmlDocumentHelpers.ORIGINAL_DS, "0",
+                FoxmlDocumentBuilder.DEFAULT_CREATED_DATE,
+                Integer.toString(BINARY_CONTENT.length()),
+                "text/plain",
+                null);
+
+        Model fileModel = createModelWithTypes(filePid, ContentModel.SIMPLE);
+
+        Document foxml2 = new FoxmlDocumentBuilder(filePid, "file")
+                .relsExtModel(fileModel)
+                .withDatastreamVersion(ds0)
+                .build();
+        serializeFoxml(filePid, foxml2);
+
+        addPremisLog(filePid);
+
+        Model folderModel = createModelWithTypes(bxc3Pid, ContentModel.CONTAINER);
+        Resource folderResc = folderModel.getResource(toBxc3Uri(bxc3Pid));
+        Resource fileResc = folderModel.getResource(toBxc3Uri(filePid));
+        folderResc.addProperty(Relationship.contains.getProperty(), fileResc);
+
+        Document foxml1 = new FoxmlDocumentBuilder(bxc3Pid, "folder")
+                .relsExtModel(folderModel)
+                .build();
+        serializeFoxml(bxc3Pid, foxml1);
+
+        addPremisLog(bxc3Pid);
+
+        indexFiles();
+
+        String[] args = new String[] { "tc", bxc3Pid.getId() };
+        executeExpectSuccess(args);
+
+        PID depositPid = extractDepositPid(output);
+
+        assertTrue("Expected one transformation successful",
+                output.contains(" 2/2 "));
+        assertTrue("Expected transformation completed message",
+                output.contains("Finished transformation"));
+
+        DepositModelManager modelManager = new DepositModelManager(depositPid, tdbDir.toString());
+        Model depModel = modelManager.getReadModel();
+
+        Resource resultFolderResc = depModel.getResource(bxc3Pid.getRepositoryPath());
+        assertTrue(resultFolderResc.hasProperty(RDF.type, Cdr.Folder));
+        assertTrue(resultFolderResc.hasProperty(CdrDeposit.createTime, FoxmlDocumentBuilder.DEFAULT_CREATED_DATE));
+
+        Bag resultWorkBag = depModel.getBag(filePid.getRepositoryPath());
+        assertTrue(resultWorkBag.hasProperty(RDF.type, Cdr.Work));
+        assertTrue(resultWorkBag.hasProperty(CdrDeposit.createTime, FoxmlDocumentBuilder.DEFAULT_CREATED_DATE));
+
+        List<RDFNode> bagChildren = resultWorkBag.iterator().toList();
+        Resource resultFileResc = (Resource) bagChildren.get(0);
+        assertTrue(resultFileResc.hasProperty(RDF.type, Cdr.FileObject));
+        assertTrue(resultFileResc.hasLiteral(CdrDeposit.md5sum, BINARY_MD5));
+        assertTrue(resultFileResc.hasLiteral(CdrDeposit.stagingLocation, dsPath.toUri().toString()));
+
+        assertTrue("Deposit directory must exist", new File(depositBaseDir, depositPid.getId()).exists());
+    }
+
+    @Test
+    public void transformDryRun() throws Exception {
+        Model folderModel = createModelWithTypes(bxc3Pid, ContentModel.CONTAINER);
+
+        Document foxml1 = new FoxmlDocumentBuilder(bxc3Pid, "folder")
+                .relsExtModel(folderModel)
+                .build();
+        serializeFoxml(bxc3Pid, foxml1);
+
+        addPremisLog(bxc3Pid);
+
+        indexFiles();
+
+        String[] args = new String[] { "tc", bxc3Pid.getId(),
+                "-n"};
+        executeExpectSuccess(args);
+
+        PID depositPid = extractDepositPid(output);
+
+        assertTrue("Expected one transformation successful",
+                output.contains(" 1/1 "));
+        assertTrue("Expected transformation completed message",
+                output.contains("Finished transformation"));
+        assertTrue("Expected dry run message",
+                output.contains("Dry run, deposit model not saved"));
+
+        DepositModelManager modelManager = new DepositModelManager(depositPid, tdbDir.toString());
+        Model depModel = modelManager.getReadModel();
+
+        assertTrue("No deposit model should have been produced", depModel.isEmpty());
+
+        assertFalse("Deposit directory must not exist", new File(depositBaseDir, depositPid.getId()).exists());
+    }
+
+    @Test
+    public void transformGenerateMissingDepositRecord() throws Exception {
+        PID mysteryDepositPid = pidMinter.mintDepositRecordPid();
+
+        Model folderModel = createModelWithTypes(bxc3Pid, ContentModel.CONTAINER);
+        Resource folderResc = folderModel.getResource(toBxc3Uri(bxc3Pid));
+        folderResc.addProperty(Relationship.originalDeposit.getProperty(),
+                createResource(toBxc3Uri(mysteryDepositPid)));
+        Document foxml1 = new FoxmlDocumentBuilder(bxc3Pid, "folder")
+                .relsExtModel(folderModel)
+                .build();
+        serializeFoxml(bxc3Pid, foxml1);
+
+        indexFiles();
+
+        String[] args = new String[] { "tc", bxc3Pid.getId(),
+                "--missing-deposit-records"};
+        executeExpectSuccess(args);
+
+        PID depositPid = extractDepositPid(output);
+
+        assertTrue("Expected one transformation successful",
+                output.contains(" 1/1 "));
+        assertTrue("Expected transformation completed message",
+                output.contains("Finished transformation"));
+
+        DepositModelManager modelManager = new DepositModelManager(depositPid, tdbDir.toString());
+        Model depModel = modelManager.getReadModel();
+
+        Resource resultFolderResc = depModel.getResource(bxc3Pid.getRepositoryPath());
+        assertTrue(resultFolderResc.hasProperty(RDF.type, Cdr.Folder));
+        assertTrue(resultFolderResc.hasProperty(CdrDeposit.createTime, FoxmlDocumentBuilder.DEFAULT_CREATED_DATE));
+        assertTrue(resultFolderResc.hasProperty(CdrDeposit.originalDeposit,
+                createResource(mysteryDepositPid.getRepositoryPath())));
+
+        DepositRecord generatedRec = repoObjLoader.getDepositRecord(mysteryDepositPid);
+        assertEquals(DEFAULT_CREATED_DATE, generatedRec.getCreatedDate());
+        PremisLogger premisLog = generatedRec.getPremisLog();
+        Model eventsModel = premisLog.getEventsModel();
+        List<Resource> eventRescs = listEventResources(mysteryDepositPid, eventsModel);
+        assertEquals(1, eventRescs.size());
+
+        Resource ingestEventResc = eventRescs.get(0);
+        assertTrue(ingestEventResc.hasProperty(RDF.type, Premis.Ingestion));
+        assertTrue("Missing migration event note",
+                ingestEventResc.hasProperty(Premis.note, "Deposit record generated by Boxc 3 to 5 migration"));
+        Resource agentResc = ingestEventResc.getProperty(Premis.hasEventRelatedAgentExecutor).getResource();
+        assertEquals(SoftwareAgent.migrationUtil.getFullname(), agentResc.getProperty(Rdf.label).getString());
+    }
+
+    private PID extractDepositPid(String output) {
+        String fieldText = "Populating deposit: ";
+        int start = output.indexOf(fieldText);
+        if (start == -1) {
+            fail("No deposit id output");
+        }
+        start += fieldText.length();
+        int end = output.indexOf("\n", start);
+        String id = output.substring(start, end);
+        return PIDs.get(RepositoryPathConstants.DEPOSIT_RECORD_BASE, id);
+    }
+
+    private void indexFiles() {
+        String[] indexArgs = new String[] { "pi", "populate",
+                objectsPath.toString(),
+                datastreamsPath.toString(),
+                "-l" };
+        migrationCommand.execute(indexArgs);
+    }
+
+    private void executeExpectSuccess(String[] args) {
+        int result = migrationCommand.execute(args);
+        output = out.toString();
+        if (result != 0) {
+            System.setOut(originalOut);
+            log.error(output);
+            fail("Expected command to result in success: " + String.join(" ", args));
+        }
+    }
+}

--- a/migration-util/src/test/java/edu/unc/lib/dcr/migration/TransformDepositRecordsCommandIT.java
+++ b/migration-util/src/test/java/edu/unc/lib/dcr/migration/TransformDepositRecordsCommandIT.java
@@ -190,7 +190,7 @@ public class TransformDepositRecordsCommandIT extends AbstractDepositRecordTrans
         Resource resc = bxc3Model.getResource(toBxc3Uri(bxc3Pid));
         resc.addLiteral(CDRProperty.depositedOnBehalfOf.getProperty(), DEPOSITOR);
 
-        writeManifestFile(bxc3Pid, MANIFEST_NAME, MANIFEST_CONTENT);
+        writeDatastreamFile(bxc3Pid, MANIFEST_NAME, MANIFEST_CONTENT);
         DatastreamVersion manifest0 = new DatastreamVersion(null,
                 MANIFEST_NAME, "0",
                 FoxmlDocumentBuilder.DEFAULT_CREATED_DATE,

--- a/migration-util/src/test/java/edu/unc/lib/dcr/migration/deposit/AbstractDepositRecordTransformationIT.java
+++ b/migration-util/src/test/java/edu/unc/lib/dcr/migration/deposit/AbstractDepositRecordTransformationIT.java
@@ -15,104 +15,33 @@
  */
 package edu.unc.lib.dcr.migration.deposit;
 
-import static edu.unc.lib.dcr.migration.MigrationConstants.toBxc3Uri;
-import static edu.unc.lib.dcr.migration.fcrepo3.ContentModelHelper.FedoraProperty.hasModel;
-import static edu.unc.lib.dcr.migration.fcrepo3.FoxmlDocumentHelpers.PREMIS_DS;
-import static edu.unc.lib.dcr.migration.premis.Premis2Constants.INITIATOR_ROLE;
-import static edu.unc.lib.dcr.migration.premis.Premis2Constants.VIRUS_CHECK_TYPE;
-import static edu.unc.lib.dcr.migration.premis.TestPremisEventHelpers.EVENT_DATE;
-import static edu.unc.lib.dcr.migration.premis.TestPremisEventHelpers.addAgent;
-import static edu.unc.lib.dcr.migration.premis.TestPremisEventHelpers.addEvent;
-import static edu.unc.lib.dcr.migration.premis.TestPremisEventHelpers.createPremisDoc;
 import static edu.unc.lib.dcr.migration.premis.TestPremisEventHelpers.getEventByType;
 import static edu.unc.lib.dcr.migration.premis.TestPremisEventHelpers.listEventResources;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.nio.file.Files.newOutputStream;
-import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.file.Path;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
-import org.jdom2.Document;
-import org.jdom2.Element;
-import org.jdom2.output.XMLOutputter;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
 
-import edu.unc.lib.dcr.migration.fcrepo3.ContentModelHelper.ContentModel;
-import edu.unc.lib.dcr.migration.fcrepo3.FoxmlDocumentBuilder;
+import edu.unc.lib.dcr.migration.AbstractTransformationIT;
 import edu.unc.lib.dl.event.PremisLogger;
 import edu.unc.lib.dl.fcrepo4.BinaryObject;
 import edu.unc.lib.dl.fcrepo4.DepositRecord;
-import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.rdf.Premis;
 import edu.unc.lib.dl.rdf.Rdf;
-import edu.unc.lib.dl.util.DateTimeUtil;
 import edu.unc.lib.dl.util.SoftwareAgentConstants.SoftwareAgent;
 
 /**
  * @author bbpennel
  */
-public abstract class AbstractDepositRecordTransformationIT {
-    static {
-        System.setProperty("fcrepo.properties.management", "relaxed");
-    }
-
-    protected final static Date DEFAULT_CREATED_DATE = DateTimeUtil.parseUTCToDate(
-            FoxmlDocumentBuilder.DEFAULT_CREATED_DATE);
-    protected final static Date DEFAULT_MODIFIED_DATE = DateTimeUtil.parseUTCToDate(
-            FoxmlDocumentBuilder.DEFAULT_LAST_MODIFIED);
-
-    @Rule
-    public final TemporaryFolder tmpFolder = new TemporaryFolder();
-
-    protected Path objectsPath;
-
-    protected Path datastreamsPath;
-
-    protected Path serializeFoxml(PID pid, Document doc) throws IOException {
-        Path xmlPath = objectsPath.resolve("uuid_" + pid.getId());
-        OutputStream outStream = newOutputStream(xmlPath);
-        new XMLOutputter().output(doc, outStream);
-        return xmlPath;
-    }
-
-    protected Path writeManifestFile(PID pid, String dsName, String content) throws IOException {
-        Path dsPath = datastreamsPath.resolve("uuid_" + pid.getId() + "+" + dsName + "+" + dsName + ".0");
-        FileUtils.writeStringToFile(dsPath.toFile(), content, UTF_8);
-        return dsPath;
-    }
-
-    protected Model createModelWithTypes(PID pid, ContentModel... models) {
-        Model model = createDefaultModel();
-        Resource resc = model.getResource(toBxc3Uri(pid));
-        for (ContentModel contentModel : models) {
-            resc.addProperty(hasModel.getProperty(), contentModel.getResource());
-        }
-        return model;
-    }
-
-    protected void addPremisLog(PID originalPid) throws IOException {
-        Document premisDoc = createPremisDoc(originalPid);
-        String detail = "virus scan";
-        Element eventEl = addEvent(premisDoc, VIRUS_CHECK_TYPE, detail, EVENT_DATE);
-        addAgent(eventEl, "Name", INITIATOR_ROLE, "virusscanner");
-
-        String premisDsName = "uuid_" + originalPid.getId() + "+" + PREMIS_DS + "+" + PREMIS_DS + ".0";
-        Path xmlPath = datastreamsPath.resolve(premisDsName);
-        OutputStream outStream = newOutputStream(xmlPath);
-        new XMLOutputter().output(premisDoc, outStream);
-    }
+public abstract class AbstractDepositRecordTransformationIT extends AbstractTransformationIT {
 
     protected BinaryObject getManifestByName(List<BinaryObject> binList, String dsName) {
         return binList.stream()

--- a/migration-util/src/test/java/edu/unc/lib/dcr/migration/deposit/DepositRecordTransformerIT.java
+++ b/migration-util/src/test/java/edu/unc/lib/dcr/migration/deposit/DepositRecordTransformerIT.java
@@ -231,7 +231,7 @@ public class DepositRecordTransformerIT extends AbstractDepositRecordTransformat
 
         String manifest0Name = "DATA_MANIFEST0";
         String manifest0Content = "content for m0";
-        writeManifestFile(bxc3Pid, manifest0Name, manifest0Content);
+        writeDatastreamFile(bxc3Pid, manifest0Name, manifest0Content);
         DatastreamVersion manifest0 = new DatastreamVersion(null,
                 manifest0Name, "0",
                 FoxmlDocumentBuilder.DEFAULT_CREATED_DATE,
@@ -241,7 +241,7 @@ public class DepositRecordTransformerIT extends AbstractDepositRecordTransformat
 
         String manifest1Name = "DATA_MANIFEST1";
         String manifest1Content = "additional content";
-        writeManifestFile(bxc3Pid, manifest1Name, manifest1Content);
+        writeDatastreamFile(bxc3Pid, manifest1Name, manifest1Content);
         DatastreamVersion manifest1 = new DatastreamVersion(null,
                 manifest1Name, "0",
                 FoxmlDocumentBuilder.DEFAULT_LAST_MODIFIED,


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2718

* Transformation option to generate referenced deposit records which don't exist as fedora objects
* Option for performing dry run of transformation
* Integration tests
* Minor updates for fedora fault resolution and new packaging type for migrations