### PR TITLE
BXC-2753 - Prevent storage of FITS error mimetypes in transformations

### DIFF
--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformer.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformer.java
@@ -326,7 +326,12 @@ public class ContentObjectTransformer extends RecursiveAction {
 
         Statement mimeTypeStmt = bxc3Resc.getProperty(hasSourceMimeType.getProperty());
         if (mimeTypeStmt != null) {
-            fileResc.addProperty(CdrDeposit.mimetype, mimeTypeStmt.getString());
+            String mimeType = mimeTypeStmt.getString();
+            if (!mimeType.contains("cannot open")) {
+                fileResc.addProperty(CdrDeposit.mimetype, mimeTypeStmt.getString());
+            } else {
+                log.debug("Ignoring unusable mimetype for {}", originalPid);
+            }
         }
 
         List<DatastreamVersion> originalVersions = listDatastreamVersions(foxml, ORIGINAL_DS);


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2753
* Prevent setting mimetype in deposit if it matches the pattern for FITS errors
* Update transformation tests to check for mimetype setting