### PR TITLE
BXC-2623 - Fix excessive indexing after ingest

### DIFF
--- a/deposit/src/main/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJob.java
@@ -15,6 +15,7 @@
  */
 package edu.unc.lib.deposit.fcrepo4;
 
+import static edu.unc.lib.deposit.work.DepositGraphUtils.getChildIterator;
 import static edu.unc.lib.dl.model.DatastreamPids.getDatastreamHistoryPid;
 import static edu.unc.lib.dl.model.DatastreamPids.getTechnicalMetadataPid;
 import static edu.unc.lib.dl.model.DatastreamType.TECHNICAL_METADATA;

--- a/deposit/src/main/java/edu/unc/lib/deposit/fcrepo4/StaffOnlyPermissionJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/fcrepo4/StaffOnlyPermissionJob.java
@@ -15,6 +15,7 @@
  */
 package edu.unc.lib.deposit.fcrepo4;
 
+import static edu.unc.lib.deposit.work.DepositGraphUtils.getChildIterator;
 import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.AUTHENTICATED_PRINC;
 import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.PUBLIC_PRINC;
 
@@ -27,9 +28,9 @@ import org.apache.jena.rdf.model.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import edu.unc.lib.dl.util.RedisWorkerConstants.DepositField;
 import edu.unc.lib.deposit.work.AbstractDepositJob;
 import edu.unc.lib.dl.rdf.CdrAcl;
+import edu.unc.lib.dl.util.RedisWorkerConstants.DepositField;
 
 /**
  * Marks file server ingests "staff only", if the appropriate flag is set on the deposit

--- a/deposit/src/main/java/edu/unc/lib/deposit/normalize/AssignStorageLocationsJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/normalize/AssignStorageLocationsJob.java
@@ -15,6 +15,7 @@
  */
 package edu.unc.lib.deposit.normalize;
 
+import static edu.unc.lib.deposit.work.DepositGraphUtils.getChildIterator;
 import static java.util.Arrays.asList;
 
 import java.util.HashSet;

--- a/deposit/src/main/java/edu/unc/lib/deposit/normalize/NormalizeFileObjectsJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/normalize/NormalizeFileObjectsJob.java
@@ -15,6 +15,7 @@
  */
 package edu.unc.lib.deposit.normalize;
 
+import static edu.unc.lib.deposit.work.DepositGraphUtils.getChildIterator;
 import static edu.unc.lib.dl.rdf.CdrDeposit.stagingLocation;
 
 import java.io.File;

--- a/deposit/src/main/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJob.java
@@ -15,6 +15,7 @@
  */
 package edu.unc.lib.deposit.transfer;
 
+import static edu.unc.lib.deposit.work.DepositGraphUtils.getChildIterator;
 import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.DEPOSIT_RECORD_BASE;
 import static edu.unc.lib.dl.model.DatastreamPids.getDatastreamHistoryPid;
 import static edu.unc.lib.dl.model.DatastreamPids.getDepositManifestPid;

--- a/deposit/src/main/java/edu/unc/lib/deposit/validate/ValidateContentModelJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/validate/ValidateContentModelJob.java
@@ -15,6 +15,7 @@
  */
 package edu.unc.lib.deposit.validate;
 
+import static edu.unc.lib.deposit.work.DepositGraphUtils.getChildIterator;
 import static edu.unc.lib.dl.rdf.CdrDeposit.stagingLocation;
 
 import java.util.ArrayList;

--- a/deposit/src/main/java/edu/unc/lib/deposit/validate/ValidateDestinationJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/validate/ValidateDestinationJob.java
@@ -15,6 +15,7 @@
  */
 package edu.unc.lib.deposit.validate;
 
+import static edu.unc.lib.deposit.work.DepositGraphUtils.getChildIterator;
 import static java.util.Arrays.asList;
 
 import java.util.ArrayList;

--- a/deposit/src/main/java/edu/unc/lib/deposit/validate/VerifyObjectsAreInFedoraService.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/validate/VerifyObjectsAreInFedoraService.java
@@ -21,9 +21,6 @@ import java.util.Collection;
 import java.util.List;
 
 import org.apache.http.HttpStatus;
-import org.apache.jena.rdf.model.NodeIterator;
-import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.vocabulary.RDF;
 import org.fcrepo.client.FcrepoClient;
 import org.fcrepo.client.FcrepoOperationFailedException;
 import org.fcrepo.client.FcrepoResponse;
