### PR TITLE
BXC-2426 - Deregister destroyed files from longleaf

### DIFF
--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/destroy/DestroyObjectsProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/destroy/DestroyObjectsProcessor.java
@@ -36,6 +36,7 @@ import edu.unc.lib.dl.persist.services.destroy.DestroyObjectsJob;
 import edu.unc.lib.dl.persist.services.destroy.DestroyObjectsRequest;
 import edu.unc.lib.dl.search.solr.service.ObjectPathFactory;
 import edu.unc.lib.dl.services.IndexingMessageSender;
+import edu.unc.lib.dl.services.MessageSender;
 
 /**
  * Processor which handles messages requesting the destruction of objects.
@@ -59,6 +60,7 @@ public class DestroyObjectsProcessor implements Processor {
     private StorageLocationManager locManager;
     private BinaryTransferService transferService;
     private IndexingMessageSender indexingMessageSender;
+    private MessageSender binaryDestroyedMessageSender;
 
     @Override
     public void process(Exchange exchange) throws Exception {
@@ -82,6 +84,7 @@ public class DestroyObjectsProcessor implements Processor {
         job.setBinaryTransferService(transferService);
         job.setStorageLocationManager(locManager);
         job.setIndexingMessageSender(indexingMessageSender);
+        job.setBinaryDestroyedMessageSender(binaryDestroyedMessageSender);
         return job;
     }
 
@@ -123,5 +126,9 @@ public class DestroyObjectsProcessor implements Processor {
 
     public void setIndexingMessageSender(IndexingMessageSender indexingMessageSender) {
         this.indexingMessageSender = indexingMessageSender;
+    }
+
+    public void setBinaryDestroyedMessageSender(MessageSender binaryDestroyedMessageSender) {
+        this.binaryDestroyedMessageSender = binaryDestroyedMessageSender;
     }
 }

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/longleaf/AbstractLongleafProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/longleaf/AbstractLongleafProcessor.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.services.camel.longleaf;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+
+import org.apache.camel.Processor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Abstract processor for executing longleaf commands
+ *
+ * @author bbpennel
+ */
+public abstract class AbstractLongleafProcessor implements Processor {
+    private static final Logger log = LoggerFactory.getLogger(AbstractLongleafProcessor.class);
+    protected static final Logger longleafLog = LoggerFactory.getLogger("longleaf");
+
+    private String longleafBaseCommand;
+
+    /**
+     * Execute a command in longleaf, using the configured base command
+     *
+     * @param command longleaf command
+     * @param pipedContent content to pipe into the command. Optional.
+     * @return exit code from register command
+     */
+    protected int executeCommand(String command, String pipedContent) {
+        try {
+            // only register binaries with md5sum
+            String longleafCommmand = longleafBaseCommand + " " + command;
+            log.debug("Executing longleaf commandlongleaf: {}", longleafCommmand);
+
+            Process process = Runtime.getRuntime().exec(longleafCommmand);
+            // Pipe the manifest data into the command
+            if (pipedContent != null) {
+                try (OutputStream pipeOut = process.getOutputStream()) {
+                    pipeOut.write(pipedContent.getBytes(UTF_8));
+                }
+            }
+
+            int exitVal = process.waitFor();
+
+            // log longleaf output
+            String line;
+            try (BufferedReader in = new BufferedReader(
+                    new InputStreamReader(process.getInputStream()))) {
+                while ((line = in.readLine()) != null) {
+                    longleafLog.info(line);
+                }
+            }
+            try (BufferedReader err = new BufferedReader(
+                    new InputStreamReader(process.getErrorStream()))) {
+                while ((line = err.readLine()) != null) {
+                    longleafLog.error(line);
+                }
+            }
+
+            return exitVal;
+        } catch (IOException e) {
+            log.error("IOException while executing longleaf command: {}", command, e);
+        } catch (InterruptedException e) {
+            log.error("InterruptedException while executing longleaf command: {}", command, e);
+        }
+
+        return 1;
+    }
+
+    public void setLongleafBaseCommand(String longleafBaseCommand) {
+        this.longleafBaseCommand = longleafBaseCommand;
+    }
+}

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/longleaf/DeregisterLongleafProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/longleaf/DeregisterLongleafProcessor.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.services.camel.longleaf;
+
+import java.net.URI;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import edu.unc.lib.dl.fedora.ServiceException;
+import edu.unc.lib.dl.metrics.HistogramFactory;
+import edu.unc.lib.dl.metrics.TimerFactory;
+import io.dropwizard.metrics5.Histogram;
+import io.dropwizard.metrics5.Timer;
+
+/**
+ * Processor which deregisters binaries in longleaf
+ *
+ * @author bbpennel
+ */
+public class DeregisterLongleafProcessor extends AbstractLongleafProcessor {
+    private static final Logger log = LoggerFactory.getLogger(DeregisterLongleafProcessor.class);
+
+    private static final Histogram batchSizeHistogram = HistogramFactory
+            .createHistogram("longleafDeregisterBatchSize");
+    private static final Timer timer = TimerFactory.createTimerForClass(DeregisterLongleafProcessor.class);
+
+    /**
+     * The exchange here is expected to be a batch message containing a List
+     * of binary uris for deregistration, where each uri is in string form.
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public void process(Exchange exchange) throws Exception {
+        Message aggrMsg = exchange.getIn();
+
+        List<String> messages = aggrMsg.getBody(List.class);
+        if (messages.isEmpty()) {
+            return;
+        }
+        int entryCount = messages.size();
+
+        log.debug("Deregistering {} binaries from longleaf", entryCount);
+
+        String deregList = messages.stream().map(m -> {
+            URI uri = URI.create(m);
+            if (uri.getScheme().equals("file")) {
+                return Paths.get(uri).toString();
+            }
+            return m;
+        }).collect(Collectors.joining("\n"));
+
+        try (Timer.Context context = timer.time()) {
+            int exitVal = executeCommand("deregister -l @-", deregList);
+
+            if (exitVal == 0) {
+                log.info("Successfully deregistered {} entries in longleaf", entryCount);
+            } else {
+                throw new ServiceException("Failed to deregister " + entryCount + " entries in Longleaf.  "
+                        + "Check longleaf logs, command returned: " + exitVal);
+            }
+
+            batchSizeHistogram.update(entryCount);
+        }
+    }
+
+}

--- a/services-camel/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel/src/main/webapp/WEB-INF/service-context.xml
@@ -173,7 +173,7 @@
         <property name="pubSubDomain" value="false" />
     </bean>
     
-    <bean id="abstractMessageSender" class="edu.unc.lib.dl.services.AbstractMessageSender" abstract="true" >
+    <bean id="abstractMessageSender" class="edu.unc.lib.dl.services.MessageSender" abstract="true" >
         <property name="jmsTemplate" ref="solrUpdateJmsTemplate" />
     </bean>
     
@@ -235,6 +235,7 @@
         <property name="storageLocationManager" ref="storageLocationManager" />
         <property name="binaryTransferService" ref="binaryTransferService" />
         <property name="indexingMessageSender" ref="indexingMessageSender" />
+        <property name="binaryDestroyedMessageSender" ref="binaryDestroyedMessageSender" />
     </bean>
     
     <bean id="fcrepo" class="org.fcrepo.camel.FcrepoComponent">
@@ -360,6 +361,20 @@
     <bean id="registerLongleafProcessor" class="edu.unc.lib.dl.services.camel.longleaf.RegisterToLongleafProcessor">
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
         <property name="fcrepoClient" ref="fcrepoClient" />
+        <property name="longleafBaseCommand" value="${longleaf.baseCommand}" />
+    </bean>
+    
+    <bean id="binaryDestroyedJmsTemplate" class="org.springframework.jms.core.JmsTemplate">
+        <property name="connectionFactory" ref="jmsFactory" />
+        <property name="defaultDestinationName" value="activemq:queue:filter.longleaf.deregister" />
+        <property name="pubSubDomain" value="false" />
+    </bean>
+    
+    <bean id="binaryDestroyedMessageSender" class="edu.unc.lib.dl.services.MessageSender">
+        <property name="jmsTemplate" ref="binaryDestroyedJmsTemplate" />
+    </bean>
+    
+    <bean id="deregisterLongleafProcessor" class="edu.unc.lib.dl.services.camel.longleaf.DeregisterLongleafProcessor">
         <property name="longleafBaseCommand" value="${longleaf.baseCommand}" />
     </bean>
 

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/destroy/DestroyObjectsRouterTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/destroy/DestroyObjectsRouterTest.java
@@ -55,6 +55,8 @@ import edu.unc.lib.dl.search.solr.model.ObjectPath;
 import edu.unc.lib.dl.search.solr.service.ObjectPathFactory;
 
 /**
+ * See edu.unc.lib.dl.persist.services.destroy.DestroyObjectsJobIT for related integration test
+ *
  * @author bbpennel
  *
  */

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/DeregisterLongleafRouteTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/DeregisterLongleafRouteTest.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.services.camel.longleaf;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.NotifyBuilder;
+import org.jgroups.util.UUID;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import edu.unc.lib.dl.services.MessageSender;
+
+/**
+ * @author bbpennel
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextHierarchy({
+    @ContextConfiguration("/spring-test/jms-context.xml"),
+    @ContextConfiguration("/deregister-longleaf-router-context.xml")
+})
+public class DeregisterLongleafRouteTest {
+
+    @Autowired
+    private MessageSender messageSender;
+
+    @Autowired
+    private DeregisterLongleafProcessor processor;
+
+    @Autowired
+    private CamelContext cdrLongleaf;
+
+    @Rule
+    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private String longleafScript;
+    private String outputPath;
+    private List<String> output;
+
+    @Before
+    public void setup() throws Exception {
+        tmpFolder.create();
+        outputPath = tmpFolder.newFile().getPath();
+        longleafScript = LongleafTestHelpers.getLongleafScript(outputPath);
+        processor.setLongleafBaseCommand(longleafScript);
+    }
+
+    @Test
+    public void deregisterSingleBinary() throws Exception {
+        NotifyBuilder notify = new NotifyBuilder(cdrLongleaf)
+                .whenCompleted(2)
+                .create();
+
+        String contentUri = generateContentUri();
+        sendMessages(contentUri);
+
+        boolean result1 = notify.matches(5l, TimeUnit.SECONDS);
+        assertTrue("Deregister route not satisfied", result1);
+
+        output = LongleafTestHelpers.readOutput(outputPath);
+        assertDeregisterCalled(1);
+        assertDeregisterPaths(contentUri);
+    }
+
+    @Test
+    public void deregisterSingleBatch() throws Exception {
+        NotifyBuilder notify = new NotifyBuilder(cdrLongleaf)
+                .whenCompleted(1 + 3)
+                .create();
+
+        String[] contentUris = generateContentUris(3);
+        sendMessages(contentUris);
+
+        boolean result1 = notify.matches(5l, TimeUnit.SECONDS);
+        assertTrue("Deregister route not satisfied", result1);
+
+        output = LongleafTestHelpers.readOutput(outputPath);
+        assertDeregisterCalled(1);
+        assertDeregisterPaths(contentUris);
+    }
+
+    @Test
+    public void deregisterMultipleBatches() throws Exception {
+        NotifyBuilder notify = new NotifyBuilder(cdrLongleaf)
+                .whenCompleted(2 + 10)
+                .create();
+
+        String[] contentUris = generateContentUris(10);
+        sendMessages(contentUris);
+
+        boolean result1 = notify.matches(5l, TimeUnit.SECONDS);
+        assertTrue("Deregister route not satisfied", result1);
+
+        output = LongleafTestHelpers.readOutput(outputPath);
+        assertDeregisterCalled(2);
+        assertDeregisterPaths(contentUris);
+    }
+
+    private String generateContentUri() {
+        return "file:///path/to/file/" + UUID.randomUUID().toString();
+    }
+
+    private String[] generateContentUris(int num) {
+        String[] uris = new String[num];
+        for (int i = 0; i < num; i++) {
+            uris[i] = generateContentUri();
+        }
+        return uris;
+    }
+
+    private void sendMessages(String... contentUris) {
+        for (String contentUri : contentUris) {
+            messageSender.sendMessage(contentUri);
+        }
+    }
+
+    private void assertDeregisterCalled(int expectedCount) {
+        int count = 0;
+        for (String line : output) {
+            if (("deregister -l @-").equals(line)) {
+                count++;
+            }
+        }
+
+        assertEquals(expectedCount, count);
+    }
+
+    private void assertDeregisterPaths(String... contentUris) {
+        for (String contentUri : contentUris) {
+            URI uri = URI.create(contentUri);
+            String contentPath = Paths.get(uri).toString();
+            assertTrue("Expected content uri to be deregistered: " + contentPath, output.contains(contentPath));
+        }
+    }
+}

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/DeregisterLongleafRouteTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/DeregisterLongleafRouteTest.java
@@ -74,8 +74,9 @@ public class DeregisterLongleafRouteTest {
 
     @Test
     public void deregisterSingleBinary() throws Exception {
+        // Expecting 1 batch message and 1 individual file message, on different routes
         NotifyBuilder notify = new NotifyBuilder(cdrLongleaf)
-                .whenCompleted(2)
+                .whenCompleted(1 + 1)
                 .create();
 
         String contentUri = generateContentUri();
@@ -91,6 +92,7 @@ public class DeregisterLongleafRouteTest {
 
     @Test
     public void deregisterSingleBatch() throws Exception {
+        // Expecting 1 batch message and 3 individual file messages, on different routes
         NotifyBuilder notify = new NotifyBuilder(cdrLongleaf)
                 .whenCompleted(1 + 3)
                 .create();
@@ -108,6 +110,7 @@ public class DeregisterLongleafRouteTest {
 
     @Test
     public void deregisterMultipleBatches() throws Exception {
+        // Expecting 2 batch messages and 10 individual file messages, on different routes
         NotifyBuilder notify = new NotifyBuilder(cdrLongleaf)
                 .whenCompleted(2 + 10)
                 .create();

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/LongleafTestHelpers.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/LongleafTestHelpers.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.services.camel.longleaf;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.io.FileUtils;
+
+/**
+ * Helpers for longleaf tests
+ *
+ * @author bbpennel
+ */
+public class LongleafTestHelpers {
+
+    private LongleafTestHelpers() {
+    }
+
+    /**
+     * Generates a longleaf test script which records all commands called through it
+     *
+     * @param outputPath
+     * @return
+     * @throws Exception
+     */
+    public static String getLongleafScript(String outputPath) throws Exception {
+        String scriptContent = "#!/usr/bin/env bash"
+                + "\necho $@ >> " + outputPath
+                + "\necho \"$(</dev/stdin)\" >> " + outputPath;
+        File longleafScript = File.createTempFile("longleaf", ".sh");
+
+        FileUtils.write(longleafScript, scriptContent, "UTF-8");
+
+        longleafScript.deleteOnExit();
+
+        Set<PosixFilePermission> ownerExecutable = PosixFilePermissions.fromString("r-x------");
+        Files.setPosixFilePermissions(longleafScript.toPath(), ownerExecutable);
+
+        return longleafScript.getAbsolutePath();
+    }
+
+    public static List<String> readOutput(String outputPath) throws IOException {
+        String outputText = FileUtils.readFileToString(new File(outputPath), UTF_8);
+        return Arrays.asList(outputText.split("\n"));
+    }
+}

--- a/services-camel/src/test/resources/deregister-longleaf-router-config.properties
+++ b/services-camel/src/test/resources/deregister-longleaf-router-config.properties
@@ -1,0 +1,3 @@
+longleaf.register.consumers=1
+longleaf.register.completionTimeout=100
+longleaf.register.completionSize=5

--- a/services-camel/src/test/resources/deregister-longleaf-router-context.xml
+++ b/services-camel/src/test/resources/deregister-longleaf-router-context.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:c="http://www.springframework.org/schema/c"
+    xmlns:p="http://www.springframework.org/schema/p" xmlns:context="http://www.springframework.org/schema/context"
+    xmlns:util="http://www.springframework.org/schema/util"
+    xmlns:camel="http://camel.apache.org/schema/spring"
+    xmlns:amq="http://activemq.apache.org/schema/core"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
+        http://www.springframework.org/schema/util 
+        http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.3.xsd
+        http://activemq.apache.org/schema/core
+        http://activemq.apache.org/schema/core/activemq-core.xsd
+        http://camel.apache.org/schema/spring
+        http://camel.apache.org/schema/spring/camel-spring.xsd">
+        
+    <bean id="properties" class="org.apache.camel.component.properties.PropertiesComponent">
+        <property name="location" value="classpath:deregister-longleaf-router-config.properties"/>
+    </bean>
+    
+    <bean id="bridgePropertyPlaceholder" class="org.apache.camel.spring.spi.BridgePropertyPlaceholderConfigurer">
+        <property name="location" value="classpath:deregister-longleaf-router-config.properties"/>
+    </bean>
+    
+    <bean id="longleafAggregationStrategy" class="edu.unc.lib.dl.services.camel.longleaf.LongleafAggregationStrategy">
+    </bean>
+    
+    <bean id="registerLongleafProcessor" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.services.camel.longleaf.RegisterToLongleafProcessor" />
+    </bean>
+    
+    <bean id="binaryDestroyedJmsTemplate" class="org.springframework.jms.core.JmsTemplate">
+        <property name="connectionFactory" ref="jmsFactory" />
+        <property name="defaultDestinationName" value="activemq:queue:filter.longleaf.deregister" />
+        <property name="pubSubDomain" value="false" />
+    </bean>
+    
+    <bean id="binaryDestroyedMessageSender" class="edu.unc.lib.dl.services.MessageSender">
+        <property name="jmsTemplate" ref="binaryDestroyedJmsTemplate" />
+    </bean>
+    
+    <bean id="deregisterLongleafProcessor" class="edu.unc.lib.dl.services.camel.longleaf.DeregisterLongleafProcessor">
+    </bean>
+    
+    <bean id="sjms" class="org.apache.camel.component.sjms.SjmsComponent">
+        <property name="connectionFactory" ref="jmsFactory" />
+    </bean>
+    
+    <bean id="sjms-batch" class="org.apache.camel.component.sjms.batch.SjmsBatchComponent">
+        <property name="connectionFactory" ref="jmsFactory" />
+    </bean>
+    
+    <camel:camelContext id="cdrLongleaf">
+        <camel:package>edu.unc.lib.dl.services.camel.longleaf</camel:package>
+    </camel:camelContext>
+  
+</beans>

--- a/services-camel/src/test/resources/destroy-objects-context.xml
+++ b/services-camel/src/test/resources/destroy-objects-context.xml
@@ -22,6 +22,7 @@
         <property name="fcrepoClient" ref="fcrepoClient" />
         <property name="inheritedAclFactory" ref="inheritedAclFactory" />
         <property name="indexingMessageSender" ref="indexingMessageSender" />
+        <property name="binaryDestroyedMessageSender" ref="binaryDestroyedMessageSender" />
     </bean>
     
     <bean id="aclService" class="org.mockito.Mockito" factory-method="mock">
@@ -54,6 +55,10 @@
     
     <bean id="fcrepoClient" class="org.mockito.Mockito" factory-method="mock">
         <constructor-arg value="org.fcrepo.client.FcrepoClient" />
+    </bean>
+    
+    <bean id="binaryDestroyedMessageSender" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.services.MessageSender" />
     </bean>
 
     <camel:camelContext id="cdrDestroyObjects">

--- a/services-camel/src/test/resources/enhancement-router-it-context.xml
+++ b/services-camel/src/test/resources/enhancement-router-it-context.xml
@@ -62,6 +62,10 @@
     <bean id="registerLongleafProcessor" class="org.mockito.Mockito" factory-method="mock">
         <constructor-arg value="edu.unc.lib.dl.services.camel.longleaf.RegisterToLongleafProcessor" />
     </bean>
+    
+    <bean id="deregisterLongleafProcessor" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.services.camel.longleaf.DeregisterLongleafProcessor" />
+    </bean>
 
     <camel:camelContext id="cdrServiceImageEnhancements">
         <camel:package>edu.unc.lib.dl.services.camel.images</camel:package>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2426

* Adds deregistration from longleaf of destroyed binaries.
* Implements bulk deregistration of binaries in longleaf
* Destroy job triggers deregistration from longleaf. Add more debug statements during destroy
* Allow longleaf message aggregator to get uri from body or header