### PR TITLE
BXC-2738 - Solr indexing performance (patron updates)

### DIFF
--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/PIDs.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/PIDs.java
@@ -149,8 +149,11 @@ public class PIDs {
     private static PID getBaseResourcePidFromId(String id) {
         if (REPOSITORY_ROOT_ID.equals(id)) {
             return RepositoryPaths.getRootPid();
-        } else if (CONTENT_BASE.equals(id)) {
-            return RepositoryPaths.getContentBasePid();
+        } else if (id.startsWith(REPOSITORY_ROOT_ID + "/")) {
+            String idPart = id.split("/")[1];
+            if (CONTENT_BASE.equals(idPart)) {
+                return RepositoryPaths.getContentBasePid();
+            }
         }
 
         return null;

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/PIDs.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/PIDs.java
@@ -154,6 +154,8 @@ public class PIDs {
             if (CONTENT_BASE.equals(idPart)) {
                 return RepositoryPaths.getContentBasePid();
             }
+        } else if (CONTENT_BASE.equals(id)) {
+            return RepositoryPaths.getContentBasePid();
         }
 
         return null;

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/PIDsTest.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/PIDsTest.java
@@ -261,6 +261,16 @@ public class PIDsTest {
     }
 
     @Test
+    public void getContentBaseFromQualifiedIdTest() {
+        PID pid = PIDs.get(CONTENT_BASE);
+        PID fromQualified = PIDs.get(pid.getQualifiedId());
+
+        assertEquals(FEDORA_BASE + CONTENT_BASE, fromQualified.getRepositoryPath());
+        assertEquals(CONTENT_BASE, fromQualified.getId());
+        assertEquals(REPOSITORY_ROOT_ID, fromQualified.getQualifier());
+    }
+
+    @Test
     public void getRootFromIdTest() {
         PID pid = PIDs.get(REPOSITORY_ROOT_ID);
 

--- a/metadata/src/main/java/edu/unc/lib/dl/util/IndexingActionType.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/util/IndexingActionType.java
@@ -58,7 +58,8 @@ public enum IndexingActionType {
     UPDATE_TYPE("Update Resource Type", "Update the resource type of an object"),
     UPDATE_TYPE_TREE("Update Resource Type Tree",
             "Update the resource type of a set of objects and all their children"),
-    SET_PRIMARY_OBJECT("Set Primary Object", "Update the primary object for a work");
+    SET_PRIMARY_OBJECT("Set Primary Object", "Update the primary object for a work"),
+    UNKNOWN("Unknown action", "Unknown action");
 
     private final String label;
     private final String description;

--- a/persistence/src/main/java/edu/unc/lib/dl/util/IndexingMessageHelper.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/util/IndexingMessageHelper.java
@@ -53,7 +53,7 @@ public class IndexingMessageHelper {
         Element entry = new Element("entry", ATOM_NS);
         msg.addContent(entry);
         entry.addContent(new Element("author", ATOM_NS).addContent(new Element("name", ATOM_NS).setText(userid)));
-        entry.addContent(new Element("pid", ATOM_NS).setText(targetPid.getRepositoryPath()));
+        entry.addContent(new Element("pid", ATOM_NS).setText(targetPid.getQualifiedId()));
         if (children != null && children.size() > 0) {
             Element childEl = new Element("children", CDR_MESSAGE_NS);
             entry.addContent(childEl);

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/solrUpdate/SolrUpdatePreprocessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/solrUpdate/SolrUpdatePreprocessor.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.services.camel.solrUpdate;
+
+import static edu.unc.lib.dl.util.IndexingActionType.ADD_SET_TO_PARENT;
+import static edu.unc.lib.dl.util.IndexingActionType.CLEAN_REINDEX;
+import static edu.unc.lib.dl.util.IndexingActionType.DELETE_CHILDREN_PRIOR_TO_TIMESTAMP;
+import static edu.unc.lib.dl.util.IndexingActionType.DELETE_SOLR_TREE;
+import static edu.unc.lib.dl.util.IndexingActionType.RECURSIVE_REINDEX;
+import static edu.unc.lib.dl.util.IndexingActionType.UPDATE_ACCESS;
+import static edu.unc.lib.dl.util.IndexingActionType.UPDATE_ACCESS_TREE;
+import static edu.unc.lib.dl.util.IndexingActionType.UPDATE_DATASTREAMS;
+import static edu.unc.lib.dl.util.IndexingActionType.UPDATE_DESCRIPTION;
+import static edu.unc.lib.dl.util.IndexingActionType.UPDATE_PATH;
+import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.ATOM_NS;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import org.apache.camel.Body;
+import org.apache.camel.Exchange;
+import org.apache.camel.Header;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.output.Format;
+import org.jdom2.output.XMLOutputter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import edu.unc.lib.dl.services.camel.util.CdrFcrepoHeaders;
+import edu.unc.lib.dl.services.camel.util.MessageUtil;
+import edu.unc.lib.dl.util.IndexingActionType;
+
+/**
+ * Processor which prepares update messages for further processing
+ *
+ * @author bbpennel
+ */
+public class SolrUpdatePreprocessor implements Processor {
+    private final static Logger log = LoggerFactory.getLogger(SolrUpdatePreprocessor.class);
+
+    @Override
+    public void process(Exchange exchange) throws Exception {
+        log.debug("Preprocessing solr update");
+        final Message in = exchange.getIn();
+
+        Document msgBody = MessageUtil.getDocumentBody(in);
+        Element body = msgBody.getRootElement();
+
+        String action = body.getChild("actionType", ATOM_NS).getTextTrim();
+        IndexingActionType actionType = IndexingActionType.getAction(action);
+
+        // Store the action type as a header
+        in.setHeader(CdrFcrepoHeaders.CdrSolrUpdateAction, actionType);
+        // Serialize the message for persistence
+        in.setBody(new XMLOutputter().outputString(msgBody));
+    }
+
+    private static final Set<IndexingActionType> LARGE_ACTIONS =
+            EnumSet.of(RECURSIVE_REINDEX, CLEAN_REINDEX, DELETE_SOLR_TREE, IndexingActionType.MOVE,
+                    ADD_SET_TO_PARENT, UPDATE_ACCESS_TREE, DELETE_CHILDREN_PRIOR_TO_TIMESTAMP);
+
+    /**
+     * @param action
+     * @return true if the action is classified as large
+     */
+    public static boolean isLargeAction(@Header(CdrFcrepoHeaders.CdrSolrUpdateAction) IndexingActionType action) {
+        return LARGE_ACTIONS.contains(action);
+    }
+
+    private static final Set<IndexingActionType> SMALL_ACTIONS =
+            EnumSet.of(IndexingActionType.ADD, UPDATE_DESCRIPTION, UPDATE_ACCESS, UPDATE_PATH,
+                    UPDATE_DATASTREAMS, IndexingActionType.COMMIT, IndexingActionType.DELETE);
+
+    /**
+     * @param action
+     * @return true if the action is classified as small
+     */
+    public static boolean isSmallAction(@Header(CdrFcrepoHeaders.CdrSolrUpdateAction) IndexingActionType action) {
+        return SMALL_ACTIONS.contains(action);
+    }
+
+    /**
+     * Log an unknown solr update message
+     * @param body
+     */
+    public void logUnknownSolrUpdate(@Body Object body) {
+        if (body instanceof Document) {
+            log.debug("Received unprocessable Solr indexing message:\n {}",
+                    new XMLOutputter(Format.getPrettyFormat()).outputString((Document) body));
+        } else {
+            log.debug("Received unprocessable Solr indexing message: {}",  body);
+        }
+    }
+}

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/solrUpdate/SolrUpdateProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/solrUpdate/SolrUpdateProcessor.java
@@ -44,7 +44,7 @@ import edu.unc.lib.dl.util.IndexingActionType;
  *
  */
 public class SolrUpdateProcessor implements Processor {
-    final Logger log = LoggerFactory.getLogger(SolrUpdateProcessor.class);
+    private static final Logger log = LoggerFactory.getLogger(SolrUpdateProcessor.class);
 
     private Map<IndexingActionType, IndexingAction> solrIndexingActionMap;
 

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/util/BodyListAggregationStrategy.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/util/BodyListAggregationStrategy.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.services.camel.util;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.processor.aggregate.AggregationStrategy;
+import org.slf4j.Logger;
+
+/**
+ * Message aggregation strategy which puts the bodies of messages into a list
+ *
+ * @author bbpennel
+ */
+public class BodyListAggregationStrategy implements AggregationStrategy {
+    private final static Logger log = getLogger(BodyListAggregationStrategy.class);
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Exchange aggregate(Exchange oldExchange, Exchange newExchange) {
+        if (oldExchange == null) {
+            log.debug("Starting new batch");
+            List<Object> list = new ArrayList<>();
+            list.add(newExchange.getIn().getBody());
+            newExchange.getIn().setBody(list);
+            return newExchange;
+        } else {
+            List<Object> list = oldExchange.getIn().getBody(List.class);
+            list.add(newExchange.getIn().getBody());
+            log.debug("Added to batch, now contains {}", list.size());
+            return oldExchange;
+        }
+    }
+}

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/util/CdrFcrepoHeaders.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/util/CdrFcrepoHeaders.java
@@ -38,4 +38,6 @@ public abstract class CdrFcrepoHeaders {
     public static final String CdrEnhancementSet = "CdrEnhancementSet";
 
     public static final String FCREPO_RESOURCE_TYPE = "org.fcrepo.jms.resourceType";
+
+    public static final String CdrSolrUpdateAction = "CdrSolrUpdateAction";
 }

--- a/services-camel/src/main/webapp/WEB-INF/solr-indexing-context.xml
+++ b/services-camel/src/main/webapp/WEB-INF/solr-indexing-context.xml
@@ -399,9 +399,18 @@
         <property name="indexingMessageSender" ref="indexingMessageSender" />
     </bean>
     
-    <bean id="solrUpdateProcessor" class="edu.unc.lib.dl.services.camel.solrUpdate.SolrUpdateProcessor">
+    <bean id="solrLargeUpdateProcessor" class="edu.unc.lib.dl.services.camel.solrUpdate.SolrUpdateProcessor">
         <property name="solrIndexingActionMap" ref="solrIndexingActionMap"/>
     </bean>
+    
+    <bean id="solrSmallUpdateProcessor" class="edu.unc.lib.dl.services.camel.solrUpdate.SolrUpdateProcessor">
+        <property name="solrIndexingActionMap" ref="solrIndexingActionMap"/>
+    </bean>
+    
+    <bean id="solrUpdatePreprocessor" class="edu.unc.lib.dl.services.camel.solrUpdate.SolrUpdatePreprocessor">
+    </bean>
+    
+    <bean id="bodyListAggregationStrategy" class="edu.unc.lib.dl.services.camel.util.BodyListAggregationStrategy"/>
     
     <camel:camelContext id="CdrServiceSolrUpdate">
         <camel:package>edu.unc.lib.dl.services.camel.solrUpdate</camel:package>

--- a/services-camel/src/main/webapp/WEB-INF/solr-indexing-context.xml
+++ b/services-camel/src/main/webapp/WEB-INF/solr-indexing-context.xml
@@ -258,6 +258,7 @@
     
     <bean id="recursiveTreeIndexer" class="edu.unc.lib.dl.data.ingest.solr.action.RecursiveTreeIndexer">
         <property name="indexingMessageSender" ref="indexingMessageSender" />
+        <property name="sparqlQueryService" ref="sparqlQueryService" />
     </bean>
     
     <bean id="updateTreeAction"

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/cdrEvents/CdrEventRoutingIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/cdrEvents/CdrEventRoutingIT.java
@@ -33,6 +33,8 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.test.spring.CamelSpringRunner;
+import org.apache.camel.test.spring.CamelTestContextBootstrapper;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,9 +42,11 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.BootstrapWith;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.ContextHierarchy;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import edu.unc.lib.dl.data.ingest.solr.ChildSetRequest;
 import edu.unc.lib.dl.data.ingest.solr.SolrUpdateRequest;
@@ -59,11 +63,13 @@ import edu.unc.lib.dl.util.IndexingActionType;
  * @author bbpennel
  *
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@RunWith(CamelSpringRunner.class)
+@BootstrapWith(CamelTestContextBootstrapper.class)
 @ContextHierarchy({
     @ContextConfiguration("/spring-test/jms-context.xml"),
     @ContextConfiguration("/cdr-event-routing-it-context.xml")
 })
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 public class CdrEventRoutingIT {
 
     private static final String USER_ID = "user";
@@ -74,7 +80,10 @@ public class CdrEventRoutingIT {
     private OperationsMessageSender opsMsgSender;
 
     @Autowired
-    private SolrUpdateProcessor solrUpdateProcessor;
+    private SolrUpdateProcessor solrSmallUpdateProcessor;
+
+    @Autowired
+    private SolrUpdateProcessor solrLargeUpdateProcessor;
 
     @Autowired
     private CamelContext cdrServiceSolrUpdate;
@@ -92,7 +101,8 @@ public class CdrEventRoutingIT {
 
         TestHelper.setContentBase(BASE_URI);
 
-        solrUpdateProcessor.setSolrIndexingActionMap(mockActionMap);
+        solrSmallUpdateProcessor.setSolrIndexingActionMap(mockActionMap);
+        solrLargeUpdateProcessor.setSolrIndexingActionMap(mockActionMap);
 
         when(mockActionMap.get(any(IndexingActionType.class)))
                 .thenReturn(mockIndexingAction);

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/DeregisterLongleafRouteTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/DeregisterLongleafRouteTest.java
@@ -25,6 +25,8 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.test.spring.CamelSpringRunner;
+import org.apache.camel.test.spring.CamelTestContextBootstrapper;
 import org.jgroups.util.UUID;
 import org.junit.Before;
 import org.junit.Rule;
@@ -32,20 +34,24 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.BootstrapWith;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.ContextHierarchy;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import edu.unc.lib.dl.services.MessageSender;
 
 /**
  * @author bbpennel
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@RunWith(CamelSpringRunner.class)
+@BootstrapWith(CamelTestContextBootstrapper.class)
 @ContextHierarchy({
     @ContextConfiguration("/spring-test/jms-context.xml"),
     @ContextConfiguration("/deregister-longleaf-router-context.xml")
 })
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 public class DeregisterLongleafRouteTest {
 
     @Autowired

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solr/AbstractSolrProcessorIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solr/AbstractSolrProcessorIT.java
@@ -28,6 +28,8 @@ import java.net.URI;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
+import org.apache.camel.test.spring.CamelSpringRunner;
+import org.apache.camel.test.spring.CamelTestContextBootstrapper;
 import org.apache.commons.io.FileUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -36,9 +38,9 @@ import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.BootstrapWith;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.ContextHierarchy;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import edu.unc.lib.dl.acl.util.AccessGroupSet;
 import edu.unc.lib.dl.data.ingest.solr.indexing.DocumentIndexingPackageFactory;
@@ -54,13 +56,15 @@ import edu.unc.lib.dl.fcrepo4.RepositoryPIDMinter;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.rdf.CdrAcl;
 import edu.unc.lib.dl.search.solr.service.SolrSearchService;
+import edu.unc.lib.dl.test.RepositoryObjectTreeIndexer;
 
 /**
  *
  * @author bbpennel
  *
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@RunWith(CamelSpringRunner.class)
+@BootstrapWith(CamelTestContextBootstrapper.class)
 @ContextHierarchy({
     @ContextConfiguration("/spring-test/test-fedora-container.xml"),
     @ContextConfiguration("/spring-test/cdr-client-container.xml"),
@@ -94,6 +98,8 @@ public abstract class AbstractSolrProcessorIT {
     protected RepositoryPIDMinter pidMinter;
     @Autowired
     private RepositoryInitializer repoInitializer;
+    @Autowired
+    private RepositoryObjectTreeIndexer treeIndexer;
 
     protected ContentRootObject rootObj;
     protected AdminUnit unitObj;
@@ -128,10 +134,8 @@ public abstract class AbstractSolrProcessorIT {
                 .thenReturn(obj.getPid().getRepositoryPath());
     }
 
-    protected void indexObjectsInTripleStore(RepositoryObject... objs) {
-        for (RepositoryObject obj : objs) {
-            queryModel.add(obj.getModel());
-        }
+    protected void indexObjectsInTripleStore() throws Exception {
+        treeIndexer.indexAll(baseAddress);
     }
 
     protected URI makeContentUri(String content) throws Exception {

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solr/SolrIngestProcessorIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solr/SolrIngestProcessorIT.java
@@ -99,7 +99,7 @@ public class SolrIngestProcessorIT extends AbstractSolrProcessorIT {
         InputStream modsStream = streamResource("/datastreams/simpleMods.xml");
         updateDescriptionService.updateDescription(agent, workObj.getPid(), modsStream);
 
-        indexObjectsInTripleStore(rootObj, workObj, fileObj, unitObj, collObj);
+        indexObjectsInTripleStore();
 
         setMessageTarget(workObj);
         processor.process(exchange);
@@ -135,7 +135,7 @@ public class SolrIngestProcessorIT extends AbstractSolrProcessorIT {
 
     @Test
     public void testIndexCollection() throws Exception {
-        indexObjectsInTripleStore(rootObj, unitObj, collObj);
+        indexObjectsInTripleStore();
 
         setMessageTarget(collObj);
         processor.process(exchange);
@@ -175,7 +175,7 @@ public class SolrIngestProcessorIT extends AbstractSolrProcessorIT {
         FileObject fileObj = workObj.addDataFile(makeContentUri(CONTENT_TEXT),
                 "text.txt", "text/plain", null, null, fileModel);
 
-        indexObjectsInTripleStore(rootObj, workObj, fileObj, unitObj, collObj);
+        indexObjectsInTripleStore();
 
         setMessageTarget(fileObj);
         processor.process(exchange);
@@ -215,7 +215,7 @@ public class SolrIngestProcessorIT extends AbstractSolrProcessorIT {
 
         BinaryObject binObj = fileObj.getOriginalFile();
 
-        indexObjectsInTripleStore(rootObj, workObj, fileObj, unitObj, collObj, binObj);
+        indexObjectsInTripleStore();
 
         setMessageTarget(binObj);
         when(message.getHeader(FCREPO_RESOURCE_TYPE)).thenReturn(Fcrepo4Repository.Binary.getURI());

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solrUpdate/SolrUpdateRouterTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solrUpdate/SolrUpdateRouterTest.java
@@ -17,6 +17,8 @@ package edu.unc.lib.dl.services.camel.solrUpdate;
 
 import static edu.unc.lib.dl.util.IndexingMessageHelper.makeIndexingOperationBody;
 import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.ATOM_NS;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
@@ -28,20 +30,26 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.camel.BeanInject;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.Produce;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.NotifyBuilder;
-import org.apache.camel.test.spring.CamelSpringTestSupport;
+import org.apache.camel.test.spring.CamelSpringRunner;
+import org.apache.camel.test.spring.CamelTestContextBootstrapper;
 import org.jdom2.Document;
 import org.jdom2.Element;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
-import org.springframework.context.support.AbstractApplicationContext;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.BootstrapWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
 
 import edu.unc.lib.dl.fcrepo4.RepositoryPIDMinter;
 import edu.unc.lib.dl.fedora.NotFoundException;
@@ -55,22 +63,29 @@ import edu.unc.lib.dl.util.IndexingActionType;
  * @author bbpennel
  *
  */
-public class SolrUpdateRouterTest extends CamelSpringTestSupport {
+@RunWith(CamelSpringRunner.class)
+@BootstrapWith(CamelTestContextBootstrapper.class)
+@ContextHierarchy({
+    @ContextConfiguration("/spring-test/jms-context.xml"),
+    @ContextConfiguration("/solr-update-context.xml")
+})
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
+public class SolrUpdateRouterTest {
     private static final String USER = "user";
 
     @Produce(uri = "{{cdr.solrupdate.stream}}")
     private ProducerTemplate template;
 
-    @BeanInject(value = "cdrServiceSolrUpdate")
+    @Autowired
     private CamelContext cdrServiceSolrUpdate;
 
-    @BeanInject(value = "solrSmallUpdateProcessor")
+    @Autowired
     private SolrUpdateProcessor solrSmallUpdateProcessor;
 
-    @BeanInject(value = "solrLargeUpdateProcessor")
+    @Autowired
     private SolrUpdateProcessor solrLargeUpdateProcessor;
 
-    @BeanInject(value = "solrUpdatePreprocessor")
+    @Autowired
     private SolrUpdatePreprocessor solrUpdatePreprocessor;
 
     private ArgumentCaptor<Exchange> exchangeCaptor;
@@ -86,9 +101,9 @@ public class SolrUpdateRouterTest extends CamelSpringTestSupport {
         exchangeCaptor = ArgumentCaptor.forClass(Exchange.class);
     }
 
-    @Override
-    protected AbstractApplicationContext createApplicationContext() {
-        return new ClassPathXmlApplicationContext("/spring-test/jms-context.xml", "/solr-update-context.xml");
+    @AfterClass
+    public static void after() throws Exception {
+//        broker.stop();
     }
 
     @Test

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solrUpdate/SolrUpdateRouterTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solrUpdate/SolrUpdateRouterTest.java
@@ -15,23 +15,39 @@
  */
 package edu.unc.lib.dl.services.camel.solrUpdate;
 
-import static edu.unc.lib.dl.services.camel.JmsHeaderConstants.EVENT_TYPE;
+import static edu.unc.lib.dl.util.IndexingMessageHelper.makeIndexingOperationBody;
+import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.ATOM_NS;
 import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.camel.BeanInject;
+import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.Produce;
 import org.apache.camel.ProducerTemplate;
-import org.apache.camel.builder.AdviceWithRouteBuilder;
+import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.test.spring.CamelSpringTestSupport;
+import org.jdom2.Document;
+import org.jdom2.Element;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import edu.unc.lib.dl.fcrepo4.RepositoryPIDMinter;
+import edu.unc.lib.dl.fedora.NotFoundException;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.services.camel.util.MessageUtil;
+import edu.unc.lib.dl.util.IndexingActionType;
 
 /**
  *
@@ -40,49 +56,177 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
  *
  */
 public class SolrUpdateRouterTest extends CamelSpringTestSupport {
-    private static final String SOLR_UPDATE_ROUTE = "CdrServiceSolrUpdate";
+    private static final String USER = "user";
 
-    @Produce(uri = "direct:start")
+    @Produce(uri = "{{cdr.solrupdate.stream}}")
     private ProducerTemplate template;
 
-    @BeanInject(value = "solrUpdateProcessor")
-    private SolrUpdateProcessor solrUpdateProcessor;
+    @BeanInject(value = "cdrServiceSolrUpdate")
+    private CamelContext cdrServiceSolrUpdate;
+
+    @BeanInject(value = "solrSmallUpdateProcessor")
+    private SolrUpdateProcessor solrSmallUpdateProcessor;
+
+    @BeanInject(value = "solrLargeUpdateProcessor")
+    private SolrUpdateProcessor solrLargeUpdateProcessor;
+
+    @BeanInject(value = "solrUpdatePreprocessor")
+    private SolrUpdatePreprocessor solrUpdatePreprocessor;
+
+    private ArgumentCaptor<Exchange> exchangeCaptor;
+
+    private RepositoryPIDMinter pidMinter;
+
+    private PID targetPid;
 
     @Before
     public void init() {
+        pidMinter = new RepositoryPIDMinter();
+        targetPid = pidMinter.mintContentPid();
+        exchangeCaptor = ArgumentCaptor.forClass(Exchange.class);
     }
 
     @Override
     protected AbstractApplicationContext createApplicationContext() {
-        return new ClassPathXmlApplicationContext("/service-context.xml", "/solr-update-context.xml");
+        return new ClassPathXmlApplicationContext("/spring-test/jms-context.xml", "/solr-update-context.xml");
     }
 
     @Test
-    public void testSolrUpdateRoute() throws Exception {
-        createContext(SOLR_UPDATE_ROUTE);
+    public void indexSingleObject() throws Exception {
+        Document msg = makeIndexingOperationBody(USER, targetPid, null, IndexingActionType.ADD);
+        template.sendBodyAndHeaders(msg, null);
 
-        template.sendBodyAndHeaders("", createEvent());
+        NotifyBuilder notify = new NotifyBuilder(cdrServiceSolrUpdate)
+                .whenCompleted(2)
+                .create();
 
-        verify(solrUpdateProcessor).process(any(Exchange.class));
+        boolean result = notify.matches(5l, TimeUnit.SECONDS);
+        assertTrue("Message count did not match expectations", result);
+
+        verify(solrSmallUpdateProcessor).process(exchangeCaptor.capture());
+        List<Exchange> exchanges = exchangeCaptor.getAllValues();
+        assertMessage(exchanges, targetPid, IndexingActionType.ADD);
     }
 
-    private void createContext(String routeName) throws Exception {
-        context.getRouteDefinition(routeName).adviceWith(context, new AdviceWithRouteBuilder() {
-            @Override
-            public void configure() throws Exception {
-                replaceFromWith("direct:start");
-                mockEndpointsAndSkip("*");
+    @Test
+    public void indexSmallOneNotFoundRecover() throws Exception {
+        doThrow(new NotFoundException("")).doNothing().when(solrSmallUpdateProcessor).process(any(Exchange.class));
+
+        Document msg = makeIndexingOperationBody(USER, targetPid, null, IndexingActionType.ADD);
+        Document msg2 = makeIndexingOperationBody(USER, targetPid, null, IndexingActionType.UPDATE_DESCRIPTION);
+        template.sendBodyAndHeaders(msg, null);
+        template.sendBodyAndHeaders(msg2, null);
+
+        NotifyBuilder notify = new NotifyBuilder(cdrServiceSolrUpdate)
+                .whenCompleted(3)
+                .create();
+
+        boolean result = notify.matches(5l, TimeUnit.SECONDS);
+        assertTrue("Message count did not match expectations", result);
+
+        verify(solrSmallUpdateProcessor, times(3)).process(exchangeCaptor.capture());
+        List<Exchange> exchanges = exchangeCaptor.getAllValues();
+        assertMessage(exchanges, targetPid, IndexingActionType.ADD);
+    }
+
+    @Test
+    public void indexMultipleSmall() throws Exception {
+        PID targetPid2 = pidMinter.mintContentPid();
+        Document msg1 = makeIndexingOperationBody(USER, targetPid, null, IndexingActionType.ADD);
+        Document msg2 = makeIndexingOperationBody(USER, targetPid2, null, IndexingActionType.UPDATE_DESCRIPTION);
+        Document msg3 = makeIndexingOperationBody(USER, targetPid, null, IndexingActionType.UPDATE_ACCESS);
+        template.sendBodyAndHeaders(msg1, null);
+        template.sendBodyAndHeaders(msg2, null);
+        template.sendBodyAndHeaders(msg3, null);
+
+        NotifyBuilder notify = new NotifyBuilder(cdrServiceSolrUpdate)
+                .whenCompleted(4)
+                .create();
+
+        boolean result = notify.matches(5l, TimeUnit.SECONDS);
+        assertTrue("Message count did not match expectations", result);
+
+        verify(solrSmallUpdateProcessor, times(3)).process(exchangeCaptor.capture());
+        List<Exchange> exchanges = exchangeCaptor.getAllValues();
+        assertMessage(exchanges, targetPid, IndexingActionType.ADD);
+        assertMessage(exchanges, targetPid2, IndexingActionType.UPDATE_DESCRIPTION);
+        assertMessage(exchanges, targetPid, IndexingActionType.UPDATE_ACCESS);
+    }
+
+    @Test
+    public void indexLarge() throws Exception {
+        Document msg = makeIndexingOperationBody(USER, targetPid, Arrays.asList(targetPid),
+                IndexingActionType.UPDATE_ACCESS_TREE);
+        template.sendBodyAndHeaders(msg, null);
+
+        NotifyBuilder notify = new NotifyBuilder(cdrServiceSolrUpdate)
+                .whenCompleted(1)
+                .create();
+
+        boolean result = notify.matches(5l, TimeUnit.SECONDS);
+        assertTrue("Message count did not match expectations", result);
+
+        verify(solrLargeUpdateProcessor).process(exchangeCaptor.capture());
+        List<Exchange> exchanges = exchangeCaptor.getAllValues();
+        assertMessage(exchanges, targetPid, IndexingActionType.UPDATE_ACCESS_TREE);
+    }
+
+    @Test
+    public void indexMixed() throws Exception {
+        PID targetPid2 = pidMinter.mintContentPid();
+        Document msg1 = makeIndexingOperationBody(USER, targetPid, null, IndexingActionType.UPDATE_DESCRIPTION);
+        Document msg2 = makeIndexingOperationBody(USER, targetPid, Arrays.asList(targetPid2),
+                IndexingActionType.ADD_SET_TO_PARENT);
+        Document msg3 = makeIndexingOperationBody(USER, targetPid2, null, IndexingActionType.ADD);
+
+        template.sendBodyAndHeaders(msg1, null);
+        template.sendBodyAndHeaders(msg2, null);
+        template.sendBodyAndHeaders(msg3, null);
+
+        NotifyBuilder notify = new NotifyBuilder(cdrServiceSolrUpdate)
+                .whenCompleted(3)
+                .create();
+
+        boolean result = notify.matches(5l, TimeUnit.SECONDS);
+        assertTrue("Message count did not match expectations", result);
+
+        verify(solrLargeUpdateProcessor).process(exchangeCaptor.capture());
+        List<Exchange> largeExchanges = exchangeCaptor.getAllValues();
+        assertMessage(largeExchanges, targetPid, IndexingActionType.ADD_SET_TO_PARENT);
+
+        verify(solrSmallUpdateProcessor, times(2)).process(exchangeCaptor.capture());
+        List<Exchange> smallExchanges = exchangeCaptor.getAllValues();
+        assertMessage(smallExchanges, targetPid2, IndexingActionType.ADD);
+        assertMessage(smallExchanges, targetPid, IndexingActionType.UPDATE_DESCRIPTION);
+    }
+
+    @Test
+    public void indexUnknownAction() throws Exception {
+        Document msg = makeIndexingOperationBody(USER, targetPid, null, IndexingActionType.UNKNOWN);
+        template.sendBodyAndHeaders(msg, null);
+
+        verify(solrUpdatePreprocessor, timeout(1000).times(1)).logUnknownSolrUpdate(any());
+        verify(solrSmallUpdateProcessor, never()).process(any(Exchange.class));
+        verify(solrLargeUpdateProcessor, never()).process(any(Exchange.class));
+    }
+
+    private void assertMessage(List<Exchange> exchanges, PID expectedPid, IndexingActionType expectedAction)
+            throws Exception {
+        for (Exchange exchange : exchanges) {
+            Document msgBody = MessageUtil.getDocumentBody(exchange.getIn());
+            Element body = msgBody.getRootElement();
+
+            String action = body.getChild("actionType", ATOM_NS).getTextTrim();
+            IndexingActionType actionType = IndexingActionType.getAction(action);
+
+            String pid = body.getChild("pid", ATOM_NS).getTextTrim();
+
+            if (expectedAction.equals(actionType) && expectedPid.getQualifiedId().equals(pid)) {
+                return;
             }
-        });
+        }
 
-        context.start();
-    }
-
-    private static Map<String, Object> createEvent() {
-
-        final Map<String, Object> headers = new HashMap<>();
-        headers.put(EVENT_TYPE, "ResourceCreation");
-
-        return headers;
+        fail("No exchanges contained expected " + expectedPid.getQualifiedId() + " action " + expectedAction
+                + ", there were " + exchanges.size() + " exchanges");
     }
 }

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solrUpdate/SolrUpdateRouterTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solrUpdate/SolrUpdateRouterTest.java
@@ -17,7 +17,6 @@ package edu.unc.lib.dl.services.camel.solrUpdate;
 
 import static edu.unc.lib.dl.util.IndexingMessageHelper.makeIndexingOperationBody;
 import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.ATOM_NS;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doThrow;
@@ -39,7 +38,6 @@ import org.apache.camel.test.spring.CamelSpringRunner;
 import org.apache.camel.test.spring.CamelTestContextBootstrapper;
 import org.jdom2.Document;
 import org.jdom2.Element;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -101,11 +99,6 @@ public class SolrUpdateRouterTest {
         exchangeCaptor = ArgumentCaptor.forClass(Exchange.class);
     }
 
-    @AfterClass
-    public static void after() throws Exception {
-//        broker.stop();
-    }
-
     @Test
     public void indexSingleObject() throws Exception {
         Document msg = makeIndexingOperationBody(USER, targetPid, null, IndexingActionType.ADD);
@@ -115,8 +108,7 @@ public class SolrUpdateRouterTest {
                 .whenCompleted(2)
                 .create();
 
-        boolean result = notify.matches(5l, TimeUnit.SECONDS);
-        assertTrue("Message count did not match expectations", result);
+        notify.matches(5l, TimeUnit.SECONDS);
 
         verify(solrSmallUpdateProcessor).process(exchangeCaptor.capture());
         List<Exchange> exchanges = exchangeCaptor.getAllValues();
@@ -136,8 +128,7 @@ public class SolrUpdateRouterTest {
                 .whenCompleted(3)
                 .create();
 
-        boolean result = notify.matches(5l, TimeUnit.SECONDS);
-        assertTrue("Message count did not match expectations", result);
+        notify.matches(5l, TimeUnit.SECONDS);
 
         verify(solrSmallUpdateProcessor, times(3)).process(exchangeCaptor.capture());
         List<Exchange> exchanges = exchangeCaptor.getAllValues();
@@ -158,8 +149,7 @@ public class SolrUpdateRouterTest {
                 .whenCompleted(4)
                 .create();
 
-        boolean result = notify.matches(5l, TimeUnit.SECONDS);
-        assertTrue("Message count did not match expectations", result);
+        notify.matches(5l, TimeUnit.SECONDS);
 
         verify(solrSmallUpdateProcessor, times(3)).process(exchangeCaptor.capture());
         List<Exchange> exchanges = exchangeCaptor.getAllValues();
@@ -178,8 +168,7 @@ public class SolrUpdateRouterTest {
                 .whenCompleted(1)
                 .create();
 
-        boolean result = notify.matches(5l, TimeUnit.SECONDS);
-        assertTrue("Message count did not match expectations", result);
+        notify.matches(5l, TimeUnit.SECONDS);
 
         verify(solrLargeUpdateProcessor).process(exchangeCaptor.capture());
         List<Exchange> exchanges = exchangeCaptor.getAllValues();
@@ -202,8 +191,7 @@ public class SolrUpdateRouterTest {
                 .whenCompleted(3)
                 .create();
 
-        boolean result = notify.matches(5l, TimeUnit.SECONDS);
-        assertTrue("Message count did not match expectations", result);
+        notify.matches(5l, TimeUnit.SECONDS);
 
         verify(solrLargeUpdateProcessor).process(exchangeCaptor.capture());
         List<Exchange> largeExchanges = exchangeCaptor.getAllValues();

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/triplesReindexing/TriplesReindexingRouterIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/triplesReindexing/TriplesReindexingRouterIT.java
@@ -31,6 +31,8 @@ import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.test.spring.CamelSpringRunner;
+import org.apache.camel.test.spring.CamelTestContextBootstrapper;
 import org.apache.commons.io.FileUtils;
 import org.apache.jena.fuseki.embedded.FusekiServer;
 import org.apache.jena.query.Dataset;
@@ -44,9 +46,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.BootstrapWith;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.ContextHierarchy;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import edu.unc.lib.dl.acl.service.AccessControlService;
 import edu.unc.lib.dl.acl.util.AccessGroupSet;
@@ -72,13 +76,15 @@ import edu.unc.lib.dl.test.TestHelper;
  * @author bbpennel
  *
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@RunWith(CamelSpringRunner.class)
+@BootstrapWith(CamelTestContextBootstrapper.class)
 @ContextHierarchy({
     @ContextConfiguration("/spring-test/test-fedora-container.xml"),
     @ContextConfiguration("/spring-test/cdr-client-container.xml"),
     @ContextConfiguration("/spring-test/jms-context.xml"),
     @ContextConfiguration("/triples-reindexing-it-context.xml")
 })
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 public class TriplesReindexingRouterIT {
 
     @Autowired
@@ -180,7 +186,7 @@ public class TriplesReindexingRouterIT {
         // 3 resources compose the folder
         NotifyBuilder notify = new NotifyBuilder(fcrepoTriplestoreIndexer)
                 .from(indexingEndpoint)
-                .whenDone(3)
+                .whenDone(2)
                 .create();
 
         notify.matches(5l, TimeUnit.SECONDS);
@@ -196,7 +202,7 @@ public class TriplesReindexingRouterIT {
         // Wait for roughly all of the objects to be indexed
         NotifyBuilder notify = new NotifyBuilder(fcrepoTriplestoreIndexer)
                 .from(indexingEndpoint)
-                .whenDone(25)
+                .whenCompleted(15)
                 .create();
 
         notify.matches(25l, TimeUnit.SECONDS);

--- a/services-camel/src/test/resources/cdr-event-routing-it-config.properties
+++ b/services-camel/src/test/resources/cdr-event-routing-it-config.properties
@@ -43,6 +43,12 @@ cdr.stream.camel=activemq://activemq:queue:repository.events
 cdr.solrupdate.stream=activemq:queue:repository.solrupdate
 cdr.solrupdate.stream.camel=activemq://activemq:queue:repository.solrupdate
 
+cdr.solrupdate.small.dest=direct:solr.update.small
+cdr.solrupdate.small.consumer=direct:solr.update.small
+
+cdr.solrupdate.large.dest=direct:solr.update.large
+cdr.solrupdate.large.consumer=direct:solr.update.large
+
 # The base URL of the triplestore being used.
 triplestore.baseUrl=http://localhost:8080/fuseki/test/update
 

--- a/services-camel/src/test/resources/cdr-event-routing-it-context.xml
+++ b/services-camel/src/test/resources/cdr-event-routing-it-context.xml
@@ -58,8 +58,15 @@
         <property name="indexingMessageSender" ref="indexingMessageSender" />
     </bean>
 
-    <bean id="solrUpdateProcessor"
+    <bean id="solrSmallUpdateProcessor"
         class="edu.unc.lib.dl.services.camel.solrUpdate.SolrUpdateProcessor">
+    </bean>
+    
+    <bean id="solrLargeUpdateProcessor"
+        class="edu.unc.lib.dl.services.camel.solrUpdate.SolrUpdateProcessor">
+    </bean>
+    
+    <bean id="solrUpdatePreprocessor" class="edu.unc.lib.dl.services.camel.solrUpdate.SolrUpdatePreprocessor">
     </bean>
 
     <camel:camelContext id="cdrServiceCdrEvents">

--- a/services-camel/src/test/resources/deregister-longleaf-router-context.xml
+++ b/services-camel/src/test/resources/deregister-longleaf-router-context.xml
@@ -44,14 +44,6 @@
     <bean id="deregisterLongleafProcessor" class="edu.unc.lib.dl.services.camel.longleaf.DeregisterLongleafProcessor">
     </bean>
     
-    <bean id="sjms" class="org.apache.camel.component.sjms.SjmsComponent">
-        <property name="connectionFactory" ref="jmsFactory" />
-    </bean>
-    
-    <bean id="sjms-batch" class="org.apache.camel.component.sjms.batch.SjmsBatchComponent">
-        <property name="connectionFactory" ref="jmsFactory" />
-    </bean>
-    
     <camel:camelContext id="cdrLongleaf">
         <camel:package>edu.unc.lib.dl.services.camel.longleaf</camel:package>
     </camel:camelContext>

--- a/services-camel/src/test/resources/solr-update-config.properties
+++ b/services-camel/src/test/resources/solr-update-config.properties
@@ -1,0 +1,16 @@
+error.maxRedeliveries=1
+error.retryDelay=1000
+error.backOffMultiplier=1
+
+cdr.enhancement.solr.error.maxRedeliveries=1
+cdr.enhancement.solr.error.retryDelay=10
+cdr.enhancement.solr.error.backOffMultiplier=1.2
+
+cdr.solrupdate.stream=direct:start
+cdr.solrupdate.stream.camel=direct:start
+
+cdr.solrupdate.small.dest=sjms:solr.update.small?transacted=true
+cdr.solrupdate.small.consumer=sjms-batch:solr.update.small?completionTimeout=100&completionSize=5&consumerCount=1&aggregationStrategy=#bodyListAggregationStrategy&connectionFactory=jmsFactory
+
+cdr.solrupdate.large.dest=activemq:queue:solr.update.large
+cdr.solrupdate.large.consumer=activemq://activemq:queue:solr.update.large?transacted=true

--- a/services-camel/src/test/resources/solr-update-context.xml
+++ b/services-camel/src/test/resources/solr-update-context.xml
@@ -7,11 +7,32 @@
         http://camel.apache.org/schema/spring
         http://camel.apache.org/schema/spring/camel-spring.xsd">
     
-    <bean id="solrUpdateProcessor" class="org.mockito.Mockito" factory-method="mock">
+    <bean id="properties" class="org.apache.camel.component.properties.PropertiesComponent">
+        <property name="location" value="classpath:solr-update-config.properties"/>
+    </bean>
+    
+    <bean id="bridgePropertyPlaceholder" class="org.apache.camel.spring.spi.BridgePropertyPlaceholderConfigurer">
+        <property name="location" value="classpath:solr-update-config.properties"/>
+    </bean>
+    
+    <bean id="solrSmallUpdateProcessor" class="org.mockito.Mockito" factory-method="mock">
         <constructor-arg value="edu.unc.lib.dl.services.camel.solrUpdate.SolrUpdateProcessor" />
     </bean>
+    
+    <bean id="solrLargeUpdateProcessor" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.services.camel.solrUpdate.SolrUpdateProcessor" />
+    </bean>
+    
+    <bean id="solrUpdatePreprocessor" class="org.mockito.Mockito" factory-method="spy">
+        <constructor-arg ref="solrUpdatePreprocessorReal" />
+    </bean>
+    
+    <bean id="solrUpdatePreprocessorReal" class="edu.unc.lib.dl.services.camel.solrUpdate.SolrUpdatePreprocessor">
+    </bean>
+    
+    <bean id="bodyListAggregationStrategy" class="edu.unc.lib.dl.services.camel.util.BodyListAggregationStrategy"/>
 
-    <camel:camelContext id="CdrServiceSolrUpdate">
+    <camel:camelContext id="cdrServiceSolrUpdate">
         <camel:package>edu.unc.lib.dl.services.camel.solrUpdate</camel:package>
     </camel:camelContext>
     

--- a/services-camel/src/test/resources/solr-update-processor-it-context.xml
+++ b/services-camel/src/test/resources/solr-update-processor-it-context.xml
@@ -23,6 +23,7 @@
     
     <bean id="recursiveTreeIndexer" class="edu.unc.lib.dl.data.ingest.solr.action.RecursiveTreeIndexer">
         <property name="indexingMessageSender" ref="indexingMessageSender" />
+        <property name="sparqlQueryService" ref="sparqlQueryService" />
     </bean>
     
     <bean id="updateTreeAction"
@@ -155,9 +156,18 @@
         class="edu.unc.lib.dl.services.IndexingMessageSender">
     </bean>
     
-    <bean id="solrUpdateProcessor" class="edu.unc.lib.dl.services.camel.solrUpdate.SolrUpdateProcessor">
+    <bean id="solrSmallUpdateProcessor" class="edu.unc.lib.dl.services.camel.solrUpdate.SolrUpdateProcessor">
         <property name="solrIndexingActionMap" ref="solrIndexingActionMap"/>
     </bean>
+    
+    <bean id="solrLargeUpdateProcessor" class="edu.unc.lib.dl.services.camel.solrUpdate.SolrUpdateProcessor">
+        <property name="solrIndexingActionMap" ref="solrIndexingActionMap"/>
+    </bean>
+    
+    <bean id="solrUpdatePreprocessor" class="edu.unc.lib.dl.services.camel.solrUpdate.SolrUpdatePreprocessor">
+    </bean>
+    
+    <bean id="bodyListAggregationStrategy" class="edu.unc.lib.dl.services.camel.util.BodyListAggregationStrategy"/>
         
     <camel:camelContext id="cdrServiceSolrUpdate">
         <camel:package>edu.unc.lib.dl.services.camel.solrUpdate</camel:package>

--- a/services-camel/src/test/resources/spring-test/cdr-client-container.xml
+++ b/services-camel/src/test/resources/spring-test/cdr-client-container.xml
@@ -76,6 +76,11 @@
         <constructor-arg ref="queryModel" />
     </bean>
     
+    <bean id="treeIndexer" class="edu.unc.lib.dl.test.RepositoryObjectTreeIndexer">
+        <constructor-arg ref="queryModel" />
+        <constructor-arg ref="fcrepoClient" />
+    </bean>
+    
     <bean id="repositoryObjectCacheLoader" class="edu.unc.lib.dl.fcrepo4.RepositoryObjectCacheLoader">
         <property name="client" ref="fcrepoClient" />
         <property name="repositoryObjectDriver" ref="repositoryObjectDriver" />

--- a/services-camel/src/test/resources/spring-test/jms-context.xml
+++ b/services-camel/src/test/resources/spring-test/jms-context.xml
@@ -39,7 +39,7 @@
     <amq:connectionFactory id="jmsFactory"
         brokerURL="vm://localhost" />
 
-    <amq:broker useJmx="false" persistent="false" useShutdownHook="false">
+    <amq:broker useJmx="false" persistent="false" useShutdownHook="true">
         <amq:transportConnectors>
             <amq:transportConnector uri="vm://localhost:61616" />
         </amq:transportConnectors>

--- a/services-camel/src/test/resources/spring-test/jms-context.xml
+++ b/services-camel/src/test/resources/spring-test/jms-context.xml
@@ -25,6 +25,14 @@
         class="org.apache.activemq.camel.component.ActiveMQComponent">
         <property name="configuration" ref="jmsConfig" />
     </bean>
+    
+    <bean id="sjms" class="org.apache.camel.component.sjms.SjmsComponent">
+        <property name="connectionFactory" ref="jmsFactory" />
+    </bean>
+    
+    <bean id="sjms-batch" class="org.apache.camel.component.sjms.batch.SjmsBatchComponent">
+        <property name="connectionFactory" ref="jmsFactory" />
+    </bean>
 
     <!-- JMS ConnectionFactory to use, configuring the embedded broker using 
         XML -->

--- a/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/exception/IndexingException.java
+++ b/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/exception/IndexingException.java
@@ -16,11 +16,11 @@
 package edu.unc.lib.dl.data.ingest.solr.exception;
 
 /**
- * 
+ *
  * @author bbpennel
  *
  */
-public class IndexingException extends Exception {
+public class IndexingException extends RuntimeException {
     private static final long serialVersionUID = 1L;
     private String body;
 

--- a/solr-ingest/src/test/java/edu/unc/lib/dl/data/ingest/solr/action/IndexTreeCleanActionTest.java
+++ b/solr-ingest/src/test/java/edu/unc/lib/dl/data/ingest/solr/action/IndexTreeCleanActionTest.java
@@ -25,6 +25,8 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.UUID;
 
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -91,6 +93,8 @@ public class IndexTreeCleanActionTest {
 
         when(repositoryObjectLoader.getRepositoryObject(eq(pid))).thenReturn(containerObj);
         when(containerObj.getPid()).thenReturn(pid);
+        Model model = ModelFactory.createDefaultModel();
+        when(containerObj.getResource()).thenReturn(model.getResource(pid.getRepositoryPath()));
     }
 
     @Test


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2738

* Switches solr tree indexing operations to retrieving children via a sparql query, instead of retrieving all of the children records up front. This significiantly speeds up the list of children in cases where there are many immediate children
* Splits solr update queue into two separate queues, one for larger actions that generate individual record updates, and a second queue for the smaller individual record updates. This allows the smaller updates to proceed without being blocked by the jobs that generate them, and allows the smaller updates to be batched for higher throughput.
* Messages generated with qualified pid format instead of fedora url syntax, although either works.
    * fixes bug in parsing of the qualified id form for the content root object
* Switches IndexingExceptions to being runtime exceptions so that they can be thrown from more closure types.