@@ -80,23 +77,6 @@ public class VerifyObjectsAreInFedoraService {
 
     public void setFcrepoClient(FcrepoClient fcrepoClient) {
         this.fcrepoClient = fcrepoClient;
-    }
-
-    /**
-     * Return an iterator for the children of the given resource, based on what
-     * type of container it is.
-     *
-     * @param resc
-     * @return
-     */
-    private NodeIterator getChildIterator(Resource resc) {
-        if (resc.hasProperty(RDF.type, RDF.Bag)) {
-            return resc.getModel().getBag(resc).iterator();
-        } else if (resc.hasProperty(RDF.type, RDF.Seq)) {
-            return resc.getModel().getSeq(resc).iterator();
-        } else {
-            return null;
-        }
     }
 
     private boolean objectExists(PID pid) {

--- a/deposit/src/main/java/edu/unc/lib/deposit/work/AbstractDepositJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/work/AbstractDepositJob.java
@@ -41,7 +41,6 @@ import org.apache.jena.query.ReadWrite;
 import org.apache.jena.rdf.model.Bag;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.NodeIterator;
 import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.RDFNode;
 import org.apache.jena.rdf.model.Resource;
@@ -49,7 +48,6 @@ import org.apache.jena.rdf.model.Selector;
 import org.apache.jena.rdf.model.SimpleSelector;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
-import org.apache.jena.vocabulary.RDF;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -466,23 +464,6 @@ public abstract class AbstractDepositJob implements Runnable {
         }
 
         return results;
-    }
-
-    /**
-     * Return an iterator for the children of the given resource, based on what
-     * type of container it is.
-     *
-     * @param resc
-     * @return
-     */
-    protected NodeIterator getChildIterator(Resource resc) {
-        if (resc.hasProperty(RDF.type, RDF.Bag)) {
-            return resc.getModel().getBag(resc).iterator();
-        } else if (resc.hasProperty(RDF.type, RDF.Seq)) {
-            return resc.getModel().getSeq(resc).iterator();
-        } else {
-            return null;
-        }
     }
 
     protected BinaryTransferSession getTransferSession(Model depositModel) {

--- a/deposit/src/main/java/edu/unc/lib/deposit/work/DepositGraphUtils.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/work/DepositGraphUtils.java
@@ -28,7 +28,7 @@ import org.apache.jena.vocabulary.RDF;
 import edu.unc.lib.dl.fedora.PID;
 
 /**
- * 
+ *
  * @author count0
  *
  */
@@ -36,13 +36,19 @@ public class DepositGraphUtils {
     private DepositGraphUtils() {
     }
 
-    private static void addChildren(Resource c, List<Resource> result) {
-        NodeIterator iterator = null;
-        if (c.hasProperty(RDF.type, RDF.Bag)) {
-            iterator = c.getModel().getBag(c).iterator();
-        } else if (c.hasProperty(RDF.type, RDF.Seq)) {
-            iterator = c.getModel().getSeq(c).iterator();
+    public static NodeIterator getChildIterator(Resource resc) {
+        if (resc.hasProperty(RDF.type, RDF.Bag)) {
+            return resc.getModel().getBag(resc).iterator();
+        } else if (resc.hasProperty(RDF.type, RDF.Seq)) {
+            return resc.getModel().getSeq(resc).iterator();
         } else {
+            return null;
+        }
+    }
+
+    private static void addChildren(Resource c, List<Resource> result) {
+        NodeIterator iterator = getChildIterator(c);
+        if (iterator == null) {
             return;
         }
 

--- a/deposit/src/main/java/edu/unc/lib/deposit/work/DepositSupervisor.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/work/DepositSupervisor.java
@@ -29,7 +29,6 @@ import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
@@ -38,6 +37,7 @@ import org.apache.jena.query.Dataset;
 import org.apache.jena.query.ReadWrite;
 import org.apache.jena.rdf.model.Bag;
 import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.NodeIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -799,9 +799,11 @@ public class DepositSupervisor implements WorkerListener {
 
             PID destPid = PIDs.get(depositStatus.get(DepositField.containerId.name()));
 
-            List<String> added = new ArrayList<>();
-            DepositGraphUtils.walkChildrenDepthFirst(depositBag, added, true);
-            List<PID> addedPids = added.stream().map(p -> PIDs.get(p)).collect(Collectors.toList());
+            List<PID> addedPids = new ArrayList<>();
+            NodeIterator childIt = DepositGraphUtils.getChildIterator(depositBag);
+            while (childIt.hasNext()) {
+                addedPids.add(PIDs.get(childIt.next().asResource().getURI()));
+            }
 
             // Send message indicating the deposit has completed
             opsMessageSender.sendAddOperation(depositStatus.get(DepositField.depositorName.name()),

--- a/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/action/UpdateObjectAction.java
+++ b/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/action/UpdateObjectAction.java
@@ -15,6 +15,9 @@
  */
 package edu.unc.lib.dl.data.ingest.solr.action;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import edu.unc.lib.dl.data.ingest.solr.SolrUpdateRequest;
 import edu.unc.lib.dl.data.ingest.solr.exception.IndexingException;
 import edu.unc.lib.dl.data.ingest.solr.indexing.DocumentIndexingPackage;
@@ -26,9 +29,11 @@ import edu.unc.lib.dl.data.ingest.solr.indexing.DocumentIndexingPackage;
  *
  */
 public class UpdateObjectAction extends AbstractIndexingAction {
+    final Logger log = LoggerFactory.getLogger(UpdateObjectAction.class);
 
     @Override
     public void performAction(SolrUpdateRequest updateRequest) throws IndexingException {
+        log.debug("Indexing object {}", updateRequest.getPid());
         // Retrieve object metadata from Fedora and add to update document list
         DocumentIndexingPackage dip = updateRequest.getDocumentIndexingPackage();
         if (dip == null) {


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2712
* Only submits top level objects ingested as part of the post ingest ADD message, as each object included is recursively indexed, regardless of whether they contain each other.
* Move common method to helper class