### PR TITLE
BXC-2765 - Skip migration of members

### DIFF
--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/TransformContentCommand.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/TransformContentCommand.java
@@ -25,6 +25,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import edu.unc.lib.dcr.migration.content.ContentObjectTransformerManager;
+import edu.unc.lib.dcr.migration.content.ContentTransformationOptions;
 import edu.unc.lib.dcr.migration.content.ContentTransformationService;
 import edu.unc.lib.dcr.migration.deposit.DepositDirectoryManager;
 import edu.unc.lib.dcr.migration.deposit.DepositModelManager;
@@ -36,7 +37,7 @@ import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
 import edu.unc.lib.dl.fcrepo4.RepositoryPIDMinter;
 import edu.unc.lib.dl.fedora.PID;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Option;
+import picocli.CommandLine.Mixin;
 import picocli.CommandLine.Parameters;
 import picocli.CommandLine.ParentCommand;
 
@@ -58,29 +59,8 @@ public class TransformContentCommand implements Callable<Integer> {
             description = "UUID of the content object from which to start the transformation")
     private String startingId;
 
-    @Option(names = {"-u", "--as-admin-units"},
-            description = "Top level collections will be transformed into admin units")
-    private boolean topLevelAsUnit;
-
-    @Option(names = {"--no-hash-nesting"}, negatable = true,
-            description = "Nest transformed logs in hashed subdirectories. Default: true")
-    private boolean hashNesting = true;
-
-    @Option(names = {"-g", "--generate-ids"},
-            description = "Generate new ids for transformed objects, for testing.")
-    private boolean generateIds;
-
-    @Option(names = {"--deposit-into"},
-            description = "Submits the transformed content for deposit to the provided container UUID")
-    private String depositInto;
-
-    @Option(names = {"-m", "--missing-deposit-records"},
-            description = "Create referenced deposit records which do not have their own bxc3 object")
-    private boolean createMissingDepositRecords;
-
-    @Option(names = {"-n", "--dry-run"},
-            description = "Perform the transformation but do not save the results")
-    private boolean dryRun;
+    @Mixin
+    private ContentTransformationOptions options;
 
     private String applicationContextPath = "spring/service-context.xml";
 
@@ -100,7 +80,7 @@ public class TransformContentCommand implements Callable<Integer> {
 
         DepositModelManager depositModelManager = new DepositModelManager(depositPid, parentCommand.tdbDir);
         DepositDirectoryManager depositDirectoryManager = new DepositDirectoryManager(
-                depositPid, parentCommand.depositBaseDir, hashNesting);
+                depositPid, parentCommand.depositBaseDir, options.isHashNesting());
 
         PathIndex pathIndex = (PathIndex) context.getBean("pathIndex");
         pathIndex.setDatabaseUrl(parentCommand.databaseUrl);
@@ -111,16 +91,14 @@ public class TransformContentCommand implements Callable<Integer> {
         ContentObjectTransformerManager transformerManager = new ContentObjectTransformerManager();
         transformerManager.setModelManager(depositModelManager);
         transformerManager.setPathIndex(pathIndex);
-        transformerManager.setTopLevelAsUnit(topLevelAsUnit);
         transformerManager.setPidMinter(pidMinter);
         transformerManager.setDirectoryManager(depositDirectoryManager);
-        transformerManager.setGenerateIds(generateIds);
         transformerManager.setPremisLoggerFactory(premisLoggerFactory);
         transformerManager.setRepositoryObjectFactory(repoObjFactory);
-        transformerManager.setCreateMissingDepositRecords(createMissingDepositRecords);
+        transformerManager.setOptions(options);
 
         ContentTransformationService transformService = new ContentTransformationService(
-                depositPid, startingId, topLevelAsUnit);
+                depositPid, startingId);
         transformService.setTransformerManager(transformerManager);
         transformService.setModelManager(depositModelManager);
 
