### PR TITLE
BXC-2744 - Improve recovery of binary transfer jobs

### DIFF
--- a/deposit/src/main/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJob.java
@@ -150,7 +150,8 @@ public class TransferBinariesToStorageJob extends AbstractDepositJob {
 
             Path stagingPath = getModsHistoryPath(objPid);
             if (Files.exists(stagingPath)) {
-                transferFile(modsPid, stagingPath.toUri(), transferSession, resc, CdrDeposit.descriptiveHistoryStorageUri);
+                transferFile(modsPid, stagingPath.toUri(), transferSession, resc,
+                        CdrDeposit.descriptiveHistoryStorageUri);
                 log.debug("Finished transferring MODS history file {}", modsPid.getQualifiedId());
             }
         }

--- a/deposit/src/main/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJob.java
@@ -17,7 +17,6 @@ package edu.unc.lib.deposit.transfer;
 
 import static edu.unc.lib.deposit.work.DepositGraphUtils.getChildIterator;
 import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.DEPOSIT_RECORD_BASE;
-import static edu.unc.lib.dl.model.DatastreamPids.getDatastreamHistoryPid;
 import static edu.unc.lib.dl.model.DatastreamPids.getDepositManifestPid;
 import static edu.unc.lib.dl.model.DatastreamPids.getOriginalFilePid;
 import static edu.unc.lib.dl.model.DatastreamPids.getTechnicalMetadataPid;
@@ -35,16 +34,21 @@ import java.util.Set;
 import org.apache.jena.rdf.model.Bag;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.NodeIterator;
+import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.vocabulary.RDF;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import edu.unc.lib.deposit.work.AbstractDepositJob;
 import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.model.DatastreamPids;
+import edu.unc.lib.dl.persist.api.storage.BinaryDetails;
+import edu.unc.lib.dl.persist.api.transfer.BinaryAlreadyExistsException;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferSession;
 import edu.unc.lib.dl.rdf.Cdr;
 import edu.unc.lib.dl.rdf.CdrDeposit;
