### PR TITLE
BXC-2761 - Fix XML import emails and leftover files

### DIFF
--- a/access/src/main/webapp/WEB-INF/service-context.xml
+++ b/access/src/main/webapp/WEB-INF/service-context.xml
@@ -119,5 +119,6 @@
     
     <bean name="spoofShibbolethFilter" class="edu.unc.lib.dl.acl.filter.SpoofShibbolethFilter">
         <property name="spoofEnabled" value="${spoofing.enabled:false}" />
+        <property name="spoofEmailSuffix" value="${spoofing.emailSuffix:@localhost}" />
     </bean>
 </beans>

--- a/admin/src/main/webapp/WEB-INF/service-context.xml
+++ b/admin/src/main/webapp/WEB-INF/service-context.xml
@@ -109,6 +109,7 @@
     
     <bean name="spoofShibbolethFilter" class="edu.unc.lib.dl.acl.filter.SpoofShibbolethFilter">
         <property name="spoofEnabled" value="${spoofing.enabled:false}" />
+        <property name="spoofEmailSuffix" value="${spoofing.emailSuffix:@localhost}" />
     </bean>
     
     

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/importxml/ImportXMLJob.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/importxml/ImportXMLJob.java
@@ -352,7 +352,8 @@ public class ImportXMLJob implements Runnable {
                                 xmlWriter = null;
                                 InputStream modsStream = new ByteArrayInputStream(contentWriter.toString().getBytes());
                                 try {
-                                    log.debug("Ending MODS tag for {}, preparing to update description", currentPid.getQualifiedId());
+                                    log.debug("Ending MODS tag for {}, preparing to update description",
+                                            currentPid.getQualifiedId());
                                     BinaryTransferSession transferSession =
                                             session.forDestination(locationManager.getStorageLocation(currentPid));
                                     updateService.updateDescription(transferSession, agent, currentPid, modsStream);

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/importxml/ImportXMLJob.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/importxml/ImportXMLJob.java
@@ -268,6 +268,7 @@ public class ImportXMLJob implements Runnable {
                             StartElement element = e.asStartElement();
                             // Make sure that this document begins with bulk md tag
                             if (element.getName().getLocalPart().equals(BULK_MD_TAG)) {
+                                log.debug("Starting bulk metadata import document");
                                 state = DocumentState.IN_BULK;
                             } else {
                                 throw new ServiceException("Submitted document is not a bulk-metadata-update doc");
@@ -283,6 +284,7 @@ public class ImportXMLJob implements Runnable {
 
                                 if (pid != null) {
                                     currentPid = PIDs.get(pid.getValue());
+                                    log.debug("Starting element for object {}", currentPid.getQualifiedId());
                                     objectCount++;
                                     state = DocumentState.IN_OBJECT;
                                 } else {
@@ -304,6 +306,7 @@ public class ImportXMLJob implements Runnable {
                                 }
                                 if (MODS_TYPE.equals(typeAttr.getValue())) {
                                     currentDs = MODS_TYPE;
+                                    log.debug("Starting MODS element for object {}", currentPid.getQualifiedId());
                                 } else {
                                     failed.put(currentPid.getRepositoryPath(),
                                             "Invalid import data, unsupported type in update tag");
@@ -349,6 +352,7 @@ public class ImportXMLJob implements Runnable {
                                 xmlWriter = null;
                                 InputStream modsStream = new ByteArrayInputStream(contentWriter.toString().getBytes());
                                 try {
+                                    log.debug("Ending MODS tag for {}, preparing to update description", currentPid.getQualifiedId());
                                     BinaryTransferSession transferSession =
                                             session.forDestination(locationManager.getStorageLocation(currentPid));
                                     updateService.updateDescription(transferSession, agent, currentPid, modsStream);

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/importxml/ImportXMLJobTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/importxml/ImportXMLJobTest.java
@@ -172,7 +172,8 @@ public class ImportXMLJobTest {
         assertEquals(1, dataMap.get("problemCount"));
         Set<Entry<String, String>> problems = (Set<Entry<String, String>>) dataMap.get("problems");
         Entry<String, String> problem = problems.iterator().next();
-        assertEquals("Import file could not be found on the server", problem.getValue());
+        assertTrue("Failure message did not match excepted value, was: " + problem.getValue(),
+                problem.getValue().contains("Failed to read import file"));
 
         verify(msg).setSubject(subjectCaptor.capture());
         assertEquals("DCR Metadata update failed", subjectCaptor.getValue());

--- a/security/src/main/java/edu/unc/lib/dl/acl/filter/SpoofShibbolethFilter.java
+++ b/security/src/main/java/edu/unc/lib/dl/acl/filter/SpoofShibbolethFilter.java
@@ -30,7 +30,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 /**
  * Filter which enables shibboleth header spoofing for testing purposes
- * 
+ *
  * @author bbpennel
  *
  */
@@ -38,6 +38,7 @@ public class SpoofShibbolethFilter extends OncePerRequestFilter implements Servl
     private static final Logger log = LoggerFactory.getLogger(SpoofShibbolethFilter.class);
 
     private boolean spoofEnabled = false;
+    private String spoofEmailSuffix = "@localhost";
 
     @PostConstruct
     public void init() {
@@ -50,7 +51,7 @@ public class SpoofShibbolethFilter extends OncePerRequestFilter implements Servl
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
         if (spoofEnabled) {
-            filterChain.doFilter(new SpoofShibbolethRequestWrapper(request), response);
+            filterChain.doFilter(new SpoofShibbolethRequestWrapper(request, spoofEmailSuffix), response);
         } else {
             filterChain.doFilter(request, response);
         }
@@ -62,5 +63,9 @@ public class SpoofShibbolethFilter extends OncePerRequestFilter implements Servl
 
     public void setSpoofEnabled(boolean spoofEnabled) {
         this.spoofEnabled = spoofEnabled;
+    }
+
+    public void setSpoofEmailSuffix(String spoofEmailSuffix) {
+        this.spoofEmailSuffix = spoofEmailSuffix;
     }
 }

--- a/security/src/main/java/edu/unc/lib/dl/acl/filter/SpoofShibbolethRequestWrapper.java
+++ b/security/src/main/java/edu/unc/lib/dl/acl/filter/SpoofShibbolethRequestWrapper.java
@@ -44,13 +44,15 @@ public class SpoofShibbolethRequestWrapper extends HttpServletRequestWrapper {
 
     private final static String SPOOF_COOKIE_PREFIX = "AUTHENTICATION_SPOOFING-";
 
+    private String spoofEmailSuffix;
     private HashMap<String, String> values;
 
     private HttpServletRequest request;
 
-    public SpoofShibbolethRequestWrapper(HttpServletRequest request) throws IOException {
+    public SpoofShibbolethRequestWrapper(HttpServletRequest request, String spoofEmailSuffix) throws IOException {
         super(request);
         this.request = request;
+        this.spoofEmailSuffix = spoofEmailSuffix;
 
         extractSpoofValues();
     }
@@ -67,6 +69,9 @@ public class SpoofShibbolethRequestWrapper extends HttpServletRequestWrapper {
                     String value = URLDecoder.decode(c.getValue(), "UTF-8");
                     values.put(key, value);
                 }
+            }
+            if (request.getRemoteUser() == null && values.containsKey(REMOTE_USER)) {
+                values.put("mail", values.get(REMOTE_USER) + spoofEmailSuffix);
             }
         }
     }

--- a/services/src/main/webapp/WEB-INF/service-context.xml
+++ b/services/src/main/webapp/WEB-INF/service-context.xml
@@ -195,6 +195,7 @@
     
     <bean name="spoofShibbolethFilter" class="edu.unc.lib.dl.acl.filter.SpoofShibbolethFilter">
         <property name="spoofEnabled" value="${spoofing.enabled:false}" />
+        <property name="spoofEmailSuffix" value="${spoofing.emailSuffix:@localhost}" />
     </bean>
     
     <bean id="gaTrackingID" class="java.lang.String">


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2761

* Sets up spoofed email address header so that services can send emails when shibboleth is not being used
* Ensures that file inputstream gets closed, to avoid issues where leftover file handles linger after the xml import files are deleted
* Adds debug logging to xml import jobs