### PR TITLE
BXC-2773/2774 - Fix Flapping tests

### DIFF
--- a/fcrepo-clients/src/test/resources/logback-test.xml
+++ b/fcrepo-clients/src/test/resources/logback-test.xml
@@ -7,6 +7,7 @@
     </encoder>
   </appender>
   <logger name="ch.qos.logback" level="ERROR"/>
+  <logger name="org.fcrepo" level="ERROR"/>
   <root level="WARN">
     <appender-ref ref="CONSOLE"/>
   </root>

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/enhancements/EnhancementRouterIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/enhancements/EnhancementRouterIT.java
@@ -29,6 +29,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -93,6 +94,8 @@ import edu.unc.lib.dl.test.TestHelper;
 public class EnhancementRouterIT {
 
     private final static String FILE_CONTENT = "content";
+
+    private final static long ALLOW_WAIT = 5000;
 
     @Autowired
     private String baseAddress;
@@ -180,17 +183,10 @@ public class EnhancementRouterIT {
                 Cdr.Collection.getURI(), Container.getURI());
         template.sendBodyAndHeaders("", headers);
 
-        NotifyBuilder notify1 = new NotifyBuilder(cdrEnhancements)
-                .whenCompleted(7)
-                .create();
-
-        boolean result1 = notify1.matches(5l, TimeUnit.SECONDS);
-        assertTrue("Enhancement route not satisfied", result1);
-
-        verify(addSmallThumbnailProcessor).process(any(Exchange.class));
-        verify(addLargeThumbnailProcessor).process(any(Exchange.class));
+        verify(addSmallThumbnailProcessor, timeout(ALLOW_WAIT)).process(any(Exchange.class));
+        verify(addLargeThumbnailProcessor, timeout(ALLOW_WAIT)).process(any(Exchange.class));
         verify(addAccessCopyProcessor, never()).process(any(Exchange.class));
-        verify(solrIngestProcessor).process(any(Exchange.class));
+        verify(solrIngestProcessor, timeout(ALLOW_WAIT)).process(any(Exchange.class));
     }
 
     @Test
@@ -200,16 +196,9 @@ public class EnhancementRouterIT {
                 Cdr.Collection.getURI(), Container.getURI());
         template.sendBodyAndHeaders("", headers);
 
-        NotifyBuilder notify1 = new NotifyBuilder(cdrEnhancements)
-                .whenCompleted(2)
-                .create();
-
-        boolean result1 = notify1.matches(5l, TimeUnit.SECONDS);
-        assertTrue("Enhancement route not satisfied", result1);
-
+        verify(solrIngestProcessor, timeout(ALLOW_WAIT)).process(any(Exchange.class));
         verify(addSmallThumbnailProcessor, never()).process(any(Exchange.class));
         verify(addLargeThumbnailProcessor, never()).process(any(Exchange.class));
-        verify(solrIngestProcessor).process(any(Exchange.class));
     }
 
     @Test
@@ -231,12 +220,12 @@ public class EnhancementRouterIT {
         boolean result1 = notify1.matches(5l, TimeUnit.SECONDS);
         assertTrue("Enhancement route not satisfied", result1);
 
-        verify(addSmallThumbnailProcessor).process(any(Exchange.class));
-        verify(addLargeThumbnailProcessor).process(any(Exchange.class));
-        verify(addAccessCopyProcessor).process(any(Exchange.class));
+        verify(addSmallThumbnailProcessor, timeout(ALLOW_WAIT)).process(any(Exchange.class));
+        verify(addLargeThumbnailProcessor, timeout(ALLOW_WAIT)).process(any(Exchange.class));
+        verify(addAccessCopyProcessor, timeout(ALLOW_WAIT)).process(any(Exchange.class));
         // Indexing triggered for binary parent
-        verify(solrIngestProcessor).process(any(Exchange.class));
-        verify(registerLongleafProcessor).process(any(Exchange.class));
+        verify(solrIngestProcessor, timeout(ALLOW_WAIT)).process(any(Exchange.class));
+        verify(registerLongleafProcessor, timeout(ALLOW_WAIT)).process(any(Exchange.class));
     }
 
     @Test

--- a/services-camel/src/test/resources/enhancement-router-it-context.xml
+++ b/services-camel/src/test/resources/enhancement-router-it-context.xml
@@ -78,6 +78,12 @@
         <property name="connectionFactory" ref="jmsFactory" />
     </bean>
     
+    <!-- Force the camel context to shutdown before activemq broker -->
+    <bean id="camelShutdownHook" class="org.apache.activemq.camel.CamelShutdownHook">
+        <constructor-arg ref="activemqBroker" />
+        <property name="camelContext" ref="cdrEnhancements" />
+    </bean>
+    
     <camel:camelContext id="cdrLongleaf">
         <camel:package>edu.unc.lib.dl.services.camel.longleaf</camel:package>
     </camel:camelContext>

--- a/services-camel/src/test/resources/logback-test.xml
+++ b/services-camel/src/test/resources/logback-test.xml
@@ -8,6 +8,7 @@
   </appender>
   <logger name="org.apache.camel" level="ERROR"/>
   <logger name="org.apache.activemq" level="ERROR"/>
+  <logger name="org.fcrepo" level="ERROR"/>
   <root level="WARN">
     <appender-ref ref="CONSOLE"/>
   </root>

--- a/services-camel/src/test/resources/spring-test/jms-context.xml
+++ b/services-camel/src/test/resources/spring-test/jms-context.xml
@@ -39,7 +39,7 @@
     <amq:connectionFactory id="jmsFactory"
         brokerURL="vm://localhost" />
 
-    <amq:broker useJmx="false" persistent="false" useShutdownHook="true">
+    <amq:broker id="activemqBroker" useJmx="false" persistent="false" useShutdownHook="true">
         <amq:transportConnectors>
             <amq:transportConnector uri="vm://localhost:61616" />
         </amq:transportConnectors>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2773
https://jira.lib.unc.edu/browse/BXC-2774

* Fixes three flapping tests
* Reduces log spam a little by tuning fedora logging to error (for frequent property namespace error) and by controlling activemq broker/camel context shutdown order for one of the tests.