@@ -62,6 +66,9 @@ public class TransferBinariesToStorageJob extends AbstractDepositJob {
 
     private static final Set<Resource> TYPES_ALLOWING_DESC = new HashSet<>(asList(
             Cdr.Folder, Cdr.Work, Cdr.Collection, Cdr.AdminUnit, Cdr.FileObject));
+
+    @Autowired
+    private RepositoryObjectFactory repoObjFactory;
 
     /**
      *
@@ -131,14 +138,9 @@ public class TransferBinariesToStorageJob extends AbstractDepositJob {
         if (resc.hasProperty(CdrDeposit.stagingLocation) && !resc.hasProperty(CdrDeposit.storageUri)) {
             PID originalPid = getOriginalFilePid(objPid);
 
-            if (!isObjectCompleted(originalPid)) {
-                URI stagingUri = URI.create(resc.getProperty(CdrDeposit.stagingLocation).getString());
-                log.debug("Transferring original file from {} for {}", stagingUri, originalPid);
-                URI storageUri = transferSession.transfer(originalPid, stagingUri);
-                log.debug("Finished transferring original file from {} to {}", stagingUri, storageUri);
-                resc.addLiteral(CdrDeposit.storageUri, storageUri.toString());
-                markObjectCompleted(originalPid);
-            }
+            URI stagingUri = URI.create(resc.getProperty(CdrDeposit.stagingLocation).getString());
+            transferFile(originalPid, stagingUri, transferSession, resc, CdrDeposit.storageUri);
+            log.debug("Finished transferring original file for {}", originalPid.getQualifiedId());
         }
     }
 
@@ -146,17 +148,10 @@ public class TransferBinariesToStorageJob extends AbstractDepositJob {
         if (!resc.hasProperty(CdrDeposit.descriptiveHistoryStorageUri)) {
             PID modsPid = DatastreamPids.getMdDescriptivePid(objPid);
 
-            if (!isObjectCompleted(modsPid)) {
-                Path stagingPath = getModsHistoryPath(objPid);
-
-                if (Files.exists(stagingPath)) {
-                    PID dsHistoryPid = getDatastreamHistoryPid(modsPid);
-                    URI stagingUri = stagingPath.toUri();
-                    URI storageUri = transferSession.transfer(dsHistoryPid, stagingUri);
-                    log.debug("Finished transferring MODS history file from {} to {}", stagingUri, storageUri);
-                    resc.addLiteral(CdrDeposit.descriptiveHistoryStorageUri, storageUri.toString());
-                    markObjectCompleted(modsPid);
-                }
+            Path stagingPath = getModsHistoryPath(objPid);
+            if (Files.exists(stagingPath)) {
+                transferFile(modsPid, stagingPath.toUri(), transferSession, resc, CdrDeposit.descriptiveHistoryStorageUri);
+                log.debug("Finished transferring MODS history file {}", modsPid.getQualifiedId());
             }
         }
     }
@@ -165,13 +160,9 @@ public class TransferBinariesToStorageJob extends AbstractDepositJob {
         if (!resc.hasProperty(CdrDeposit.fitsStorageUri)) {
             PID fitsPid = getTechnicalMetadataPid(objPid);
 
-            if (!isObjectCompleted(fitsPid)) {
-                URI stagingUri = getTechMdPath(objPid, false).toUri();
-                URI storageUri = transferSession.transfer(fitsPid, stagingUri);
-                log.debug("Finished transferring techmd file from {} to {}", stagingUri, storageUri);
-                resc.addLiteral(CdrDeposit.fitsStorageUri, storageUri.toString());
-                markObjectCompleted(fitsPid);
-            }
+            URI stagingUri = getTechMdPath(objPid, false).toUri();
+            transferFile(fitsPid, stagingUri, transferSession, resc, CdrDeposit.fitsStorageUri);
+            log.debug("Finished transferring techmd file {}", fitsPid.getQualifiedId());
         }
     }
 
@@ -187,13 +178,38 @@ public class TransferBinariesToStorageJob extends AbstractDepositJob {
             }
 
             PID manifestPid = getDepositManifestPid(objPid, manifestFile.getName());
+            transferFile(manifestPid, manifestUri, transferSession, resc, CdrDeposit.storageUri);
+        }
+    }
 
-            if (!isObjectCompleted(manifestPid)) {
-                URI storageUri = transferSession.transfer(manifestPid, manifestUri);
-                log.debug("Finished transferring manifest file from {} to {}", manifestUri, storageUri);
-                resc.addLiteral(CdrDeposit.storageUri, storageUri.toString());
-                markObjectCompleted(manifestPid);
+    private void transferFile(PID binPid, URI stagingUri, BinaryTransferSession transferSession,
+            Resource resc, Property storageProperty) {
+
+        log.debug("Transferring {} file from {} for {}", storageProperty.getLocalName(),
+                stagingUri, binPid.getQualifiedId());
+        URI storageUri;
+        try {
+            storageUri = transferSession.transfer(binPid, stagingUri);
+        } catch (BinaryAlreadyExistsException e) {
+            // Make sure a PID collision with an existing repository object isn't happening
+            if (repoObjFactory.objectExists(binPid.getRepositoryUri())) {
+                failJob(e, "Cannot transfer binary {0}, an object with PID {1} already exists in the repository",
+                        stagingUri, binPid.getQualifiedId());
+            }
+            // Check if the binary at the destination matches the staged copy
+            if (transferSession.isTransferred(binPid, stagingUri)) {
+                // binary was previously fully transferred so all we need to do is record the destination uri
+                log.debug("Binary {} was already transferred, recording and moving on", binPid.getQualifiedId());
+                BinaryDetails details = transferSession.getStoredBinaryDetails(binPid);
+                storageUri = details.getDestinationUri();
+            } else {
+                // binary was not previously fully transferred, so retry with replacement enabled
+                log.debug("Retransferring {} file from {} for {} with replacement enabled",
+                        storageProperty.getLocalName(), stagingUri, binPid.getQualifiedId());
+                storageUri = transferSession.transferReplaceExisting(binPid, stagingUri);
             }
         }
+        log.debug("Finished transferring file from {} to {}", stagingUri, storageUri);
+        resc.addLiteral(storageProperty, storageUri.toString());
     }
 }

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/persist/api/storage/BinaryDetails.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/persist/api/storage/BinaryDetails.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.persist.api.storage;
+
+import java.net.URI;
+import java.util.Date;
+
+/**
+ * Details of a binary file
+ *
+ * @author bbpennel
+ */
+public interface BinaryDetails {
+
+    /**
+     * @return the URI of the stored binary
+     */
+    URI getDestinationUri();
+
+    /**
+     * @return last modified timestamp of the binary
+     */
+    Date getLastModified();
+
+    /**
+     * @return file size of the binary
+     */
+    long getSize();
+}

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/persist/api/transfer/BinaryTransferClient.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/persist/api/transfer/BinaryTransferClient.java
@@ -18,6 +18,7 @@ package edu.unc.lib.dl.persist.api.transfer;
 import java.net.URI;
 
 import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.persist.api.storage.BinaryDetails;
 
 /**
  * Client for transferring binaries between a category of ingest sources and a
@@ -57,6 +58,23 @@ public interface BinaryTransferClient {
      * @return the URI of the binary in its destination.
      */
     URI transferVersion(PID binPid, URI sourceFileUri);
+
+    /**
+     * Checks if a storage location already contains the source binary in its current state.
+     *
+     * @param binPid PID of the binary object the binary is associated with
+     * @param sourceUri URI of the binary located in an IngestSource
+     * @return true if the storage location contains the source file
+     */
+    boolean isTransferred(PID binPid, URI sourceUri);
+
+    /**
+     * Get details of a binary located in a storage location
+     *
+     * @param binPid PID of the binary object the binary is associated with
+     * @return object containing binary details
+     */
+    BinaryDetails getStoredBinaryDetails(PID binPid);
 
     /**
      * Shut down this transfer client.

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/persist/api/transfer/BinaryTransferSession.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/persist/api/transfer/BinaryTransferSession.java
@@ -19,6 +19,7 @@ import java.io.InputStream;
 import java.net.URI;
 
 import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.persist.api.storage.BinaryDetails;
 
 /**
  * A session for transferring one or more binaries to a preservation storage location
@@ -96,6 +97,23 @@ public interface BinaryTransferSession extends AutoCloseable {
      * @param fileUri uri of the binary to delete.
      */
     void delete(URI fileUri);
+
+    /**
+     * Get details of a binary located in a storage location
+     *
+     * @param binPid PID of the binary object the binary is associated with
+     * @return object containing binary details, or null if not found
+     */
+    BinaryDetails getStoredBinaryDetails(PID binPid);
+
+    /**
+     * Checks if a storage location already contains the source binary in its current state.
+     *
+     * @param binPid PID of the binary object the binary is associated with
+     * @param sourceUri URI of the binary located in an IngestSource
+     * @return true if the storage location contains the source file
+     */
+    boolean isTransferred(PID binPid, URI sourceUri);
 
     /**
      * Closes the binary session. If there are any failures, they will be RuntimeExceptions.

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/persist/api/transfer/StreamTransferClient.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/persist/api/transfer/StreamTransferClient.java
@@ -19,6 +19,7 @@ import java.io.InputStream;
 import java.net.URI;
 
 import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.persist.api.storage.BinaryDetails;
 
 /**
  * Client for streaming content to a preservation storage location
@@ -64,6 +65,14 @@ public interface StreamTransferClient {
      * @param fileUri uri of the file to delete
      */
     void delete(URI fileUri);
+
+    /**
+     * Get details of a binary located in a storage location
+     *
+     * @param binPid PID of the binary object the binary is associated with
+     * @return object containing binary details
+     */
+    BinaryDetails getStoredBinaryDetails(PID binPid);
 
     /**
      * Shut down this transfer client.

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/storage/BinaryDetailsImpl.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/storage/BinaryDetailsImpl.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.persist.services.storage;
+
+import java.net.URI;
+import java.util.Date;
+
+import edu.unc.lib.dl.persist.api.storage.BinaryDetails;
+
+/**
+ * Implementation of generic details of a binary file
+ *
+ * @author bbpennel
+ */
+public class BinaryDetailsImpl implements BinaryDetails {
+
+    private URI uri;
+    private Date lastModified;
+    private long size;
+
+    /**
+     * @param lastModified
+     * @param size
+     */
+    public BinaryDetailsImpl(URI uri, Date lastModified, long size) {
+        this.uri = uri;
+        this.lastModified = lastModified;
+        this.size = size;
+    }
+
+    @Override
+    public Date getLastModified() {
+        return lastModified;
+    }
+
+    @Override
+    public long getSize() {
+        return size;
+    }
+
+    @Override
+    public URI getDestinationUri() {
+        return uri;
+    }
+
+}

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/BinaryTransferSessionImpl.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/BinaryTransferSessionImpl.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang3.NotImplementedException;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.persist.api.ingest.IngestSource;
 import edu.unc.lib.dl.persist.api.ingest.IngestSourceManager;
+import edu.unc.lib.dl.persist.api.storage.BinaryDetails;
 import edu.unc.lib.dl.persist.api.storage.StorageLocation;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferClient;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferSession;
@@ -148,5 +149,17 @@ public class BinaryTransferSessionImpl implements BinaryTransferSession {
     @Override
     public void delete(URI fileUri) {
         getStreamClient().delete(fileUri);
+    }
+
+    @Override
+    public BinaryDetails getStoredBinaryDetails(PID binPid) {
+        return getStreamClient().getStoredBinaryDetails(binPid);
+    }
+
+    @Override
+    public boolean isTransferred(PID binPid, URI sourceUri) {
+        IngestSource source = sourceManager.getIngestSourceForUri(sourceUri);
+        BinaryTransferClient client = getTransferClient(source);
+        return client.isTransferred(binPid, sourceUri);
     }
 }

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/FileSystemTransferHelpers.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/FileSystemTransferHelpers.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.persist.services.transfer;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Date;
+
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.persist.api.storage.BinaryDetails;
+import edu.unc.lib.dl.persist.api.storage.StorageLocation;
+import edu.unc.lib.dl.persist.api.transfer.BinaryTransferException;
+import edu.unc.lib.dl.persist.services.storage.BinaryDetailsImpl;
+
+/**
+ * Helpers for file system transfer client operations
+ *
+ * @author bbpennel
+ */
+public class FileSystemTransferHelpers {
+
+    private FileSystemTransferHelpers() {
+    }
+
+    /**
+     * Get binary details from a filesystem storage location
+     *
+     * @param storageLoc storage location where binary is stored
+     * @param binPid pid of the binary
+     * @return details of stored binary, or null if not found
+     */
+    public static BinaryDetails getStoredBinaryDetails(StorageLocation storageLoc, PID binPid) {
+        URI destUri = storageLoc.getStorageUri(binPid);
+        return getBinaryDetails(destUri);
+    }
+
+    /**
+     * Get binary details for the provided file uri
+     *
+     * @param binUri URI of the file
+     * @return details of the binary, or null if not found
+     */
+    public static BinaryDetails getBinaryDetails(URI binUri) {
+        Path path = Paths.get(binUri);
+
+        try {
+            if (Files.notExists(path)) {
+                return null;
+            }
+
+            long size = Files.size(path);
+            Date lastModified = Date.from(Files.getLastModifiedTime(path).toInstant());
+            return new BinaryDetailsImpl(binUri, lastModified, size);
+        } catch (IOException e) {
+            throw new BinaryTransferException("Failed to retrieve binary details for " + binUri, e);
+        }
+    }
+}

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/StreamToFSTransferClient.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/StreamToFSTransferClient.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.persist.api.storage.BinaryDetails;
 import edu.unc.lib.dl.persist.api.storage.StorageLocation;
 import edu.unc.lib.dl.persist.api.transfer.BinaryAlreadyExistsException;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferException;
@@ -135,5 +136,10 @@ public class StreamToFSTransferClient implements StreamTransferClient {
             throw new BinaryTransferException("Failed to delete file from destination "
                     + destination.getId(), e);
         }
+    }
+
+    @Override
+    public BinaryDetails getStoredBinaryDetails(PID binPid) {
+        return FileSystemTransferHelpers.getStoredBinaryDetails(destination, binPid);
     }
 }

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/transfer/BinaryTransferServiceImplIT.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/transfer/BinaryTransferServiceImplIT.java
@@ -162,6 +162,26 @@ public class BinaryTransferServiceImplIT {
         }
     }
 