@@ -130,20 +108,20 @@ public class TransformContentCommand implements Callable<Integer> {
 
         context.close();
 
-        if (dryRun) {
+        if (options.isDryRun()) {
             output.info("Dry run, deposit model not saved");
             depositModelManager.removeModel();
             depositDirectoryManager.cleanupDepositDirectory();
             return result;
         }
 
-        if (depositInto != null) {
+        if (options.getDepositInto() != null) {
             if (result != 0) {
                 output.info("Encountered issues during transformation, skipping deposit submission");
                 return result;
             }
 
-            PID destinationPid = PIDs.get(depositInto);
+            PID destinationPid = PIDs.get(options.getDepositInto());
 
             DepositSubmissionService depositService = new DepositSubmissionService(
                     parentCommand.redisHost, parentCommand.redisPort);

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformer.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformer.java
@@ -119,7 +119,6 @@ public class ContentObjectTransformer extends RecursiveAction {
 
     private PathIndex pathIndex;
     private DepositModelManager modelManager;
-    private boolean topLevelAsUnit;
     private ContentObjectTransformerManager manager;
     private RepositoryPIDMinter pidMinter;
     private DepositDirectoryManager directoryManager;
@@ -133,7 +132,7 @@ public class ContentObjectTransformer extends RecursiveAction {
 
     private Document foxml;
 
-    private boolean createMissingDepositRecords;
+    private ContentTransformationOptions options;
 
     /**
      *
@@ -219,7 +218,7 @@ public class ContentObjectTransformer extends RecursiveAction {
         PID originalDepPid = convertBxc3RefToPid(DEPOSIT_RECORD_BASE, originalDepStmt.getResource().getURI());
         depResc.addProperty(CdrDeposit.originalDeposit, createResource(originalDepPid.getRepositoryPath()));
 
-        if (createMissingDepositRecords) {
+        if (options.isCreateMissingDepositRecords()) {
             Path depRecPath = pathIndex.getPath(originalDepPid, OBJECT_TYPE);
             if (depRecPath == null && !createdDepositRecords.contains(originalDepPid)) {
                 createdDepositRecords.add(originalDepPid);
@@ -454,7 +453,7 @@ public class ContentObjectTransformer extends RecursiveAction {
             return Cdr.Work;
         }
         if (contentModels.contains(COLLECTION.getResource())) {
-            if (Cdr.AdminUnit.equals(parentType) || !topLevelAsUnit) {
+            if (Cdr.AdminUnit.equals(parentType) || !options.isTopLevelAsUnit()) {
                 return Cdr.Collection;
             } else {
                 return Cdr.AdminUnit;
@@ -534,10 +533,6 @@ public class ContentObjectTransformer extends RecursiveAction {
         this.modelManager = modelManager;
     }
 
-    public void setTopLevelAsUnit(boolean topLevelAsUnit) {
-        this.topLevelAsUnit = topLevelAsUnit;
-    }
-
     public void setManager(ContentObjectTransformerManager manager) {
         this.manager = manager;
     }
@@ -562,7 +557,7 @@ public class ContentObjectTransformer extends RecursiveAction {
         this.repoObjFactory = repoObjFactory;
     }
 
-    public void setCreateMissingDepositRecords(boolean createMissingDepositRecords) {
-        this.createMissingDepositRecords = createMissingDepositRecords;
+    public void setOptions(ContentTransformationOptions options) {
+        this.options = options;
     }
 }

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformer.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformer.java
@@ -262,15 +262,17 @@ public class ContentObjectTransformer extends RecursiveAction {
         containerBag.addProperty(RDF.type, resourceType);
 
         Map<PID, PID> oldToNewPids = new HashMap<>();
-        List<PID> contained = listContained(bxc3Resc);
-        for (PID containedPid : contained) {
-            // Determine PID to use for transformed child, in case we are generating or preserving ids.
-            PID newContainedPid = manager.getTransformedPid(containedPid);
-            oldToNewPids.put(containedPid, newContainedPid);
+        if (!options.isSkipMembers()) {
+            List<PID> contained = listContained(bxc3Resc);
+            for (PID containedPid : contained) {
+                // Determine PID to use for transformed child, in case we are generating or preserving ids.
+                PID newContainedPid = manager.getTransformedPid(containedPid);
+                oldToNewPids.put(containedPid, newContainedPid);
 
-            // Spawn and execute transformer for children
-            manager.createTransformer(containedPid, newContainedPid, newPid, resourceType)
-                   .fork();
+                // Spawn and execute transformer for children
+                manager.createTransformer(containedPid, newContainedPid, newPid, resourceType)
+                       .fork();
+            }
         }
 
         if (Cdr.Work.equals(resourceType)) {

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformerManager.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformerManager.java
@@ -44,9 +44,7 @@ public class ContentObjectTransformerManager {
 
     private PathIndex pathIndex;
     private DepositModelManager modelManager;
-    private boolean topLevelAsUnit;
-    private boolean generateIds;
-    private boolean createMissingDepositRecords;
+    private ContentTransformationOptions options;
     private RepositoryPIDMinter pidMinter;
     private DepositDirectoryManager directoryManager;
     private PremisLoggerFactory premisLoggerFactory;
@@ -75,13 +73,12 @@ public class ContentObjectTransformerManager {
                 originalPid, newPid, parentPid, parentType);
         transformer.setModelManager(modelManager);
         transformer.setPathIndex(pathIndex);
-        transformer.setTopLevelAsUnit(topLevelAsUnit);
         transformer.setManager(this);
         transformer.setPidMinter(pidMinter);
         transformer.setDirectoryManager(directoryManager);
         transformer.setPremisLoggerFactory(premisLoggerFactory);
         transformer.setRepositoryObjectFactory(repoObjFactory);
-        transformer.setCreateMissingDepositRecords(createMissingDepositRecords);
+        transformer.setOptions(options);
 
         createdTransformers.add(transformer);
         totalAdded.incrementAndGet();
@@ -113,7 +110,7 @@ public class ContentObjectTransformerManager {
     }
 
     public PID getTransformedPid(PID originalPid) {
-        return generateIds ? pidMinter.mintContentPid() : originalPid;
+        return options.isGenerateIds() ? pidMinter.mintContentPid() : originalPid;
     }
 
     public void setPathIndex(PathIndex pathIndex) {
@@ -122,10 +119,6 @@ public class ContentObjectTransformerManager {
 
     public void setModelManager(DepositModelManager modelManager) {
         this.modelManager = modelManager;
-    }
-
-    public void setTopLevelAsUnit(boolean topLevelAsUnit) {
-        this.topLevelAsUnit = topLevelAsUnit;
     }
 
     public void setPidMinter(RepositoryPIDMinter pidMinter) {
@@ -140,15 +133,11 @@ public class ContentObjectTransformerManager {
         this.premisLoggerFactory = premisLoggerFactory;
     }
 
-    public void setGenerateIds(boolean generateIds) {
-        this.generateIds = generateIds;
-    }
-
     public void setRepositoryObjectFactory(RepositoryObjectFactory repoObjFactory) {
         this.repoObjFactory = repoObjFactory;
     }
 
-    public void setCreateMissingDepositRecords(boolean createMissingDepositRecords) {
-        this.createMissingDepositRecords = createMissingDepositRecords;
+    public void setOptions(ContentTransformationOptions options) {
+        this.options = options;
     }
 }

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentTransformationOptions.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentTransformationOptions.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dcr.migration.content;
+
+import picocli.CommandLine.Option;
+
+/**
+ * Configuration options for a content transformation operation
+ *
+ * @author bbpennel
+ */
+public class ContentTransformationOptions {
+
+    @Option(names = {"-u", "--as-admin-units"},
+            description = "Top level collections will be transformed into admin units")
+    private boolean topLevelAsUnit;
+
+    @Option(names = {"--no-hash-nesting"}, negatable = true,
+            description = "Nest transformed logs in hashed subdirectories. Default: true")
+    private boolean hashNesting = true;
+
+    @Option(names = {"-g", "--generate-ids"},
+            description = "Generate new ids for transformed objects, for testing.")
+    private boolean generateIds;
+
+    @Option(names = {"-m", "--missing-deposit-records"},
+            description = "Create referenced deposit records which do not have their own bxc3 object")
+    private boolean createMissingDepositRecords;
+
+    @Option(names = {"-n", "--dry-run"},
+            description = "Perform the transformation but do not save the results")
+    private boolean dryRun;
+
+    @Option(names = {"--deposit-into"},
+            description = "Submits the transformed content for deposit to the provided container UUID")
+    private String depositInto;
+
+    public boolean isTopLevelAsUnit() {
+        return topLevelAsUnit;
+    }
+
+    public void setTopLevelAsUnit(boolean topLevelAsUnit) {
+        this.topLevelAsUnit = topLevelAsUnit;
+    }
+
+    public boolean isHashNesting() {
+        return hashNesting;
+    }
+
+    public void setHashNesting(boolean hashNesting) {
+        this.hashNesting = hashNesting;
+    }
+
+    public boolean isGenerateIds() {
+        return generateIds;
+    }
+
+    public void setGenerateIds(boolean generateIds) {
+        this.generateIds = generateIds;
+    }
+
+    public boolean isCreateMissingDepositRecords() {
+        return createMissingDepositRecords;
+    }
+
+    public void setCreateMissingDepositRecords(boolean createMissingDepositRecords) {
+        this.createMissingDepositRecords = createMissingDepositRecords;
+    }
+
+    public boolean isDryRun() {
+        return dryRun;
+    }
+
+    public void setDryRun(boolean dryRun) {
+        this.dryRun = dryRun;
+    }
+
+    public String getDepositInto() {
+        return depositInto;
+    }
+
+    public void setDepositInto(String depositInto) {
+        this.depositInto = depositInto;
+    }
+}

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentTransformationOptions.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentTransformationOptions.java
@@ -40,6 +40,10 @@ public class ContentTransformationOptions {
             description = "Create referenced deposit records which do not have their own bxc3 object")
     private boolean createMissingDepositRecords;
 
+    @Option(names = {"--skip-members"},
+            description = "Only migrate the specified object, do not migrate its members")
+    private boolean skipMembers;
+
     @Option(names = {"-n", "--dry-run"},
             description = "Perform the transformation but do not save the results")
     private boolean dryRun;
@@ -78,6 +82,14 @@ public class ContentTransformationOptions {
 
     public void setCreateMissingDepositRecords(boolean createMissingDepositRecords) {
         this.createMissingDepositRecords = createMissingDepositRecords;
+    }
+
+    public boolean isSkipMembers() {
+        return skipMembers;
+    }
+
+    public void setSkipMembers(boolean skipMembers) {
+        this.skipMembers = skipMembers;
     }
 
     public boolean isDryRun() {

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentTransformationService.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentTransformationService.java
@@ -35,7 +35,7 @@ public class ContentTransformationService {
     private ContentObjectTransformerManager transformerManager;
     private DepositModelManager modelManager;
 
-    public ContentTransformationService(PID depositPid, String startingId, boolean topLevelAsUnit) {
+    public ContentTransformationService(PID depositPid, String startingId) {
         this.startingPid = PIDs.get(startingId);
         this.depositPid = depositPid;
     }

--- a/migration-util/src/test/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformerTest.java
+++ b/migration-util/src/test/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformerTest.java
@@ -135,6 +135,8 @@ public class ContentObjectTransformerTest {
 
     private PremisLoggerFactory premisLoggerFactory;
 
+    private ContentTransformationOptions options;
+
     @Mock
     private PathIndex pathIndex;
 
@@ -160,15 +162,18 @@ public class ContentObjectTransformerTest {
         premisLoggerFactory = new PremisLoggerFactory();
         premisLoggerFactory.setPidMinter(pidMinter);
 
+        options = new ContentTransformationOptions();
+        options.setTopLevelAsUnit(true);
+
         manager = new ContentObjectTransformerManager();
         manager.setPathIndex(pathIndex);
         manager.setModelManager(modelManager);
         manager.setPidMinter(pidMinter);
-        manager.setTopLevelAsUnit(true);
+        manager.setOptions(options);
         manager.setDirectoryManager(directoryManager);
         manager.setPremisLoggerFactory(premisLoggerFactory);
 
-        service = new ContentTransformationService(depositPid, startingPid.getId(), true);
+        service = new ContentTransformationService(depositPid, startingPid.getId());
         service.setModelManager(modelManager);
         service.setTransformerManager(manager);
     }
@@ -253,7 +258,7 @@ public class ContentObjectTransformerTest {
     @Test
     public void transformFolderWithChildGenerateIds() throws Exception {
         // Enable id generation
-        manager.setGenerateIds(true);
+        options.setGenerateIds(true);
 
         // Create the children objects' foxml
         PID child1Pid = makePid();
@@ -508,7 +513,7 @@ public class ContentObjectTransformerTest {
 
     @Test
     public void transformWorkWithFileWithGeneratedIds() throws Exception {
-        manager.setGenerateIds(true);
+        options.setGenerateIds(true);
 
         PID child1Pid = makePid();
         Document foxml1 = new FoxmlDocumentBuilder(child1Pid, "file1")
@@ -738,7 +743,7 @@ public class ContentObjectTransformerTest {
 
     @Test
     public void transformCollectionAtTopWithFlagFalse() throws Exception {
-        manager.setTopLevelAsUnit(false);
+        options.setTopLevelAsUnit(false);
 
         Model model = createContainerModel(startingPid, ContentModel.COLLECTION);
         addStaffRoles(model, startingPid);


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2765

* To support migrating units without their contents, adds a `--skip-members` option for the migrate content command which causes just the specified object to be migrated without its children
* Refactors the content transformation options into an object to pass around rather than separate setters per option, since there was getting to be a lot of them.
* Removes an unused parameter