### PR TITLE
BXC-2732 - Quiet/Unquiet/Stop deposit pipeline

### DIFF
--- a/deposit/src/main/java/edu/unc/lib/deposit/work/DepositSupervisor.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/work/DepositSupervisor.java
@@ -364,12 +364,7 @@ public class DepositSupervisor implements WorkerListener {
     protected void quiet(boolean stopWorkers, boolean stopNow) {
         isQuieted = true;
 
-        if (stopWorkers) {
-            // End the worker pools to prevent further processing, immediately if requested
-            for (WorkerPool pool : depositWorkerPools) {
-                pool.end(stopNow);
-            }
-        } else {
+        if (!stopWorkers) {
             // Pause all worker pools to prevent new jobs from starting
             for (WorkerPool pool : depositWorkerPools) {
                 pool.togglePause(true);
@@ -384,6 +379,13 @@ public class DepositSupervisor implements WorkerListener {
             if (DepositState.running.equals(depositState)) {
                 String uuid = fields.get(DepositField.uuid.name());
                 depositStatusFactory.setState(uuid, DepositState.quieted);
+            }
+        }
+
+        if (stopWorkers) {
+            // End the worker pools to prevent further processing, immediately if requested
+            for (WorkerPool pool : depositWorkerPools) {
+                pool.end(stopNow);
             }
         }
 
@@ -466,7 +468,7 @@ public class DepositSupervisor implements WorkerListener {
                     if (depositSet.get(uuid).contains(CleanupDepositJob.class.getName())) {
                         depositStatusFactory.setState(uuid, DepositState.finished);
                     } else {
-                        LOG.debug("Skipping resumption of deposit {} because it already is in the queue", uuid);
+                        LOG.info("Skipping resumption of deposit {} because it already is in the queue", uuid);
                     }
                 } else {
                     depositStatusFactory.setActionRequest(uuid, DepositAction.resume);

--- a/deposit/src/main/java/edu/unc/lib/deposit/work/DepositSupervisor.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/work/DepositSupervisor.java
@@ -68,11 +68,14 @@ import edu.unc.lib.dl.metrics.CounterFactory;
 import edu.unc.lib.dl.metrics.HistogramFactory;
 import edu.unc.lib.dl.services.OperationsMessageSender;
 import edu.unc.lib.dl.util.DepositConstants;
+import edu.unc.lib.dl.util.DepositPipelineStatusFactory;
 import edu.unc.lib.dl.util.DepositStatusFactory;
 import edu.unc.lib.dl.util.JobStatusFactory;
 import edu.unc.lib.dl.util.PackagingType;
 import edu.unc.lib.dl.util.RedisWorkerConstants.DepositAction;
 import edu.unc.lib.dl.util.RedisWorkerConstants.DepositField;
+import edu.unc.lib.dl.util.RedisWorkerConstants.DepositPipelineAction;
+import edu.unc.lib.dl.util.RedisWorkerConstants.DepositPipelineState;
 import edu.unc.lib.dl.util.RedisWorkerConstants.DepositState;
 import edu.unc.lib.dl.util.RedisWorkerConstants.Priority;
 import io.dropwizard.metrics5.Counter;
@@ -101,6 +104,9 @@ public class DepositSupervisor implements WorkerListener {
 
     @Autowired
     private DepositStatusFactory depositStatusFactory;
+
+    @Autowired
+    private DepositPipelineStatusFactory pipelineStatusFactory;
 
     @Autowired
     private JobStatusFactory jobStatusFactory;
@@ -149,9 +155,16 @@ public class DepositSupervisor implements WorkerListener {
     @Autowired
     private File depositsDirectory;
 
+    private long actionMonitorDelay = 1000l;
+
     private int cleanupDelaySeconds;
 
     private int unavailableDelaySeconds;
+
+    private boolean isQuieted;
+
+    // Visible for testing
+    protected ActionMonitoringTask actionMonitoringTask;
 
     public int getCleanupDelaySeconds() {
         return cleanupDelaySeconds;
@@ -171,6 +184,7 @@ public class DepositSupervisor implements WorkerListener {
 
     public DepositSupervisor() {
         id = UUID.randomUUID().toString();
+        actionMonitoringTask = new ActionMonitoringTask();
     }
 
     private static enum Queue {
@@ -199,6 +213,8 @@ public class DepositSupervisor implements WorkerListener {
     }
 
     public void start() {
+        pipelineStatusFactory.setPipelineState(DepositPipelineState.starting);
+
         // Repopulate the queue
         requeueAll();
 
@@ -207,59 +223,14 @@ public class DepositSupervisor implements WorkerListener {
             return;
         }
         timer = new Timer("DepositSupervisor " + id);
-        timer.schedule(new TimerTask() {
+        timer.schedule(actionMonitoringTask, actionMonitorDelay, actionMonitorDelay);
 
-            @Override
-            public void run() {
+        startWorkerPools();
 
-                try {
-                    // Scan for actions and trigger them
-                    for (Map<String, String> fields : depositStatusFactory.getAll()) {
+        pipelineStatusFactory.setPipelineState(DepositPipelineState.active);
+    }
 
-                        String requestedActionName = fields.get(DepositField.actionRequest.name());
-                        String uuid = fields.get(DepositField.uuid.name());
-
-                        if (DepositAction.register.name().equals(requestedActionName)) {
-
-                            LOG.info("Registering job {}", uuid);
-
-                            if (depositStatusFactory.addSupervisorLock(uuid, id)) {
-                                try {
-                                    queueNewDeposit(uuid, fields);
-                                } finally {
-                                    depositStatusFactory.removeSupervisorLock(uuid);
-                                }
-                            }
-
-                        } else if (DepositAction.pause.name().equals(requestedActionName)) {
-
-                            LOG.info("Pausing job {}", uuid);
-
-                            depositStatusFactory.setState(uuid, DepositState.paused);
-                            depositStatusFactory.clearActionRequest(uuid);
-
-                        } else if (DepositAction.resume.name().equals(requestedActionName)) {
-
-                            LOG.info("Resuming job {}", uuid);
-
-                            if (depositStatusFactory.addSupervisorLock(uuid, id)) {
-                                try {
-                                    resumeDeposit(uuid, fields);
-                                } finally {
-                                    depositStatusFactory.removeSupervisorLock(uuid);
-                                }
-                            }
-
-                        }
-
-                    }
-                } catch (Throwable t) {
-                    LOG.error("Encountered an exception while checking for action requests", t);
-                }
-            }
-
-        }, 1000, 1000);
-
+    protected void startWorkerPools() {
         for (WorkerPool pool : depositWorkerPools) {
             if (pool.isShutdown()) {
                 throw new Error("Cannot start deposit workers, already shutdown.");
@@ -271,6 +242,181 @@ public class DepositSupervisor implements WorkerListener {
                 pool.run();
             }
         }
+    }
+
+    /**
+     * TimerTask used to monitor for actions to the deposit pipeline or deposits
+     */
+    protected class ActionMonitoringTask extends TimerTask {
+        @Override
+        public void run() {
+            try {
+                // Check for actions taken against the deposit pipeline
+                DepositPipelineAction pipelineAction = pipelineStatusFactory.getPipelineAction();
+
+                if (pipelineAction != null) {
+                    performPipelineAction(pipelineAction);
+                    return;
+                }
+
+                // Do not process deposit actions while quieted
+                if (isQuieted) {
+                    return;
+                }
+
+                // Scan for deposit actions and trigger them
+                for (Map<String, String> fields : depositStatusFactory.getAll()) {
+                    performDepositAction(fields);
+                }
+            } catch (Throwable t) {
+                LOG.error("Encountered an exception while checking for action requests", t);
+            }
+        }
+
+        private void performPipelineAction(DepositPipelineAction pipelineAction) {
+            DepositPipelineState state = pipelineStatusFactory.getPipelineState();
+
+            switch (pipelineAction) {
+            case quiet:
+                LOG.warn("Quieting the deposit pipeline, deposits and works will cease work soon");
+                if (DepositPipelineState.active.equals(state)) {
+                    quiet(false, false);
+                } else {
+                    LOG.debug("Cannot unquiet deposit pipeline in state {}", state);
+                }
+
+                break;
+            case stop:
+                if (DepositPipelineState.shutdown.equals(state)
+                        || DepositPipelineState.stopped.equals(state)) {
+                    LOG.debug("Cannot stop deposit pipeline in state {}", state);
+                } else {
+                    stop(true);
+                }
+                break;
+            case unquiet:
+                if (DepositPipelineState.quieted.equals(state)) {
+                    unquiet();
+                } else {
+                    LOG.debug("Cannot unquiet deposit pipeline in state {}", state);
+                }
+                break;
+            default:
+                LOG.warn("Unknown deposit pipeline action {} requested", pipelineAction);
+                break;
+            }
+
+            pipelineStatusFactory.clearPipelineActionRequest();
+        }
+
+        private void performDepositAction(Map<String, String> fields) {
+            String requestedActionName = fields.get(DepositField.actionRequest.name());
+            if (requestedActionName == null) {
+                return;
+            }
+
+            String uuid = fields.get(DepositField.uuid.name());
+            DepositAction depositAction = DepositAction.valueOf(requestedActionName);
+
+            switch (depositAction) {
+            case register:
+                LOG.info("Registering job {}", uuid);
+
+                if (depositStatusFactory.addSupervisorLock(uuid, id)) {
+                    try {
+                        queueNewDeposit(uuid, fields);
+                    } finally {
+                        depositStatusFactory.removeSupervisorLock(uuid);
+                    }
+                }
+                break;
+            case resume:
+                LOG.info("Resuming job {}", uuid);
+                if (depositStatusFactory.addSupervisorLock(uuid, id)) {
+                    try {
+                        resumeDeposit(uuid, fields);
+                    } finally {
+                        depositStatusFactory.removeSupervisorLock(uuid);
+                    }
+                }
+                break;
+            case pause:
+                LOG.info("Pausing job {}", uuid);
+                depositStatusFactory.setState(uuid, DepositState.paused);
+                break;
+            case cancel:
+            case destroy:
+            default:
+                LOG.warn("Deposit action {} is not currently supported", requestedActionName);
+                break;
+            }
+
+            depositStatusFactory.clearActionRequest(uuid);
+        }
+    }
+
+    /**
+     * Quiet the pipeline and running deposits, so that no new deposits or deposit jobs will start
+     *
+     * @param stopWorkers will stop the worker pools if true
+     * @param stopNow will attempt to immediately stop workers
+     */
+    protected void quiet(boolean stopWorkers, boolean stopNow) {
+        isQuieted = true;
+
+        if (stopWorkers) {
+            // End the worker pools to prevent further processing, immediately if requested
+            for (WorkerPool pool : depositWorkerPools) {
+                pool.end(stopNow);
+            }
+        } else {
+            // Pause all worker pools to prevent new jobs from starting
+            for (WorkerPool pool : depositWorkerPools) {
+                pool.togglePause(true);
+            }
+        }
+
+        // Quiet all deposits
+        Set<Map<String, String>> depositStatuses = depositStatusFactory.getAll();
+
+        for (Map<String, String> fields : depositStatuses) {
+            DepositState depositState = DepositState.valueOf(fields.get(DepositField.state.name()));
+            if (DepositState.running.equals(depositState)) {
+                String uuid = fields.get(DepositField.uuid.name());
+                depositStatusFactory.setState(uuid, DepositState.quieted);
+            }
+        }
+
+        if (stopWorkers) {
+            pipelineStatusFactory.setPipelineState(DepositPipelineState.stopped);
+        } else {
+            pipelineStatusFactory.setPipelineState(DepositPipelineState.quieted);
+        }
+    }
+
+    /**
+     * Resume the deposit pipeline and all quieted deposits
+     */
+    protected void unquiet() {
+        // Resume all quieted deposits
+        Set<Map<String, String>> depositStatuses = depositStatusFactory.getAll();
+
+        for (Map<String, String> fields : depositStatuses) {
+            DepositState depositState = DepositState.valueOf(fields.get(DepositField.state.name()));
+            // If the deposit is quieted and has no queued actions, then request it be resumed
+            if (DepositState.quieted.equals(depositState) && !fields.containsKey(DepositField.actionRequest.name())) {
+                String uuid = fields.get(DepositField.uuid.name());
+                depositStatusFactory.setActionRequest(uuid, DepositAction.resume);
+            }
+        }
+
+        // Unpause workers
+        for (WorkerPool pool : depositWorkerPools) {
+            pool.togglePause(false);
+        }
+
+        pipelineStatusFactory.setPipelineState(DepositPipelineState.active);
+        isQuieted = false;
     }
 
     private Map<String, Set<String>> getQueuedDepositsWithJobs() {
@@ -306,9 +452,10 @@ public class DepositSupervisor implements WorkerListener {
 
         LOG.info("Repopulating the deposit queue, {} items in backlog", depositStatuses.size());
 
-        // Requeue the previously running jobs from where they left off first
+        // Requeue the previously running or quieted jobs from where they left off first
         for (Map<String, String> fields : depositStatuses) {
-            if (DepositState.running.name().equals(fields.get(DepositField.state.name()))) {
+            DepositState depositState = DepositState.valueOf(fields.get(DepositField.state.name()));
+            if (DepositState.running.equals(depositState) || DepositState.quieted.equals(depositState)) {
                 String uuid = fields.get(DepositField.uuid.name());
 
                 // Job may have been locked to a particular supervisor depend on when it was interrupted
@@ -329,7 +476,8 @@ public class DepositSupervisor implements WorkerListener {
 
         // Requeue the "queued" jobs next
         for (Map<String, String> fields : depositStatuses) {
-            if (DepositState.queued.name().equals(fields.get(DepositField.state.name()))) {
+            DepositState depositState = DepositState.valueOf(fields.get(DepositField.state.name()));
+            if (DepositState.queued.equals(depositState)) {
                 String uuid = fields.get(DepositField.uuid.name());
 
                 depositStatusFactory.removeSupervisorLock(uuid);
@@ -353,19 +501,21 @@ public class DepositSupervisor implements WorkerListener {
         }
     }
 
-    public void stop() {
-        LOG.info("Stopping the Deposit Supervisor");
-        if (timer != null) { // stop registering new deposits
+    /**
+     * Stops the deposit supervisor, preventing new jobs from starting or actions being processed
+     *
+     * @param stopNow if true, ongoing deposit jobs will be interrupted, potentially ending them before a breakpoint
+     */
+    public void stop(boolean stopNow) {
+        LOG.info("Stopping the deposit pipeline, workers will stop and deposits will be quieted.");
+        if (timer != null) { // stop processing deposit actions
             this.timer.cancel();
             this.timer.purge();
             this.timer = null;
         }
 
-        for (WorkerPool pool : depositWorkerPools) {
-            pool.togglePause(true); // take no new jobs
-            pool.end(false); // cancel running jobs without interrupting
-        }
-        LOG.info("Stopped the Deposit Supervisor");
+        quiet(true, stopNow);
+        LOG.warn("Stopped the deposit pipeline. To resume operations, restart the deposit service.");
     }
 
     public DepositStatusFactory getDepositStatusFactory() {
@@ -392,9 +542,18 @@ public class DepositSupervisor implements WorkerListener {
         this.depositsDirectory = depositsDirectory;
     }
 
+    public void setActionMonitorDelay(long monitorDelay) {
+        this.actionMonitorDelay = monitorDelay;
+    }
+
     @PreDestroy
     public void shutdown() {
-        stop();
+        LOG.info("Stopping the Deposit Supervisor");
+
+        stop(false);
+
+        pipelineStatusFactory.setPipelineState(DepositPipelineState.shutdown);
+        LOG.info("Stopped the Deposit Supervisor");
     }
 
     public Job makeJob(@SuppressWarnings("rawtypes") Class jobClass,

--- a/deposit/src/main/webapp/WEB-INF/service-context.xml
+++ b/deposit/src/main/webapp/WEB-INF/service-context.xml
@@ -155,6 +155,10 @@
         <property name="jedisPool" ref="jedisPool" />
     </bean>
     
+    <bean id="pipelineStatusFactory" class="edu.unc.lib.dl.util.DepositPipelineStatusFactory">
+        <property name="jedisPool" ref="jedisPool" />
+    </bean>
+    
     <bean id="multiThreadedHttpConnectionManager" class="org.apache.http.impl.conn.PoolingHttpClientConnectionManager"
             destroy-method="shutdown">
     </bean>

--- a/deposit/src/test/java/edu/unc/lib/deposit/work/DepositSupervisorTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/work/DepositSupervisorTest.java
@@ -1,0 +1,484 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.deposit.work;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.MethodMode;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import edu.unc.lib.deposit.work.DepositSupervisor.ActionMonitoringTask;
+import edu.unc.lib.dl.acl.util.AccessGroupSet;
+import edu.unc.lib.dl.acl.util.AgentPrincipals;
+import edu.unc.lib.dl.fcrepo4.RepositoryPIDMinter;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.persist.api.ingest.DepositData;
+import edu.unc.lib.dl.persist.services.ingest.AbstractDepositHandler;
+import edu.unc.lib.dl.util.DepositException;
+import edu.unc.lib.dl.util.DepositPipelineStatusFactory;
+import edu.unc.lib.dl.util.DepositStatusFactory;
+import edu.unc.lib.dl.util.PackagingType;
+import edu.unc.lib.dl.util.RedisWorkerConstants.DepositAction;
+import edu.unc.lib.dl.util.RedisWorkerConstants.DepositField;
+import edu.unc.lib.dl.util.RedisWorkerConstants.DepositPipelineAction;
+import edu.unc.lib.dl.util.RedisWorkerConstants.DepositPipelineState;
+import edu.unc.lib.dl.util.RedisWorkerConstants.DepositState;
+import edu.unc.lib.dl.util.RedisWorkerConstants.Priority;
+import net.greghaines.jesque.worker.WorkerPool;
+
+/**
+ * @author bbpennel
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration( locations = { "/spring-test/cdr-client-container.xml",
+    "/spring-test/deposit-supervisor-test-context.xml"} )
+public class DepositSupervisorTest {
+
+    @Rule
+    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    @Autowired
+    private RepositoryPIDMinter pidMinter;
+
+    @Autowired
+    private DepositStatusFactory depositStatusFactory;
+
+    @Autowired
+    private DepositPipelineStatusFactory pipelineStatusFactory;
+
+    @Autowired
+    private List<WorkerPool> depositWorkerPools;
+
+    @Autowired
+    private DepositSupervisor supervisor;
+
+    private PID depositDestination;
+
+    private ActionMonitoringTask actionMonitor;
+
+    private AgentPrincipals agent;
+
+    @Before
+    public void setup() throws Exception {
+        depositDestination = pidMinter.mintContentPid();
+        agent = new AgentPrincipals("user", new AccessGroupSet());
+
+        actionMonitor = supervisor.actionMonitoringTask;
+
+        pipelineStatusFactory.setPipelineState(DepositPipelineState.active);
+        // Turn up monitoring speed so tests are shorter
+        supervisor.setActionMonitorDelay(25l);
+    }
+
+    @Test
+    public void queueNewDepositRequested() throws Exception {
+        PID depositPid = queueDeposit();
+
+        assertDepositStatus(DepositState.unregistered, depositPid);
+        assertDepositAction(DepositAction.register, depositPid);
+
+        // Run once to process the submitted deposit
+        actionMonitor.run();
+
+        assertDepositStatus(DepositState.queued, depositPid);
+        assertDepositAction(null, depositPid);
+    }
+
+    @Test
+    public void noNewActionsRequested() throws Exception {
+        PID depositPid = queueDeposit(true, DepositState.queued);
+
+        actionMonitor.run();
+
+        assertDepositStatus(DepositState.queued, depositPid);
+        assertPipelineStatus(DepositPipelineState.active);
+    }
+
+    @Test
+    public void pauseAndResumeDeposit() throws Exception {
+        PID depositPid = queueDeposit(true, DepositState.queued);
+
+        requestDepositAction(depositPid, DepositAction.pause);
+
+        actionMonitor.run();
+
+        assertDepositStatus(DepositState.paused, depositPid);
+
+        requestDepositAction(depositPid, DepositAction.resume);
+
+        actionMonitor.run();
+
+        assertDepositStatus(DepositState.queued, depositPid);
+    }
+
+    @Test
+    public void quietPipelineInInvalidState() throws Exception {
+        pipelineStatusFactory.setPipelineState(DepositPipelineState.shutdown);
+
+        pipelineStatusFactory.requestPipelineAction(DepositPipelineAction.quiet);
+
+        actionMonitor.run();
+
+        assertPipelineStatus(DepositPipelineState.shutdown);
+        assertPipelineAction(null);
+    }
+
+    @Test
+    public void unquietPipelineInInvalidState() throws Exception {
+        pipelineStatusFactory.setPipelineState(DepositPipelineState.active);
+
+        pipelineStatusFactory.requestPipelineAction(DepositPipelineAction.unquiet);
+
+        actionMonitor.run();
+
+        assertPipelineStatus(DepositPipelineState.active);
+        assertPipelineAction(null);
+    }
+
+    @Test
+    public void quietAndUnquietWithRunningDeposit() throws Exception {
+        PID depositPid = queueDeposit(true, DepositState.running);
+        actionMonitor.run();
+
+        assertWorkersPaused(false);
+
+        // Quiet the pipeline
+        pipelineStatusFactory.requestPipelineAction(DepositPipelineAction.quiet);
+
+        actionMonitor.run();
+
+        assertPipelineStatus(DepositPipelineState.quieted);
+        assertPipelineAction(null);
+        assertWorkersPaused(true);
+
+        assertDepositStatus(DepositState.quieted, depositPid);
+
+        // Unquiet pipeline
+        pipelineStatusFactory.requestPipelineAction(DepositPipelineAction.unquiet);
+
+        actionMonitor.run();
+
+        assertPipelineStatus(DepositPipelineState.active);
+        assertPipelineAction(null);
+
+        assertDepositStatus(DepositState.quieted, depositPid);
+        assertDepositAction(DepositAction.resume, depositPid);
+
+        assertWorkersPaused(false);
+
+        // One more pass to resume the deposits
+        actionMonitor.run();
+
+        assertPipelineStatus(DepositPipelineState.active);
+
+        assertDepositStatus(DepositState.queued, depositPid);
+        assertDepositAction(null, depositPid);
+    }
+
+    @Test
+    public void quietAndUnquietWithQueuedDeposit() throws Exception {
+        PID depositPid = queueDeposit(true, DepositState.queued);
+
+        // Quiet the pipeline
+        pipelineStatusFactory.requestPipelineAction(DepositPipelineAction.quiet);
+
+        actionMonitor.run();
+
+        assertPipelineStatus(DepositPipelineState.quieted);
+        assertWorkersPaused(true);
+
+        // Queued state should be unaffected
+        assertDepositStatus(DepositState.queued, depositPid);
+
+        // Unquiet pipeline
+        pipelineStatusFactory.requestPipelineAction(DepositPipelineAction.unquiet);
+
+        actionMonitor.run();
+
+        assertPipelineStatus(DepositPipelineState.active);
+        assertWorkersPaused(false);
+
+        assertDepositStatus(DepositState.queued, depositPid);
+        assertDepositAction(null, depositPid);
+    }
+
+    @Test
+    public void quietAndUnquietWithPauseAction() throws Exception {
+        PID depositPid = queueDeposit(true, DepositState.running);
+
+        // Quiet the pipeline
+        pipelineStatusFactory.requestPipelineAction(DepositPipelineAction.quiet);
+
+        actionMonitor.run();
+
+        assertPipelineStatus(DepositPipelineState.quieted);
+        assertWorkersPaused(true);
+
+        assertDepositStatus(DepositState.quieted, depositPid);
+
+        // Attempt to pause deposit, which should have no effect currently
+        requestDepositAction(depositPid, DepositAction.pause);
+
+        actionMonitor.run();
+
+        assertDepositStatus(DepositState.quieted, depositPid);
+        assertDepositAction(DepositAction.pause, depositPid);
+
+        // Unquiet pipeline
+        pipelineStatusFactory.requestPipelineAction(DepositPipelineAction.unquiet);
+
+        actionMonitor.run();
+
+        assertPipelineStatus(DepositPipelineState.active);
+        assertPipelineAction(null);
+        assertWorkersPaused(false);
+
+        // Requested pause action should survive the unquieting
+        assertDepositStatus(DepositState.quieted, depositPid);
+        assertDepositAction(DepositAction.pause, depositPid);
+
+        // One more pass to trigger the pause action
+        actionMonitor.run();
+
+        assertDepositStatus(DepositState.paused, depositPid);
+        assertDepositAction(null, depositPid);
+    }
+
+    @Test
+    public void stopPipelineInInvalidState() throws Exception {
+        pipelineStatusFactory.setPipelineState(DepositPipelineState.shutdown);
+
+        pipelineStatusFactory.requestPipelineAction(DepositPipelineAction.stop);
+
+        actionMonitor.run();
+
+        assertPipelineStatus(DepositPipelineState.shutdown);
+        assertPipelineAction(null);
+    }
+
+    @DirtiesContext(methodMode = MethodMode.BEFORE_METHOD)
+    @Test
+    public void stopPipeline() throws Exception {
+        assertWorkersShutdown(false);
+
+        pipelineStatusFactory.requestPipelineAction(DepositPipelineAction.stop);
+
+        actionMonitor.run();
+
+        assertPipelineStatus(DepositPipelineState.stopped);
+        assertPipelineAction(null);
+
+        assertWorkersShutdown(true);
+
+        // Queue a deposit and show that the action is not performed while stopped
+        PID depositPid = queueDeposit();
+
+        actionMonitor.run();
+
+        assertDepositStatus(DepositState.unregistered, depositPid);
+        assertDepositAction(DepositAction.register, depositPid);
+
+        // Attempt to unquiet in order to resume, which should have no affect
+        pipelineStatusFactory.requestPipelineAction(DepositPipelineAction.unquiet);
+
+        actionMonitor.run();
+
+        assertPipelineStatus(DepositPipelineState.stopped);
+        assertPipelineAction(null);
+
+        assertWorkersShutdown(true);
+    }
+
+    @DirtiesContext(methodMode = MethodMode.BEFORE_METHOD)
+    @Test
+    public void startSupervisorProcessAndPauseDeposit() throws Exception {
+        supervisor.setActionMonitorDelay(25l);
+
+        supervisor.start();
+
+        PID depositPid = queueDeposit();
+
+        Thread.sleep(50l);
+
+        assertDepositStatus(DepositState.queued, depositPid);
+        assertDepositAction(null, depositPid);
+
+        requestDepositAction(depositPid, DepositAction.pause);
+
+        Thread.sleep(50l);
+
+        assertDepositStatus(DepositState.paused, depositPid);
+        assertDepositAction(null, depositPid);
+    }
+
+    @DirtiesContext(methodMode = MethodMode.BEFORE_METHOD)
+    @Test
+    public void startSupervisorWithRunningDeposit() throws Exception {
+        PID depositPid = queueDeposit(true, DepositState.running);
+
+        supervisor.start();
+
+        assertDepositAction(DepositAction.resume, depositPid);
+
+        Thread.sleep(50l);
+
+        assertDepositStatus(DepositState.queued, depositPid);
+        assertDepositAction(null, depositPid);
+    }
+
+    @DirtiesContext(methodMode = MethodMode.BEFORE_METHOD)
+    @Test
+    public void startSupervisorWithQuietedDeposit() throws Exception {
+        PID depositPid = queueDeposit(true, DepositState.quieted);
+
+        supervisor.start();
+
+        assertDepositAction(DepositAction.resume, depositPid);
+
+        Thread.sleep(50l);
+
+        assertDepositStatus(DepositState.queued, depositPid);
+        assertDepositAction(null, depositPid);
+    }
+
+    @DirtiesContext(methodMode = MethodMode.BEFORE_METHOD)
+    @Test
+    public void startSupervisorWithPausedDeposit() throws Exception {
+        PID depositPid = queueDeposit(true, DepositState.paused);
+
+        supervisor.start();
+
+        assertDepositAction(null, depositPid);
+
+        Thread.sleep(50l);
+
+        assertDepositStatus(DepositState.paused, depositPid);
+        assertDepositAction(null, depositPid);
+    }
+
+    @DirtiesContext(methodMode = MethodMode.BEFORE_METHOD)
+    @Test
+    public void startSupervisorWithNewQueuedDeposit() throws Exception {
+        PID depositPid = queueDeposit(true, DepositState.queued);
+
+        supervisor.start();
+
+        assertDepositAction(DepositAction.register, depositPid);
+
+        Thread.sleep(50l);
+
+        assertDepositStatus(DepositState.queued, depositPid);
+        assertDepositAction(null, depositPid);
+    }
+
+    /*
+     * TODO tests for the following:
+     * * queue different priorities
+     * * next jobs come back in expected orders
+     * * normalization jobs selected correctly
+     * * handles case of no matching normalization job
+     * * job started event processing
+     * * job success event processing
+     * * job failure event tests
+     * * deposit completion
+     */
+
+    private void assertWorkersPaused(boolean expectedValue) {
+        for (WorkerPool workerPool : depositWorkerPools) {
+            assertEquals("Expected worker to be " + (expectedValue ? "" : "un") + "paused, but it was not",
+                    expectedValue, workerPool.isPaused());
+        }
+    }
+
+    private void assertWorkersShutdown(boolean expectedValue) {
+        for (WorkerPool workerPool : depositWorkerPools) {
+            assertEquals("Expected worker to " + (expectedValue ? "not " : "") + " be shutdown, but it was",
+                    expectedValue, workerPool.isShutdown());
+        }
+    }
+
+    private void assertDepositStatus(DepositState expectedState, PID depositPid) {
+        assertEquals(expectedState, depositStatusFactory.getState(depositPid.getId()));
+    }
+
+    private void assertDepositAction(DepositAction expectedAction, PID depositPid) {
+        Map<String, String> status = depositStatusFactory.get(depositPid.getId());
+        DepositAction action;
+        if (status.containsKey(DepositField.actionRequest.name())) {
+            action = DepositAction.valueOf(status.get(DepositField.actionRequest.name()));
+        } else {
+            action = null;
+        }
+        assertEquals(expectedAction, action);
+    }
+
+    private void assertPipelineStatus(DepositPipelineState expectedState) {
+        assertEquals(expectedState, pipelineStatusFactory.getPipelineState());
+    }
+
+    private void assertPipelineAction(DepositPipelineAction expectedAction) {
+        assertEquals(expectedAction, pipelineStatusFactory.getPipelineAction());
+    }
+
+    private void requestDepositAction(PID depositPid, DepositAction action) {
+        depositStatusFactory.requestAction(depositPid.getId(), action);
+    }
+
+    private PID queueDeposit() throws DepositException {
+        return queueDeposit(false, null);
+    }
+
+    private PID queueDeposit(boolean clearAction, DepositState finalState) throws DepositException {
+        PID depositPid = queueDeposit(PackagingType.DIRECTORY, Priority.normal);
+        if (clearAction) {
+            depositStatusFactory.clearActionRequest(depositPid.getId());
+        }
+        if (finalState != null) {
+            depositStatusFactory.setState(depositPid.getId(), finalState);
+        }
+        return depositPid;
+    }
+
+    private PID queueDeposit(PackagingType packagingType, Priority priority) throws DepositException {
+        AbstractDepositHandler depositHandler = new AbstractDepositHandler() {
+            @Override
+            public PID doDeposit(PID destination, DepositData deposit) throws DepositException {
+                PID depositPID = pidMinter.mintDepositRecordPid();
+                registerDeposit(depositPID, destination, deposit, null);
+                return depositPID;
+            }
+
+        };
+        depositHandler.setDepositStatusFactory(depositStatusFactory);
+        depositHandler.setPidMinter(pidMinter);
+        depositHandler.setDepositsDirectory(tmpFolder.getRoot());
+
+        DepositData deposit = new DepositData(null, null, packagingType, null, agent);
+        deposit.setPriority(priority);
+        return depositHandler.doDeposit(depositDestination, deposit);
+    }
+}

--- a/deposit/src/test/java/edu/unc/lib/deposit/work/DepositSupervisorTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/work/DepositSupervisorTest.java
@@ -132,6 +132,9 @@ public class DepositSupervisorTest {
 
         actionMonitor.run();
 
+        // Allow time for redis to sync up
+        Thread.sleep(10);
+
         assertDepositStatus(DepositState.queued, depositPid);
     }
 

--- a/deposit/src/test/resources/spring-test/cdr-client-container.xml
+++ b/deposit/src/test/resources/spring-test/cdr-client-container.xml
@@ -161,6 +161,17 @@
         <constructor-arg type="int" value="${redis.port:46380}" />
     </bean>
     
+    <bean id="jesqueConfig" class="net.greghaines.jesque.Config">
+        <constructor-arg value="localhost" type="java.lang.String" />
+        <constructor-arg value="46380" type="int" />
+        <constructor-arg value="2000" type="int" />
+        <constructor-arg type="java.lang.String">
+            <null />
+        </constructor-arg>
+        <constructor-arg value="resque" type="java.lang.String" />
+        <constructor-arg value="0" type="int" />
+    </bean>
+    
     <bean id="poolConfig" class="redis.clients.jedis.JedisPoolConfig">
         <property name="maxIdle" value="15"/>
         <property name="minIdle" value="2"/>
@@ -168,6 +179,10 @@
     </bean>
     
     <bean id="depositStatusFactory" class="edu.unc.lib.dl.util.DepositStatusFactory">
+        <property name="jedisPool" ref="jedisPool" />
+    </bean>
+    
+    <bean id="pipelineStatusFactory" class="edu.unc.lib.dl.util.DepositPipelineStatusFactory">
         <property name="jedisPool" ref="jedisPool" />
     </bean>
     

--- a/deposit/src/test/resources/spring-test/deposit-supervisor-test-context.xml
+++ b/deposit/src/test/resources/spring-test/deposit-supervisor-test-context.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xmlns:util="http://www.springframework.org/schema/util"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/util 
+        http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context.xsd">
+
+    <context:property-placeholder />
+    
+    <bean id="operationsMessageSender" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.services.OperationsMessageSender" />
+    </bean>
+    
+    <bean id="depositEmailHandler" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.deposit.work.DepositEmailHandler" />
+    </bean>
+    
+    <bean id="mockDepositDirectory" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="java.io.File" />
+    </bean>
+    
+    <bean id="queueDAO" class="net.greghaines.jesque.meta.dao.impl.QueueInfoDAORedisImpl">
+        <constructor-arg ref="jesqueConfig" />
+        <constructor-arg ref="jedisPool" />
+    </bean>
+    
+    <bean id="jobFactory" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.util.SpringJobFactory" />
+    </bean>
+    
+    <bean id="depositWorkerPool" class="net.greghaines.jesque.worker.WorkerPool">
+        <constructor-arg name="workerFactory">
+            <bean class="net.greghaines.jesque.worker.WorkerImplFactory">
+                <constructor-arg name="config" ref="jesqueConfig" />
+                <constructor-arg name="queues">
+                    <util:list>
+                        <value>PREPARE</value>
+                        <value>DELAYED_PREPARE</value>
+                    </util:list>
+                </constructor-arg>
+                <constructor-arg ref="jobFactory" />
+            </bean>
+        </constructor-arg>
+        <constructor-arg name="numWorkers" value="2" />
+    </bean>
+    
+    <bean id="highPriorityDepositWorkerPool" class="net.greghaines.jesque.worker.WorkerPool">
+        <constructor-arg name="workerFactory">
+            <bean class="net.greghaines.jesque.worker.WorkerImplFactory">
+                <constructor-arg name="config" ref="jesqueConfig" />
+                <constructor-arg name="queues">
+                    <util:list>
+                        <value>PREPARE_HIGH_PRIORITY</value>
+                    </util:list>
+                </constructor-arg>
+                <constructor-arg ref="jobFactory" />
+            </bean>
+        </constructor-arg>
+        <constructor-arg name="numWorkers" value="2" />
+    </bean>
+    
+    <util:list id="depositWorkerPools" value-type="net.greghaines.jesque.worker.WorkerPool">
+        <ref bean="depositWorkerPool"/>
+        <ref bean="highPriorityDepositWorkerPool"/>
+    </util:list>
+    
+    <bean id="depositSupervisor" class="edu.unc.lib.deposit.work.DepositSupervisor" >
+        <property name="jesqueConfig" ref="jesqueConfig"/>
+        <property name="cleanupDelaySeconds" value="${cleanup.delay.seconds:60}"/>
+        <property name="unavailableDelaySeconds" value="${unavailable.delay.seconds:60}"/>
+    </bean>
+</beans>

--- a/metadata/src/main/java/edu/unc/lib/dl/util/DepositPipelineStatusFactory.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/util/DepositPipelineStatusFactory.java
@@ -71,7 +71,11 @@ public class DepositPipelineStatusFactory {
      */
     public void setPipelineState(DepositPipelineState state) {
         try (Jedis jedis = getJedisPool().getResource()) {
-            jedis.set(DEPOSIT_PIPELINE_STATE, state.name());
+            if (state == null) {
+                jedis.del(DEPOSIT_PIPELINE_STATE);
+            } else {
+                jedis.set(DEPOSIT_PIPELINE_STATE, state.name());
+            }
         }
     }
 
@@ -81,10 +85,7 @@ public class DepositPipelineStatusFactory {
     public DepositPipelineState getPipelineState() {
         try (Jedis jedis = getJedisPool().getResource()) {
             String state = jedis.get(DEPOSIT_PIPELINE_STATE);
-            if (state == null) {
-                return null;
-            }
-            return DepositPipelineState.valueOf(state);
+            return DepositPipelineState.fromName(state);
         }
     }
 

--- a/metadata/src/main/java/edu/unc/lib/dl/util/DepositPipelineStatusFactory.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/util/DepositPipelineStatusFactory.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.util;
+
+import static edu.unc.lib.dl.util.RedisWorkerConstants.DEPOSIT_PIPELINE_ACTION;
+import static edu.unc.lib.dl.util.RedisWorkerConstants.DEPOSIT_PIPELINE_STATE;
+
+import edu.unc.lib.dl.util.RedisWorkerConstants.DepositPipelineAction;
+import edu.unc.lib.dl.util.RedisWorkerConstants.DepositPipelineState;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+/**
+ * Service for interactions with the state of the deposit pipeline
+ *
+ * @author bbpennel
+ */
+public class DepositPipelineStatusFactory {
+
+    private JedisPool jedisPool;
+
+    /**
+     * @return action being requested against the deposit pipeline as a whole
+     */
+    public DepositPipelineAction getPipelineAction() {
+        try (Jedis jedis = getJedisPool().getResource()) {
+            String action = jedis.get(DEPOSIT_PIPELINE_ACTION);
+            if (action == null) {
+                return null;
+            }
+            return DepositPipelineAction.valueOf(action);
+        }
+    }
+
+    /**
+     * Request an action be taken on the deposit pipeline
+     * @param action action to request
+     */
+    public void requestPipelineAction(DepositPipelineAction action) {
+        try (Jedis jedis = getJedisPool().getResource()) {
+            jedis.set(DEPOSIT_PIPELINE_ACTION, action.name());
+        }
+    }
+
+    /**
+     * Clear the requested pipeline action if there is one
+     */
+    public void clearPipelineActionRequest() {
+        try (Jedis jedis = getJedisPool().getResource()) {
+            jedis.del(DEPOSIT_PIPELINE_ACTION);
+        }
+    }
+
+    /**
+     * Set the state of the deposit pipeline
+     *
+     * @param state new state for the pipeline
+     */
+    public void setPipelineState(DepositPipelineState state) {
+        try (Jedis jedis = getJedisPool().getResource()) {
+            jedis.set(DEPOSIT_PIPELINE_STATE, state.name());
+        }
+    }
+
+    /**
+     * @return state of the deposit pipeline
+     */
+    public DepositPipelineState getPipelineState() {
+        try (Jedis jedis = getJedisPool().getResource()) {
+            String state = jedis.get(DEPOSIT_PIPELINE_STATE);
+            if (state == null) {
+                return null;
+            }
+            return DepositPipelineState.valueOf(state);
+        }
+    }
+
+    /**
+     * Clear the pipeline state
+     */
+    public void clearPipelineState() {
+        try (Jedis jedis = getJedisPool().getResource()) {
+            jedis.del(DEPOSIT_PIPELINE_STATE);
+        }
+    }
+
+    public void setJedisPool(JedisPool jedisPool) {
+        this.jedisPool = jedisPool;
+    }
+
+    private JedisPool getJedisPool() {
+        return jedisPool;
+    }
+}

--- a/metadata/src/main/java/edu/unc/lib/dl/util/RedisWorkerConstants.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/util/RedisWorkerConstants.java
@@ -65,15 +65,15 @@ public class RedisWorkerConstants {
      *
      */
     public static enum DepositAction {
-        register, pause, resume, cancel, destroy, quiet;
+        register, pause, resume, cancel, destroy;
     }
 
     public static enum DepositPipelineState {
-        starting, active, quieted, stopped
+        starting, active, quieted, stopped, shutdown
     }
 
     public static enum DepositPipelineAction {
-        quiet, quietNow
+        quiet, unquiet, stop
     }
 
     private RedisWorkerConstants() {

--- a/metadata/src/main/java/edu/unc/lib/dl/util/RedisWorkerConstants.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/util/RedisWorkerConstants.java
@@ -20,6 +20,8 @@ public class RedisWorkerConstants {
     public static final String DEPOSIT_METRICS_PREFIX = "deposit-metrics:";
     public static final String DEPOSIT_MANIFEST_PREFIX = "deposit-manifest:";
     public static final String DEPOSIT_TO_JOBS_PREFIX = "deposit-to-jobs:";
+    public static final String DEPOSIT_PIPELINE_STATE = "deposit-pipeline-state";
+    public static final String DEPOSIT_PIPELINE_ACTION = "deposit-pipeline-action";
     public static final String JOB_STATUS_PREFIX = "job-status:";
     public static final String BULK_UPDATE_PREFIX = "bulk-update:";
     public static final String BULK_RESUME_PREFIX = "bulk-resume:";
@@ -49,7 +51,7 @@ public class RedisWorkerConstants {
     }
 
     public static enum DepositState {
-        unregistered, queued, running, paused, finished, cancelled, failed;
+        unregistered, queued, running, paused, finished, cancelled, failed, quieted;
     }
 
     public static enum Priority {
@@ -63,7 +65,15 @@ public class RedisWorkerConstants {
      *
      */
     public static enum DepositAction {
-        register, pause, resume, cancel, destroy;
+        register, pause, resume, cancel, destroy, quiet;
+    }
+
+    public static enum DepositPipelineState {
+        starting, active, quieted, stopped
+    }
+
+    public static enum DepositPipelineAction {
+        quiet, quietNow
     }
 
     private RedisWorkerConstants() {

--- a/metadata/src/main/java/edu/unc/lib/dl/util/RedisWorkerConstants.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/util/RedisWorkerConstants.java
@@ -69,11 +69,27 @@ public class RedisWorkerConstants {
     }
 
     public static enum DepositPipelineState {
-        starting, active, quieted, stopped, shutdown
+        starting, active, quieted, stopped, shutdown;
+
+        public static DepositPipelineState fromName(String name) {
+            try {
+                return valueOf(name);
+            } catch (IllegalArgumentException | NullPointerException e) {
+                return null;
+            }
+        }
     }
 
     public static enum DepositPipelineAction {
-        quiet, unquiet, stop
+        quiet, unquiet, stop;
+
+        public static DepositPipelineAction fromName(String name) {
+            try {
+                return valueOf(name);
+            } catch (IllegalArgumentException | NullPointerException e) {
+                return null;
+            }
+        }
     }
 
     private RedisWorkerConstants() {

--- a/metadata/src/test/java/edu/unc/lib/dl/util/DepositPipelineStatusFactoryIT.java
+++ b/metadata/src/test/java/edu/unc/lib/dl/util/DepositPipelineStatusFactoryIT.java
@@ -70,7 +70,7 @@ public class DepositPipelineStatusFactoryIT {
     public void requestGetAndClearAction() {
         factory.clearPipelineActionRequest();
         assertNull(factory.getPipelineAction());
-        factory.requestPipelineAction(DepositPipelineAction.quietNow);
-        assertEquals(DepositPipelineAction.quietNow, factory.getPipelineAction());
+        factory.requestPipelineAction(DepositPipelineAction.stop);
+        assertEquals(DepositPipelineAction.stop, factory.getPipelineAction());
     }
 }

--- a/metadata/src/test/java/edu/unc/lib/dl/util/DepositPipelineStatusFactoryIT.java
+++ b/metadata/src/test/java/edu/unc/lib/dl/util/DepositPipelineStatusFactoryIT.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import edu.unc.lib.dl.util.RedisWorkerConstants.DepositPipelineAction;
+import edu.unc.lib.dl.util.RedisWorkerConstants.DepositPipelineState;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+/**
+ * @author bbpennel
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration({"/spring-test/cdr-client-container.xml"})
+public class DepositPipelineStatusFactoryIT {
+
+    private DepositPipelineStatusFactory factory;
+    @Autowired
+    private JedisPool jedisPool;
+    private Jedis jedisResource;
+
+    @Before
+    public void init() {
+        factory = new DepositPipelineStatusFactory();
+        factory.setJedisPool(jedisPool);
+        jedisResource = jedisPool.getResource();
+        jedisResource.flushAll();
+    }
+
+    @After
+    public void cleanup() {
+        jedisResource.close();
+    }
+
+    @Test
+    public void clearSetAndGetState() {
+        factory.clearPipelineState();
+        assertNull(factory.getPipelineState());
+        factory.setPipelineState(DepositPipelineState.active);
+        assertEquals(DepositPipelineState.active, factory.getPipelineState());
+        factory.setPipelineState(DepositPipelineState.quieted);
+        assertEquals(DepositPipelineState.quieted, factory.getPipelineState());
+    }
+
+    @Test
+    public void requestGetAndClearAction() {
+        factory.clearPipelineActionRequest();
+        assertNull(factory.getPipelineAction());
+        factory.requestPipelineAction(DepositPipelineAction.quietNow);
+        assertEquals(DepositPipelineAction.quietNow, factory.getPipelineAction());
+    }
+}

--- a/metadata/src/test/java/edu/unc/lib/dl/util/DepositStatusFactoryIT.java
+++ b/metadata/src/test/java/edu/unc/lib/dl/util/DepositStatusFactoryIT.java
@@ -15,7 +15,11 @@
  */
 package edu.unc.lib.dl.util;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -36,19 +40,19 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 
 /**
- * 
+ *
  * @author harring
  *
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration({"/spring-test/cdr-client-container.xml"})
 public class DepositStatusFactoryIT {
-    
+
     private DepositStatusFactory factory;
     @Autowired
     private JedisPool jedisPool;
     private Jedis jedisResource;
-    
+
     @Before
     public void init() {
         factory = new DepositStatusFactory();
@@ -56,10 +60,10 @@ public class DepositStatusFactoryIT {
         jedisResource = jedisPool.getResource();
         jedisResource.flushAll();
     }
-    
+
     @After
     public void cleanup() {
-        jedisPool.returnResourceObject(jedisResource);
+        jedisResource.close();
     }
 
     @Test
@@ -67,16 +71,16 @@ public class DepositStatusFactoryIT {
         final String uuid = UUID.randomUUID().toString();
         final String filename1 = "bagit.txt";
         final String filename2 = "manifest-md5.txt";
-        
+
         factory.addManifest(uuid, filename1);
         factory.addManifest(uuid,  filename2);
         List<String> filenames = factory.getManifestURIs(uuid);
-        
+
         assertEquals(filenames.size(), 2);
         assertEquals(filename1, filenames.get(0));
         assertEquals(filename2, filenames.get(1));
     }
-    
+
     @Test
     public void testAddRemoveSupervisorLock() {
         final String uuid = UUID.randomUUID().toString();
@@ -87,37 +91,37 @@ public class DepositStatusFactoryIT {
         factory.removeSupervisorLock(uuid);
         assertTrue(factory.addSupervisorLock(uuid, owner2));
     }
-    
+
     @Test
     public void testSetStateGetState() {
         final String uuid = UUID.randomUUID().toString();
         factory.setState(uuid, DepositState.queued);
         assertEquals(DepositState.queued, factory.getState(uuid));
     }
-    
+
     @Test
     public void testSetGetDeleteField() {
         final String uuid = UUID.randomUUID().toString();
         factory.set(uuid, DepositField.contactName, "Boxy");
         factory.set(uuid, DepositField.fileName, "boxys_file.txt");
-        
+
         Map<String,String> status = factory.get(uuid);
         assertEquals(status.size(), 2);
         assertEquals("Boxy", status.get(DepositField.contactName.toString()));
         assertEquals("boxys_file.txt", status.get(DepositField.fileName.toString()));
-        
+
         factory.deleteField(uuid, DepositField.fileName);
         status = factory.get(uuid);
         assertNull(status.get(DepositField.fileName.toString()));
         assertEquals(status.size(), 1);
-        
+
         final String uuid2 = UUID.randomUUID().toString();
         factory.set(uuid2, DepositField.depositorName, "FriendOfBoxy");
-        
+
         Set<Map<String,String>> statuses = factory.getAll();
         assertEquals(statuses.size(), 2);
     }
-    
+
     @Test
     public void testRequestClearAction() {
         final String uuid = UUID.randomUUID().toString();
@@ -128,24 +132,24 @@ public class DepositStatusFactoryIT {
         status = factory.get(uuid);
         assertNull(status.get(DepositField.actionRequest.name()));
     }
-    
+
     @Test
     public void testExpireFail() throws InterruptedException {
         final String uuid = UUID.randomUUID().toString();
         factory.set(uuid, DepositField.contactName, "Boxy");
         final String uuid2 = UUID.randomUUID().toString();
         factory.set(uuid2, DepositField.depositorName, "FriendOfBoxy");
-        
+
         //delete the uuid status by expiring its key
         factory.expireKeys(uuid, 1);
         Thread.sleep(1000);
         Set<Map<String,String>> statuses = factory.getAll();
         assertEquals(statuses.size(), 1);
-        
+
         factory.fail(uuid2, "Boxy is sad");
         assertEquals("Boxy is sad", factory.get(uuid2).get(DepositField.errorMessage.name()));
     }
-    
+
     @Test
     public void testInProgressIsResumed() {
         final String uuid = UUID.randomUUID().toString();

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/DepositPipelineController.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/DepositPipelineController.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.cdr.services.rest;
+
+import static edu.unc.lib.dl.acl.util.GroupsThreadStore.getAgentPrincipals;
+import static java.util.Collections.singletonMap;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import edu.unc.lib.dl.acl.fcrepo4.GlobalPermissionEvaluator;
+import edu.unc.lib.dl.acl.util.AccessGroupSet;
+import edu.unc.lib.dl.acl.util.Permission;
+import edu.unc.lib.dl.util.DepositPipelineStatusFactory;
+import edu.unc.lib.dl.util.RedisWorkerConstants.DepositPipelineAction;
+import edu.unc.lib.dl.util.RedisWorkerConstants.DepositPipelineState;
+
+/**
+ * Controller for API endpoints to interact with the deposit pipeline.
+ *
+ * @author bbpennel
+ */
+@Controller
+@RequestMapping(value = { "/edit/depositPipeline" })
+public class DepositPipelineController {
+    private static final Logger log = LoggerFactory
+            .getLogger(DepositPipelineController.class);
+
+    public static final String ERROR_KEY = "error";
+    public static final String STATE_KEY = "state";
+    public static final String ACTION_KEY = "requestedAction";
+
+    @Autowired
+    private DepositPipelineStatusFactory pipelineStatusFactory;
+
+    @Autowired
+    private GlobalPermissionEvaluator globalPermissionEvaluator;
+
+    /**
+     * Retrieve the current state of the deposit pipeline
+     *
+     * @return json response containing the state, or an error if unauthorized
+     */
+    @GetMapping(produces = APPLICATION_JSON_VALUE)
+    public @ResponseBody ResponseEntity<Object> getState() {
+        AccessGroupSet principals = getAgentPrincipals().getPrincipals();
+        if (!globalPermissionEvaluator.hasGlobalPermission(principals, Permission.ingest)) {
+            return new ResponseEntity<>(singletonMap(ERROR_KEY, "Unauthorized"), HttpStatus.UNAUTHORIZED);
+        }
+
+        DepositPipelineState pipelineState = pipelineStatusFactory.getPipelineState();
+        String pipeline = pipelineState == null ? "unknown" : pipelineState.toString();
+
+        log.debug("Retrieve deposit pipeline state {}", pipelineState);
+
+        return new ResponseEntity<>(singletonMap(STATE_KEY, pipeline), HttpStatus.OK);
+    }
+
+    /**
+     * Request an action be taken on the deposit pipeline
+     *
+     * @param actionName name of the action being requested
+     * @return response indicating the requested action if successful, or an error if unauthorized
+     *      or an invalid action was requested
+     */
+    @PostMapping( path = { "{actionName}", "/{actionName}" }, produces = APPLICATION_JSON_VALUE )
+    public @ResponseBody ResponseEntity<Object> requestAction(@PathVariable String actionName) {
+        AccessGroupSet principals = getAgentPrincipals().getPrincipals();
+        if (!globalPermissionEvaluator.hasGlobalPermission(principals, Permission.createAdminUnit)) {
+            return new ResponseEntity<>(singletonMap(ERROR_KEY, "Unauthorized"), HttpStatus.UNAUTHORIZED);
+        }
+
+        DepositPipelineAction action = DepositPipelineAction.fromName(actionName);
+        if (action == null) {
+            String allowed = Arrays.stream(DepositPipelineAction.values())
+                    .map(DepositPipelineAction::name)
+                    .collect(Collectors.joining(", "));
+            return new ResponseEntity<>(
+                    singletonMap(ERROR_KEY, "Invalid action specified, must specify one of the follow: " + allowed),
+                    HttpStatus.BAD_REQUEST);
+        }
+
+        log.info("Requesting deposit pipeline action {}", actionName);
+        pipelineStatusFactory.requestPipelineAction(action);
+
+        return new ResponseEntity<>(singletonMap(ACTION_KEY, actionName), HttpStatus.OK);
+    }
+
+}

--- a/services/src/main/webapp/WEB-INF/deposits-context.xml
+++ b/services/src/main/webapp/WEB-INF/deposits-context.xml
@@ -50,6 +50,10 @@
         <property name="jedisPool" ref="jedisPool" />
     </bean>
     
+    <bean id="depositPipelineStatusFactory" class="edu.unc.lib.dl.util.DepositPipelineStatusFactory">
+        <property name="jedisPool" ref="jedisPool" />
+    </bean>
+    
     <bean id="jobStatusFactory" class="edu.unc.lib.dl.util.JobStatusFactory">
         <property name="jedisPool" ref="jedisPool" />
     </bean>

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/DepositPipelineControllerIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/DepositPipelineControllerIT.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.cdr.services.rest;
+
+import static edu.unc.lib.dl.cdr.services.rest.DepositPipelineController.ACTION_KEY;
+import static edu.unc.lib.dl.cdr.services.rest.DepositPipelineController.ERROR_KEY;
+import static edu.unc.lib.dl.cdr.services.rest.DepositPipelineController.STATE_KEY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.unc.lib.dl.acl.util.AccessGroupSet;
+import edu.unc.lib.dl.acl.util.GroupsThreadStore;
+import edu.unc.lib.dl.cdr.services.rest.modify.AbstractAPIIT;
+import edu.unc.lib.dl.util.DepositPipelineStatusFactory;
+import edu.unc.lib.dl.util.RedisWorkerConstants.DepositPipelineState;
+
+/**
+ * @author bbpennel
+ */
+@ContextHierarchy({
+    @ContextConfiguration("/spring-test/redis-server-context.xml"),
+    @ContextConfiguration("/deposit-pipeline-it-servlet.xml")
+})
+public class DepositPipelineControllerIT extends AbstractAPIIT {
+
+    @Autowired
+    private DepositPipelineStatusFactory pipelineStatusFactory;
+
+    @Before
+    public void setup() {
+        pipelineStatusFactory.clearPipelineActionRequest();
+        pipelineStatusFactory.setPipelineState(null);
+    }
+
+    @Test
+    public void getState_ValidState() throws Exception {
+        pipelineStatusFactory.setPipelineState(DepositPipelineState.active);
+
+        MvcResult result = mvc.perform(get("/edit/depositPipeline"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Map<String, Object> respMap = getMapFromResponse(result);
+        assertEquals(DepositPipelineState.active.name(), respMap.get(STATE_KEY));
+    }
+
+    @Test
+    public void getState_NoState() throws Exception {
+        MvcResult result = mvc.perform(get("/edit/depositPipeline"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Map<String, Object> respMap = getMapFromResponse(result);
+        assertEquals("unknown", respMap.get(STATE_KEY));
+    }
+
+    @Test
+    public void getState_NoPermission() throws Exception {
+        GroupsThreadStore.storeGroups(new AccessGroupSet("authenticated"));
+
+        MvcResult result = mvc.perform(get("/edit/depositPipeline"))
+                .andExpect(status().isUnauthorized())
+                .andReturn();
+
+        Map<String, Object> respMap = getMapFromResponse(result);
+        assertEquals("Unauthorized", respMap.get(ERROR_KEY));
+    }
+
+    @Test
+    public void requestAction_ValidAction() throws Exception {
+        MvcResult result = mvc.perform(post("/edit/depositPipeline/quiet"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Map<String, Object> respMap = getMapFromResponse(result);
+        assertEquals("quiet", respMap.get(ACTION_KEY));
+    }
+
+    @Test
+    public void requestAction_NoPermission() throws Exception {
+        GroupsThreadStore.storeGroups(new AccessGroupSet("authenticated"));
+
+        MvcResult result = mvc.perform(post("/edit/depositPipeline/quiet"))
+                .andExpect(status().isUnauthorized())
+                .andReturn();
+
+        Map<String, Object> respMap = getMapFromResponse(result);
+        assertEquals("Unauthorized", respMap.get(ERROR_KEY));
+    }
+
+    @Test
+    public void requestAction_InvalidAction() throws Exception {
+        MvcResult result = mvc.perform(post("/edit/depositPipeline/plumb"))
+                .andExpect(status().isBadRequest())
+                .andReturn();
+
+        Map<String, Object> respMap = getMapFromResponse(result);
+        assertTrue(((String) respMap.get(ERROR_KEY)).contains("Invalid action specified"));
+    }
+}

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/AbstractAPIIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/AbstractAPIIT.java
@@ -62,7 +62,7 @@ public abstract class AbstractAPIIT {
     protected String baseAddress;
     @Autowired
     protected WebApplicationContext context;
-    @Autowired
+    @Autowired(required = false)
     protected AccessControlService aclService;
     @Autowired(required = false)
     protected RepositoryObjectFactory repositoryObjectFactory;

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/IngestControllerIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/IngestControllerIT.java
@@ -62,6 +62,7 @@ import edu.unc.lib.dl.util.RedisWorkerConstants.DepositField;
  *
  */
 @ContextHierarchy({
+    @ContextConfiguration("/spring-test/redis-server-context.xml"),
     @ContextConfiguration("/spring-test/cdr-client-container.xml"),
     @ContextConfiguration("/ingest-it-servlet.xml")
 })

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/IngestFromSourcesIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/IngestFromSourcesIT.java
@@ -82,6 +82,7 @@ import edu.unc.lib.dl.util.ZipFileUtil;
  *
  */
 @ContextHierarchy({
+    @ContextConfiguration("/spring-test/redis-server-context.xml"),
     @ContextConfiguration("/spring-test/cdr-client-container.xml"),
     @ContextConfiguration("/ingest-it-servlet.xml")
 })

--- a/services/src/test/resources/deposit-pipeline-it-servlet.xml
+++ b/services/src/test/resources/deposit-pipeline-it-servlet.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2008 The University of North Carolina at Chapel Hill
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:mvc="http://www.springframework.org/schema/mvc"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xmlns:util="http://www.springframework.org/schema/util"
+    xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/util 
+        http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/context 
+        http://www.springframework.org/schema/context/spring-context-3.0.xsd
+        http://www.springframework.org/schema/mvc
+        http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd">
+        
+    <mvc:annotation-driven/>
+
+    <context:component-scan resource-pattern="**/DepositPipelineController*" base-package="edu.unc.lib.dl.cdr.services.rest"/>
+    
+    <bean id="aclGlobalProperties"
+        class="org.springframework.beans.factory.config.PropertiesFactoryBean">
+        <property name="locations">
+            <list>
+                <value>classpath:acl-config.properties</value>
+            </list>
+        </property>
+    </bean>
+    
+    <bean id="globalPermissionEvaluator" class="edu.unc.lib.dl.acl.fcrepo4.GlobalPermissionEvaluator">
+        <constructor-arg ref="aclGlobalProperties" />
+    </bean>
+    
+    <bean id="pipelineStatusFactory" class="edu.unc.lib.dl.util.DepositPipelineStatusFactory">
+        <property name="jedisPool" ref="jedisPool" />
+    </bean>
+</beans>

--- a/services/src/test/resources/ingest-it-servlet.xml
+++ b/services/src/test/resources/ingest-it-servlet.xml
@@ -75,23 +75,6 @@
         <constructor-arg value="edu.unc.lib.dl.acl.fcrepo4.AccessControlServiceImpl" />
     </bean>
     
-    <bean id="redisServer" class="redis.embedded.RedisServer" init-method="start" destroy-method="stop">
-        <constructor-arg value="46380" />
-    </bean>
-    
-    <bean id="jedisPool" class="redis.clients.jedis.JedisPool"
-        destroy-method="destroy">
-        <constructor-arg ref="poolConfig"/>
-        <constructor-arg type="String" value="localhost" />
-        <constructor-arg type="int" value="46380" />
-    </bean>
-    
-    <bean id="poolConfig" class="redis.clients.jedis.JedisPoolConfig">
-        <property name="maxIdle" value="15"/>
-        <property name="minIdle" value="2"/>
-        <property name="maxTotal" value="25"/>
-    </bean>
-    
     <bean id="depositStatusFactory" class="edu.unc.lib.dl.util.DepositStatusFactory">
         <property name="jedisPool" ref="jedisPool" />
     </bean>

--- a/services/src/test/resources/spring-test/redis-server-context.xml
+++ b/services/src/test/resources/spring-test/redis-server-context.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2008 The University of North Carolina at Chapel Hill
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context 
+        http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+    
+    <bean id="redisServer" class="redis.embedded.RedisServer" init-method="start" destroy-method="stop">
+        <constructor-arg value="46380" />
+    </bean>
+    
+    <bean id="jedisPool" class="redis.clients.jedis.JedisPool"
+        destroy-method="destroy">
+        <constructor-arg ref="poolConfig"/>
+        <constructor-arg type="String" value="localhost" />
+        <constructor-arg type="int" value="46380" />
+    </bean>
+    
+    <bean id="poolConfig" class="redis.clients.jedis.JedisPoolConfig">
+        <property name="maxIdle" value="15"/>
+        <property name="minIdle" value="2"/>
+        <property name="maxTotal" value="25"/>
+    </bean>
+</beans>

--- a/static/css/admin/cdradmin.css
+++ b/static/css/admin/cdradmin.css
@@ -529,3 +529,19 @@ div.in-admin-iframe,
 .update_button {
 	color: white;
 }
+
+.status_monitor_actions {
+	float: right;
+	margin-top: -40px;
+	margin-bottom: 10px;
+}
+
+.status_monitor_actions > button {
+	width: 10em;
+	height: 2em;
+	box-shadow: 0 0 3px rgba(0, 0, 0, 0.2);
+}
+
+.status_monitor_actions > button:disabled {
+	opacity: 70%;
+}

--- a/static/js/admin/src/action/AjaxCallbackAction.js
+++ b/static/js/admin/src/action/AjaxCallbackAction.js
@@ -157,7 +157,7 @@ define('AjaxCallbackAction', [ 'jquery', 'jquery-ui', 'RemoteStateChangeMonitor'
 	};
 
 	AjaxCallbackAction.prototype.resolveParameters = function(url) {
-		if (!url || !this.context.target.pid)
+		if (!url || !this.context.target || !this.context.target.pid)
 			return url;
 		return url.replace("{idPath}", this.context.target.pid);
 	};

--- a/static/js/admin/src/action/ChangeDepositPipelineStateAction.js
+++ b/static/js/admin/src/action/ChangeDepositPipelineStateAction.js
@@ -1,0 +1,31 @@
+define('ChangeDepositPipelineStateAction', [ 'jquery', 'AjaxCallbackAction'], function($, AjaxCallbackAction) {
+	function ChangeDepositPipelineStateAction(options) {
+		this._create(options);
+	};
+	
+	ChangeDepositPipelineStateAction.prototype.constructor = ChangeDepositPipelineStateAction;
+	ChangeDepositPipelineStateAction.prototype = Object.create( AjaxCallbackAction.prototype );
+	
+	ChangeDepositPipelineStateAction.prototype.actionName = "Delete";
+		
+	ChangeDepositPipelineStateAction.prototype._create = function(context) {
+		this.context = context;
+		
+		this.options = {
+			workMethod: "post",
+			workPath: "/services/api/edit/depositPipeline/" + context.pipelineAction,
+			confirm: {
+				promptText: context.pipelineAction + " the deposit pipeline?",
+				confirmAnchor: context.confirmAnchor
+			}
+		};
+		
+		AjaxCallbackAction.prototype._create.call(this, this.options);
+	};
+	
+	ChangeDepositPipelineStateAction.prototype.completeState = function() {
+		this.alertHandler.alertHandler("success", "Changing state of the deposit pipeline: " + this.context.pipelineAction);
+	};
+
+	return ChangeDepositPipelineStateAction;
+});

--- a/static/js/admin/src/statusMonitor/AbstractStatusMonitor.js
+++ b/static/js/admin/src/statusMonitor/AbstractStatusMonitor.js
@@ -9,7 +9,7 @@ define('AbstractStatusMonitor', [ 'jquery', 'jquery-ui', 'underscore', 'tpl!../t
 		},
 		overviewConfig : {
 			url : undefined,
-			refresh : 10000,
+			refresh : 5000,
 			render : undefined,
 			template : overviewTemplate
 		}

--- a/static/js/admin/src/statusMonitor/DepositMonitor.js
+++ b/static/js/admin/src/statusMonitor/DepositMonitor.js
@@ -11,6 +11,7 @@ define('DepositMonitor', [ 'jquery', 'jquery-ui', 'underscore', 'AbstractStatusM
 			fields : ["Status", "Submitter", "Submit time", "Progress", "First object", "Note"],
 			jobTypes : [
 				{name : "running", refresh : 1000, detailsRefresh : 1000},
+				{name : "quieted", refresh : 5000},
 				{name : "queued", refresh : 10000},
 				{name : "paused", refresh : 10000},
 				{name : "finished", refresh : 10000},

--- a/static/js/admin/src/statusMonitor/DepositMonitor.js
+++ b/static/js/admin/src/statusMonitor/DepositMonitor.js
@@ -1,5 +1,5 @@
-define('DepositMonitor', [ 'jquery', 'jquery-ui', 'underscore', 'AbstractStatusMonitor', 'tpl!../templates/admin/statusMonitor/depositMonitorJob', 'tpl!../templates/admin/statusMonitor/depositMonitorJobDetails', 'ResubmitPackageForm'],
-		function($, ui, _, AbstractStatusMonitor, depositMonitorJobTemplate, depositMonitorDetailsTemplate, ResubmitPackageForm) {
+define('DepositMonitor', [ 'jquery', 'jquery-ui', 'underscore', 'AbstractStatusMonitor', 'ActionEventHandler', 'tpl!../templates/admin/statusMonitor/depositMonitorJob', 'tpl!../templates/admin/statusMonitor/depositMonitorJobDetails', 'ResubmitPackageForm'],
+		function($, ui, _, AbstractStatusMonitor, ActionEventHandler, depositMonitorJobTemplate, depositMonitorDetailsTemplate, ResubmitPackageForm) {
 			
 	var defaultOptions = {
 		name : "deposit",
@@ -33,6 +33,8 @@ define('DepositMonitor', [ 'jquery', 'jquery-ui', 'underscore', 'AbstractStatusM
 	DepositMonitor.prototype.init = function() {
 		AbstractStatusMonitor.prototype.init.call(this);
 		
+		this.actionHandler = new ActionEventHandler({});
+		
 		$(this.element).on("click", ".monitor_action", function(){
 			var $this = $(this);
 			$this.text($this.text() + "...");
@@ -53,6 +55,17 @@ define('DepositMonitor', [ 'jquery', 'jquery-ui', 'underscore', 'AbstractStatusM
 			// FIXME: prepending "uuid:" is a hack??
 			resubmitPackageForm.open("uuid:" + $this.data("uuid"));
 			return false;
+		});
+		
+		var self = this;
+		$(this.element).on("click", ".status_monitor_actions button", function() {
+			var actionName = this.id.split("_", 2)[0];
+			$(".status_monitor_actions button", self.element).prop('disabled', true);
+			self.actionHandler.addEvent({
+				action : 'ChangeDepositPipelineState',
+				pipelineAction : actionName,
+				confirmAnchor : $(this)
+			});
 		});
 	};
 	

--- a/static/js/admin/statusMonitor.js
+++ b/static/js/admin/statusMonitor.js
@@ -11,6 +11,7 @@ require.config({
 		
 		'StatusMonitorManager' : 'cdr-admin',
 		'AbstractStatusMonitor' : 'cdr-admin',
+		'ActionEventHandler' : 'cdr-admin',
 		'DepositMonitor' : 'cdr-admin',
 		'URLUtilities' : 'cdr-admin',
 		

--- a/static/templates/admin/statusMonitor/overview.html
+++ b/static/templates/admin/statusMonitor/overview.html
@@ -1,18 +1,23 @@
+<% if (data.isAdmin) { %>
+<div class="status_monitor_actions">
+  <button id="quiet_pipeline_btn" <%= data.state == "active" ? "" : "disabled" %> title="Stops processing of new deposit jobs, pauses any active jobs">Quiet</button>
+  <button id="unquiet_pipeline_btn" <%= data.state == "quieted" ? "" : "disabled" %> title="Resumes processing of new deposit jobs, resumes jobs paused by quieting">Unquiet</button>
+  <button id="stop_pipeline_btn" <%= data.state == "active" ? "" : "disabled" %> title="Stops processing of new deposit jobs, interrupts any active jobs. Deposit service must be restarted to resume.">Stop</button>
+</div>
+<% } %>
 <table class="status_monitor_overview">
 	<tbody>
 		<tr class="column_headers">
-			<th>Active</th>
-			<th>Idle</th>
-			<th>Queued</th>
+			<th>Last Refreshed</th>
+			<th>Jobs Queued</th>
 			<th>Active</th>
 			<th>Failed</th>
 			<th>Finished</th>
-			<th>Refreshed</th>
+			<th>Workers</th>
+			<th>Pipeline State</th>
 		</tr>
 		<tr>
-			<td><span id="monitorActive"><%= data.active %></span>
-			</td>
-			<td><span id="monitorIdle"><%= data.idle %></span>
+			<td><span id="monitorRefreshed"><%= moment().format('YYYY-MM-DD h:mm:ssa') %></span>
 			</td>
 			<td><span id="monitorQueuedJobs"><%= data.queuedJobs %></span>
 			</td>
@@ -22,7 +27,9 @@
 			</td>
 			<td><span id="monitorFinishedJobs"><%= data.finishedJobs %></span>
 			</td>
-			<td><span id="monitorRefreshed"><%= moment().format('YYYY-MM-DD h:mm:ssa') %></span>
+			<td><span id="monitorWorkers"><%= data.workers %></span>
+			</td>
+			<td><span id="monitorState"><%= data.state %></span>
 			</td>
 		</tr>
 	</tbody>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2732

* Adds buttons to the status monitor for changing the state of the pipeline.
    * Adds API endpoints for requesting these changes, and functionality in deposit pipeline to execute the changes
* Implements the following actions for Admin users:
    * Quiet action - Stops processing of new deposit jobs, pauses any active jobs. Perform
    * Unquiet action - Resumes processing of new deposit jobs, resumes jobs paused by quieting
    * Stop action - Stops processing of new deposit jobs, interrupts any active jobs. Deposit service must be restarted to resume.
* Adds tests for some portions of the DepositSupervisor, and refactors the class to allow for more testing