+    @Test
+    public void checkIfTransferred() throws Exception {
+        PID binPid = pidMinter.mintContentPid();
+        StorageLocation destination = storageManager.getStorageLocationById("loc1");
+        Path sourceFile = createSourceFile(sourcePath1, "myfile.txt", "some content");
+        URI sourceUri = sourceFile.toUri();
+
+        try (BinaryTransferSession session = transferService.getSession(destination)) {
+            assertFalse(session.isTransferred(binPid, sourceUri));
+
+            // Perform transfer, should now return true
+            session.transfer(binPid, sourceFile.toUri());
+            assertTrue(session.isTransferred(binPid, sourceUri));
+
+            // Change the file and see if its still considered transferred
+            FileUtils.writeStringToFile(sourceFile.toFile(), "updated", "UTF-8");
+            assertFalse(session.isTransferred(binPid, sourceUri));
+        }
+    }
+
     private Map<String, Object> addStorageLocation(String id, String name, Path base) throws IOException {
         Map<String, Object> info = new HashMap<>();
         info.put("id", id);


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2744
* Binary transfer job handles three error cases when a transfer runs into an existing file at the destination
    1. The file has already been transferred, but the storage uri was lost due to an error or the jvm shutting down. In this case, no transfer occurs, and the storage uri is recorded
    2. The file was partially transferred due to interruption. In this case, the file will be overwritten
    3. The pid of the file overlaps with an object in the repository, and therefore they have the same file uri. In this case, the deposit fails
* Removed redis tracking of binary transfers as having the JVM terminate will result in losing storage uris recorded in jena, which would be skipped during resumption, ultimately causing IngestContentJob to fail    