### PR TITLE
BXC-2745 - Expand interruption of deposit jobs

### DIFF
--- a/deposit/src/main/java/edu/unc/lib/deposit/work/AbstractDepositJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/work/AbstractDepositJob.java
@@ -212,7 +212,9 @@ public abstract class AbstractDepositJob implements Runnable {
 
     public void setDepositUUID(String depositUUID) {
         this.depositUUID = depositUUID;
-        this.depositPID = PIDs.get(RepositoryPathConstants.DEPOSIT_RECORD_BASE, depositUUID);
+        if (depositUUID != null) {
+            this.depositPID = PIDs.get(RepositoryPathConstants.DEPOSIT_RECORD_BASE, depositUUID);
+        }
     }
 
     public PID getDepositPID() {
@@ -333,7 +335,7 @@ public abstract class AbstractDepositJob implements Runnable {
     protected PID getDestinationPID() {
         Map<String, String> depositStatus = getDepositStatus();
         String destinationPath = depositStatus.get(DepositField.containerId.name());
-        PID destPid = PIDs.get(destinationPath);
+        PID destPid = destinationPath != null ? PIDs.get(destinationPath) : null;
         if (destPid == null) {
             failJob("Invalid destination URI", "The provide destination uri " + destinationPath
                     + " was not a valid repository path");

--- a/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/AbstractDepositJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/AbstractDepositJobTest.java
@@ -131,7 +131,7 @@ public class AbstractDepositJobTest {
         depositDir.mkdir();
         depositPid = PIDs.get(RepositoryPathConstants.DEPOSIT_RECORD_BASE, depositUUID);
 
-        dataset = TDBFactory.createDataset();
+        dataset = TDBFactory.createDataset(tmpFolder.newFolder("tdb").getAbsolutePath());
 
         when(txManager.startTransaction()).thenReturn(tx);
         doAnswer(new Answer<Void>() {

--- a/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/AbstractFedoraDepositJobIT.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/AbstractFedoraDepositJobIT.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 
 import org.apache.http.HttpStatus;
 import org.apache.jena.query.Dataset;
+import org.apache.jena.tdb.TDBFactory;
 import org.fcrepo.client.FcrepoClient;
 import org.fcrepo.client.FcrepoOperationFailedException;
 import org.fcrepo.client.FcrepoResponse;
@@ -67,7 +68,6 @@ public class AbstractFedoraDepositJobIT {
     protected String baseAddress;
     @Autowired
     protected RepositoryPIDMinter pidMinter;
-    @Autowired
     protected Dataset dataset;
     @Autowired
     protected JobStatusFactory jobStatusFactory;
@@ -106,6 +106,8 @@ public class AbstractFedoraDepositJobIT {
         depositDir.mkdir();
 
         depositStatusFactory.setState(depositUUID, DepositState.running);
+
+        dataset = TDBFactory.createDataset(tmpFolder.newFolder("tdb").getAbsolutePath());
     }
 
     protected URI createBaseContainer(String name) throws IOException, FcrepoOperationFailedException {

--- a/deposit/src/test/resources/spring-test/cdr-client-container.xml
+++ b/deposit/src/test/resources/spring-test/cdr-client-container.xml
@@ -147,9 +147,6 @@
         <property name="fcrepoClient" ref="fcrepoClient" />
     </bean>
     
-    <bean id="dataSet" class="org.apache.jena.tdb.TDBFactory" factory-method="createDataset" destroy-method="close">
-    </bean>
-    
     <bean id="redisServer" class="redis.embedded.RedisServer" init-method="start" destroy-method="stop">
         <constructor-arg value="46380" />
     </bean>

--- a/deposit/src/test/resources/spring-test/deposit-supervisor-test-context.xml
+++ b/deposit/src/test/resources/spring-test/deposit-supervisor-test-context.xml
@@ -12,6 +12,9 @@
 
     <context:property-placeholder />
     
+    <bean id="dataSet" class="org.apache.jena.tdb.TDBFactory" factory-method="createDataset" destroy-method="close">
+    </bean>
+    
     <bean id="operationsMessageSender" class="org.mockito.Mockito" factory-method="mock">
         <constructor-arg value="edu.unc.lib.dl.services.OperationsMessageSender" />
     </bean>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2745
* Expand interruption handling to seek out interruption related root causes, so they can be rethrown as interruptions and handled correctly. 
* Add tests to trigger interruptions in deposit jobs, switch to using on disk tdb persistence for tests to more accurately reflect production