### PR TITLE
BXC-2756 - Exclude logback-test.xml from test-jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -436,6 +436,9 @@
                             <Class-Path>.</Class-Path>
                         </manifestEntries>
                     </archive>
+                    <excludes>
+                        <exclude>logback-test.xml</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2756

* This should resolve the `Resource [logback-test.xml] occurs multiple times on the classpath.` style messages being logged for every test, but only when running tests via maven or travis