### PR TITLE
BXC-2711 - Improve deposit pausing

### DIFF
--- a/deposit/src/main/java/edu/unc/lib/deposit/normalize/BagIt2N3BagJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/normalize/BagIt2N3BagJob.java
@@ -92,9 +92,13 @@ public class BagIt2N3BagJob extends AbstractFileServerToBagJob {
             MandatoryVerifier.checkBagitFileExists(bagReader.getRootDir(), bagReader.getVersion());
 
             try (BagVerifier verifier = new BagVerifier()) {
+                interruptJobIfStopped();
                 verifier.isComplete(bagReader, false);
+                interruptJobIfStopped();
                 verifier.isValid(bagReader, false);
             }
+
+            interruptJobIfStopped();
 
             Set<Manifest> payloadManifests = bagReader.getPayLoadManifests();
 

--- a/deposit/src/main/java/edu/unc/lib/deposit/normalize/CDRMETS2N3BagJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/normalize/CDRMETS2N3BagJob.java
@@ -55,6 +55,9 @@ public class CDRMETS2N3BagJob extends AbstractMETS2N3BagJob {
         // Store a reference to the manifest file
         addManifestURI();
         validateProfile(METSProfile.CDR_SIMPLE);
+
+        interruptJobIfStopped();
+
         Document mets = loadMETS();
         // assign any missing PIDs
         assignPIDs(mets);

--- a/deposit/src/main/java/edu/unc/lib/deposit/normalize/DirectoryToBagJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/normalize/DirectoryToBagJob.java
@@ -20,7 +20,6 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
@@ -62,17 +61,11 @@ public class DirectoryToBagJob extends AbstractFileServerToBagJob {
         Path sourcePath = Paths.get(sourceUri);
         File sourceFile = sourcePath.toFile();
 
-        // List all files and directories in the deposit, excluding the base directory
+        // List all files and directories in the deposit
         Collection<File> fileListings =
                 FileUtils.listFilesAndDirs(sourceFile, TrueFileFilter.TRUE, TrueFileFilter.TRUE);
-        Iterator<File> filesIt = fileListings.iterator();
-        while (filesIt.hasNext()) {
-            File file = filesIt.next();
-            if (file.equals(sourceFile)) {
-                filesIt.remove();
-                break;
-            }
-        }
+
+        interruptJobIfStopped();
 
         // Turn the base directory itself into the top level folder for this deposit
         Bag sourceBag = getSourceBag(depositBag, sourceFile);
@@ -80,6 +73,11 @@ public class DirectoryToBagJob extends AbstractFileServerToBagJob {
         int i = 0;
         // Add all of the payload objects into the bag folder
         for (File file : fileListings) {
+            // skip adding the base directory to the deposit
+            if (file.equals(sourceFile)) {
+                continue;
+            }
+
             log.debug("Adding object {}: {}", i++, file.getName());
 
             Boolean isDir = file.isDirectory();

--- a/deposit/src/main/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJob.java
@@ -91,6 +91,8 @@ public class TransferBinariesToStorageJob extends AbstractDepositJob {
     }
 
     private void transferBinaries(Resource resc, BinaryTransferSession transferSession) {
+        interruptJobIfStopped();
+
         PID objPid = PIDs.get(resc.toString());
         log.debug("Preparing to transfer binaries for {}", objPid);
 

--- a/deposit/src/main/java/edu/unc/lib/deposit/validate/ExtractTechnicalMetadataJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/validate/ExtractTechnicalMetadataJob.java
@@ -64,6 +64,7 @@ import org.slf4j.LoggerFactory;
 
 import edu.unc.lib.deposit.work.AbstractDepositJob;
 import edu.unc.lib.deposit.work.JobFailedException;
+import edu.unc.lib.deposit.work.JobInterruptedException;
 import edu.unc.lib.dl.fcrepo4.PIDs;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.util.URIUtil;
@@ -112,6 +113,8 @@ public class ExtractTechnicalMetadataJob extends AbstractDepositJob {
         List<Entry<PID, String>> stagingList = generateStagingLocationsToProcess(model);
 
         for (Entry<PID, String> stagedPair : stagingList) {
+            interruptJobIfStopped();
+
             PID objPid = stagedPair.getKey();
             String stagedPath = stagedPair.getValue();
 
@@ -135,7 +138,7 @@ public class ExtractTechnicalMetadataJob extends AbstractDepositJob {
 
                 // Store the premis report to file
                 writePremisReport(objPid, premisDoc);
-            } catch (JobFailedException e) {
+            } catch (JobFailedException | JobInterruptedException e) {
                 throw e;
             } catch (Exception e) {
                 failJob(e, "Failed to extract FITS details for {0} from document:\n{1}",

--- a/deposit/src/main/java/edu/unc/lib/deposit/validate/FixityCheckJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/validate/FixityCheckJob.java
@@ -75,6 +75,8 @@ public class FixityCheckJob extends AbstractDepositJob {
                 continue;
             }
 
+            interruptJobIfStopped();
+
             String stagedPath = stagingEntry.getValue();
             URI stagedUri = URI.create(stagedPath);
 

--- a/deposit/src/main/java/edu/unc/lib/deposit/validate/ValidateFileAvailabilityJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/validate/ValidateFileAvailabilityJob.java
@@ -66,7 +66,7 @@ public class ValidateFileAvailabilityJob extends AbstractDepositJob {
         setTotalClicks(hrefs.size());
 
         // Verify that the deposit is still running before proceeding with check
-        verifyRunning();
+        interruptJobIfStopped();
 
         // Iterate through local file hrefs and verify that each one exists
         for (Entry<PID, String> entry : hrefs) {

--- a/deposit/src/main/java/edu/unc/lib/deposit/validate/VerifyObjectsAreInFedoraService.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/validate/VerifyObjectsAreInFedoraService.java
@@ -44,7 +44,7 @@ public class VerifyObjectsAreInFedoraService {
  *
  * @param depositPid
  * @param objectPIDs
- * @return list of missing oibject PIDs as a String
+ * @return list of missing object PIDs as a String
  */
     public String listObjectPIDs(String depositPid, List<PID> objectPIDs) {
         StringBuilder buildListOfObjectPIDs = new StringBuilder();

--- a/deposit/src/main/java/edu/unc/lib/deposit/validate/VirusScanJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/validate/VirusScanJob.java
@@ -78,7 +78,8 @@ public class VirusScanJob extends AbstractDepositJob {
         int scannedObjects = 0;
 
         for (Entry<PID, String> href : hrefs) {
-            verifyRunning();
+            interruptJobIfStopped();
+
             PID objPid = href.getKey();
 
             if (isObjectCompleted(objPid)) {
@@ -97,9 +98,9 @@ public class VirusScanJob extends AbstractDepositJob {
                     break;
                 case ERROR:
                     throw new Error(
-                            "Virus checks are producing errors: "
-                                    + result.getException()
-                                    .getLocalizedMessage());
+                            "Virus checks are producing errors: " +
+                            ((result.getException() == null) ? result.getResult() :
+                                    result.getException().getLocalizedMessage()));
                 case PASSED:
                     PremisLogger premisLogger = getPremisLogger(href.getKey());
                     PremisEventBuilder premisEventBuilder = premisLogger.buildEvent(Premis.VirusCheck);

--- a/deposit/src/main/java/edu/unc/lib/deposit/work/DepositSupervisor.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/work/DepositSupervisor.java
@@ -63,7 +63,6 @@ import edu.unc.lib.deposit.validate.ValidateDestinationJob;
 import edu.unc.lib.deposit.validate.ValidateFileAvailabilityJob;
 import edu.unc.lib.deposit.validate.VirusScanJob;
 import edu.unc.lib.dl.fcrepo4.PIDs;
-import edu.unc.lib.dl.fedora.FedoraTimeoutException;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.metrics.CounterFactory;
 import edu.unc.lib.dl.metrics.HistogramFactory;
@@ -472,16 +471,8 @@ public class DepositSupervisor implements WorkerListener {
                 }
 
                 if (t instanceof JobInterruptedException) {
-                    LOG.debug("Job {} in deposit {} was interrupted", jobUUID, depositUUID);
+                    LOG.info("Job {} in deposit {} was interrupted: {}", jobUUID, depositUUID, t.getMessage());
                     jobStatusFactory.interrupted(jobUUID);
-                    return;
-                }
-
-                if (t instanceof FedoraTimeoutException) {
-                    LOG.warn("Fedora timed out for job {} in deposit {},"
-                            + " will resume after delay", jobUUID, depositUUID);
-                    jobStatusFactory.failed(jobUUID);
-                    resumeDeposit(depositUUID, status, getUnavailableDelaySeconds() * 1000);
                     return;
                 }
 

--- a/deposit/src/test/java/edu/unc/lib/deposit/CleanupDepositJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/CleanupDepositJobTest.java
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.io.File;
 import java.net.URI;
@@ -74,7 +73,6 @@ public class CleanupDepositJobTest extends AbstractDepositJobTest {
 
     @Before
     public void setup() throws Exception {
-        initMocks(this);
         depositStatus = new HashMap<>();
         when(depositStatusFactory.get(anyString())).thenReturn(depositStatus);
 
@@ -95,9 +93,9 @@ public class CleanupDepositJobTest extends AbstractDepositJobTest {
         // Initialize the job
         job = new CleanupDepositJob(jobUUID, depositUUID);
         job.setIngestSourceManager(sourceManager);
+        job.setDepositStatusFactory(depositStatusFactory);
         setField(job, "depositsDirectory", depositsDirectory);
         setField(job, "jobStatusFactory", jobStatusFactory);
-        setField(job, "depositStatusFactory", depositStatusFactory);
         setField(job, "dataset", dataset);
 
         job.init();

--- a/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/AbstractDepositJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/AbstractDepositJobTest.java
@@ -54,6 +54,7 @@ import edu.unc.lib.dl.reporting.ActivityMetricsClient;
 import edu.unc.lib.dl.test.TestHelper;
 import edu.unc.lib.dl.util.DepositStatusFactory;
 import edu.unc.lib.dl.util.JobStatusFactory;
+import edu.unc.lib.dl.util.RedisWorkerConstants.DepositState;
 
 /**
  *
@@ -142,6 +143,8 @@ public class AbstractDepositJobTest {
         }).when(tx).cancel(any(Exception.class));
 
         completedIds = new HashSet<>();
+
+        when(depositStatusFactory.getState(anyString())).thenReturn(DepositState.running);
 
         doAnswer(invocation -> {
             String objId = invocation.getArgumentAt(1, String.class);

--- a/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/AbstractFedoraDepositJobIT.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/AbstractFedoraDepositJobIT.java
@@ -47,6 +47,7 @@ import edu.unc.lib.dl.reporting.ActivityMetricsClient;
 import edu.unc.lib.dl.test.TestHelper;
 import edu.unc.lib.dl.util.DepositStatusFactory;
 import edu.unc.lib.dl.util.JobStatusFactory;
+import edu.unc.lib.dl.util.RedisWorkerConstants.DepositState;
 
 /**
  *
@@ -103,6 +104,8 @@ public class AbstractFedoraDepositJobIT {
         depositUUID = depositPid.getId();
         depositDir = new File(depositsDirectory, depositUUID);
         depositDir.mkdir();
+
+        depositStatusFactory.setState(depositUUID, DepositState.running);
     }
 
     protected URI createBaseContainer(String name) throws IOException, FcrepoOperationFailedException {

--- a/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJobIT.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJobIT.java
@@ -67,7 +67,6 @@ import edu.unc.lib.dl.fcrepo4.RepositoryObject;
 import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
 import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
 import edu.unc.lib.dl.fcrepo4.RepositoryPaths;
-import edu.unc.lib.dl.fcrepo4.TransactionCancelledException;
 import edu.unc.lib.dl.fcrepo4.TransactionManager;
 import edu.unc.lib.dl.fcrepo4.WorkObject;
 import edu.unc.lib.dl.fedora.FedoraException;
@@ -549,7 +548,7 @@ public class IngestContentObjectsJobIT extends AbstractFedoraDepositJobIT {
         try {
             job.run();
             fail("Test should not reach this line. Job should have thrown exception");
-        } catch (TransactionCancelledException e) {
+        } catch (JobFailedException e) {
             // expected, lets continue
         }
 

--- a/deposit/src/test/java/edu/unc/lib/deposit/normalize/NormalizeFileObjectsJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/normalize/NormalizeFileObjectsJobTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.io.File;
 import java.net.URI;
@@ -87,13 +86,12 @@ public class NormalizeFileObjectsJobTest extends AbstractDepositJobTest {
 
     @Before
     public void init() {
-        initMocks(this);
-
         Dataset dataset = TDBFactory.createDataset();
 
         job = new NormalizeFileObjectsJob();
         job.setDepositUUID(depositUUID);
         job.setDepositDirectory(depositDir);
+        job.setDepositStatusFactory(depositStatusFactory);
         setField(job, "dataset", dataset);
         setField(job, "premisLoggerFactory", mockPremisLoggerFactory);
         setField(job, "depositsDirectory", depositsDirectory);

--- a/deposit/src/test/java/edu/unc/lib/deposit/validate/FixityCheckJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/validate/FixityCheckJobTest.java
@@ -75,6 +75,7 @@ public class FixityCheckJobTest extends AbstractDepositJobTest {
         premisLoggerFactory.setPidMinter(pidMinter);
 
         job = new FixityCheckJob(jobUUID, depositUUID);
+        job.setDepositStatusFactory(depositStatusFactory);
         setField(job, "dataset", dataset);
         setField(job, "premisLoggerFactory", premisLoggerFactory);
         setField(job, "depositsDirectory", depositsDirectory);

--- a/deposit/src/test/java/edu/unc/lib/deposit/validate/ValidateContentModelJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/validate/ValidateContentModelJobTest.java
@@ -49,7 +49,6 @@ import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.rdf.Cdr;
 import edu.unc.lib.dl.rdf.CdrAcl;
 import edu.unc.lib.dl.rdf.CdrDeposit;
-import edu.unc.lib.dl.util.DepositStatusFactory;
 import edu.unc.lib.dl.util.RedisWorkerConstants.DepositField;
 
 /**
@@ -69,8 +68,6 @@ public class ValidateContentModelJobTest extends AbstractDepositJobTest {
 
     @Mock
     private ContentObjectAccessRestrictionValidator aclValidator;
-    @Mock
-    private DepositStatusFactory depositStatusFactory;
     @Mock
     private RepositoryObjectLoader repoObjectLoader;
     @Mock

--- a/deposit/src/test/java/edu/unc/lib/deposit/validate/ValidateFileAvailabilityJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/validate/ValidateFileAvailabilityJobTest.java
@@ -88,8 +88,6 @@ public class ValidateFileAvailabilityJobTest extends AbstractDepositJobTest {
         setField(job, "jobStatusFactory", jobStatusFactory);
         job.init();
 
-        when(depositStatusFactory.getState(anyString()))
-                .thenReturn(DepositState.running);
         when(sourceManager.getIngestSourceForUri(any(URI.class))).thenReturn(ingestSource);
         when(ingestSource.exists(any(URI.class))).thenReturn(true);
 


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2711

* Adds breakpoints in longer running deposit jobs, where the job checks to see if it has been paused or interrupted, and ends early if so.
* Switch binary transfer client to write using utility method which can be interrupted
* Adjustments to exception throwing, fix for virus scans, and cleanup of extraneous code