### PR TITLE
BXC-2690 - Longleaf recovery

### DIFF
--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/AddFailedRouteProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/AddFailedRouteProcessor.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.services.camel;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+
+/**
+ * Processor which adds info about what route failed to an exchange
+ *
+ * @author bbpennel
+ */
+public class AddFailedRouteProcessor implements Processor {
+
+    @Override
+    public void process(Exchange exchange) throws Exception {
+        String originalEndpoint = exchange.getFromEndpoint().getEndpointUri();
+        exchange.getIn().setHeader(Exchange.FAILURE_ROUTE_ID, originalEndpoint);
+    }
+}

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/longleaf/DeregisterLongleafProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/longleaf/DeregisterLongleafProcessor.java
@@ -80,6 +80,11 @@ public class DeregisterLongleafProcessor extends AbstractLongleafProcessor {
                         .map(c -> Paths.get(c).toUri().toString())
                         .forEach(messages::remove);
                 }
+                if (messages.isEmpty()) {
+                    log.error("Result from longleaf indicates deregistration failed, but there are "
+                            + "no failed URIs remaining. See longleaf logs for details.");
+                    return;
+                }
                 throw new ServiceException("Failed to deregister " + entryCount + " entries in Longleaf.  "
                         + "Check longleaf logs, command returned: " + result.exitVal);
             }

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/longleaf/LongleafAggregationStrategy.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/longleaf/LongleafAggregationStrategy.java
@@ -15,9 +15,11 @@
  */
 package edu.unc.lib.dl.services.camel.longleaf;
 
+import static java.util.Collections.singletonList;
 import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.camel.Exchange;
@@ -37,24 +39,29 @@ public class LongleafAggregationStrategy implements AggregationStrategy {
     @Override
     public Exchange aggregate(Exchange oldExchange, Exchange newExchange) {
         String binaryUri = (String) newExchange.getIn().getHeader(FCREPO_URI);
+        List<String> incomingList ;
         if (binaryUri == null) {
             Object body = newExchange.getIn().getBody();
             if (body instanceof String) {
-                binaryUri = (String) body;
+                incomingList = singletonList((String) body);
+            } else if (body instanceof List) {
+                incomingList = (List<String>) body;
             } else {
                 log.error("Received unexpected message of type {}, ignoring", body.getClass().getName());
                 return oldExchange;
             }
+        } else {
+            incomingList = Collections.singletonList(binaryUri);
         }
 
         if (oldExchange == null) {
             List<String> list = new ArrayList<>();
-            list.add(binaryUri);
+            list.addAll(incomingList);
             newExchange.getIn().setBody(list);
             return newExchange;
         } else {
             List<String> list = oldExchange.getIn().getBody(List.class);
-            list.add(binaryUri);
+            list.addAll(incomingList);
             return oldExchange;
         }
     }

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/longleaf/LongleafRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/longleaf/LongleafRouter.java
@@ -20,6 +20,8 @@ import org.apache.camel.LoggingLevel;
 import org.apache.camel.builder.RouteBuilder;
 import org.springframework.beans.factory.annotation.Value;
 
+import edu.unc.lib.dl.services.camel.AddFailedRouteProcessor;
+
 /**
  * Router for longleaf operations
  *
@@ -41,10 +43,12 @@ public class LongleafRouter extends RouteBuilder {
 
     @Override
     public void configure() throws Exception {
+        AddFailedRouteProcessor failedRouteProcessor = new AddFailedRouteProcessor();
+
         errorHandler(deadLetterChannel("{{longleaf.dlq.dest}}")
                 .maximumRedeliveries(longleafMaxRedelivieries)
                 .redeliveryDelay(longleafRedeliveryDelay)
-                .retryAttemptedLogLevel(LoggingLevel.ERROR));
+                .onPrepareFailure(failedRouteProcessor));
 
         from("direct-vm:filter.longleaf")
             .routeId("RegisterLongleafQueuing")

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/longleaf/RegisterToLongleafProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/longleaf/RegisterToLongleafProcessor.java
@@ -195,6 +195,11 @@ public class RegisterToLongleafProcessor extends AbstractLongleafProcessor {
                     .filter(fcrepoUri -> fcrepoUri != null)
                     .forEach(messages::remove);
             }
+            if (messages.isEmpty()) {
+                log.error("Result from longleaf indicates registration failed, but there are "
+                        + "no failed URIs remaining. See longleaf logs for details.");
+                return;
+            }
             throw new ServiceException("Failed to register " + entryCount + " entries to Longleaf.  "
                     + "Check longleaf logs, command returned: " + result.exitVal);
         }

--- a/services-camel/src/main/webapp/WEB-INF/activemq-context.xml
+++ b/services-camel/src/main/webapp/WEB-INF/activemq-context.xml
@@ -18,16 +18,21 @@
         <property name="brokerURL" value="${jms.brokerUrl}" />
         <property name="userName" value="${jms.username}" />
         <property name="password" value="${jms.password}" />
+        <property name="trustedPackages">
+            <util:list>
+                <value>java.util</value>
+            </util:list>
+        </property>
     </bean>
 
-    <bean id="pooledConnectionFactory" class="org.apache.activemq.pool.PooledConnectionFactory"
+    <bean id="pooledAmqConnectionFactory" class="org.apache.activemq.pool.PooledConnectionFactory"
         init-method="start" destroy-method="stop">
         <property name="maxConnections" value="${jms.connections}" />
         <property name="connectionFactory" ref="connectionFactory" />
     </bean>
 
     <bean id="jmsConfig" class="org.apache.camel.component.jms.JmsConfiguration">
-        <property name="connectionFactory" ref="pooledConnectionFactory" />
+        <property name="connectionFactory" ref="pooledAmqConnectionFactory" />
         <property name="concurrentConsumers" value="${jms.consumers}" />
     </bean>
 
@@ -38,16 +43,16 @@
     </bean>
     
     <bean class="org.springframework.jms.core.JmsTemplate">
-        <property name="connectionFactory" ref="pooledConnectionFactory" />
+        <property name="connectionFactory" ref="pooledAmqConnectionFactory" />
         <property name="defaultDestinationName" value="repository.updates" />
         <property name="pubSubDomain" value="true" />
     </bean>
     
     <bean id="sjms" class="org.apache.camel.component.sjms.SjmsComponent">
-        <property name="connectionFactory" ref="pooledConnectionFactory" />
+        <property name="connectionFactory" ref="pooledAmqConnectionFactory" />
     </bean>
     
     <bean id="sjms-batch" class="org.apache.camel.component.sjms.batch.SjmsBatchComponent">
-        <property name="connectionFactory" ref="pooledConnectionFactory" />
+        <property name="connectionFactory" ref="pooledAmqConnectionFactory" />
     </bean>
 </beans>

--- a/services-camel/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel/src/main/webapp/WEB-INF/service-context.xml
@@ -151,24 +151,14 @@
     </bean>
     
     <!-- JMS messaging -->
-    <bean id="jmsFactory" class="org.apache.activemq.pool.PooledConnectionFactory" destroy-method="stop">
-        <property name="connectionFactory">
-            <bean class="org.apache.activemq.ActiveMQConnectionFactory">
-                <property name="brokerURL"> 
-                    <value>${jms.brokerUrl}</value>
-                </property>
-            </bean>
-        </property>
-    </bean>
-    
     <bean id="jmsTemplate" class="org.springframework.jms.core.JmsTemplate">
-        <property name="connectionFactory" ref="jmsFactory" />
+        <property name="connectionFactory" ref="pooledAmqConnectionFactory" />
         <property name="defaultDestinationName" value="${cdr.stream}" />
         <property name="pubSubDomain" value="false" />
     </bean>
 
     <bean id="solrUpdateJmsTemplate" class="org.springframework.jms.core.JmsTemplate">
-        <property name="connectionFactory" ref="jmsFactory" />
+        <property name="connectionFactory" ref="pooledAmqConnectionFactory" />
         <property name="defaultDestinationName" value="${cdr.solrupdate.stream}" />
         <property name="pubSubDomain" value="false" />
     </bean>
@@ -365,7 +355,7 @@
     </bean>
     
     <bean id="binaryDestroyedJmsTemplate" class="org.springframework.jms.core.JmsTemplate">
-        <property name="connectionFactory" ref="jmsFactory" />
+        <property name="connectionFactory" ref="pooledAmqConnectionFactory" />
         <property name="defaultDestinationName" value="activemq:queue:filter.longleaf.deregister" />
         <property name="pubSubDomain" value="false" />
     </bean>

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/AbstractLongleafRouteTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/AbstractLongleafRouteTest.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.services.camel.longleaf;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.net.URI;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.slf4j.Logger;
+
+/**
+ * @author bbpennel
+ */
+public abstract class AbstractLongleafRouteTest {
+    private static final Logger log = getLogger(AbstractLongleafRouteTest.class);
+
+    protected String outputPath;
+    protected List<String> output;
+
+    /**
+     * Assert that all of the provided content uris are present in the longleaf output
+     * @param timeout time in milliseconds allowed for the condition to become true,
+     *      to accommodate asynchronous unpredictable batch cutoffs
+     * @param contentUris list of expected content uris
+     * @throws Exception
+     */
+    protected void assertSubmittedPaths(long timeout, String... contentUris) throws Exception {
+        long start = System.currentTimeMillis();
+        do {
+            try {
+                output = LongleafTestHelpers.readOutput(outputPath);
+                assertSubmittedPaths(contentUris);
+                return;
+            } catch (AssertionError e) {
+                if ((System.currentTimeMillis() - start) > timeout) {
+                    throw e;
+                }
+                Thread.sleep(25);
+                log.debug("DeregisterPaths not yet satisfied, retrying");
+            }
+        } while (true);
+    }
+
+    protected void assertSubmittedPaths(String... contentUris) {
+        for (String contentUri : contentUris) {
+            URI uri = URI.create(contentUri);
+            String contentPath = Paths.get(uri).toString();
+            assertTrue("Expected content uri to be submitted: " + contentPath,
+                    output.stream().anyMatch(line -> line.contains(contentPath)));
+        }
+    }
+
+    protected void assertNoSubmittedPaths() throws Exception {
+        output = LongleafTestHelpers.readOutput(outputPath);
+        assertEquals("Expected no calls to longleaf, but received output:\n" + String.join("\n", output),
+                0, output.size());
+    }
+}

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/LongleafTestHelpers.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/LongleafTestHelpers.java
@@ -23,10 +23,12 @@ import java.nio.file.Files;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Helpers for longleaf tests
@@ -55,7 +57,7 @@ public class LongleafTestHelpers {
 
         longleafScript.deleteOnExit();
 
-        Set<PosixFilePermission> ownerExecutable = PosixFilePermissions.fromString("r-x------");
+        Set<PosixFilePermission> ownerExecutable = PosixFilePermissions.fromString("rwx------");
         Files.setPosixFilePermissions(longleafScript.toPath(), ownerExecutable);
 
         return longleafScript.getAbsolutePath();
@@ -63,6 +65,9 @@ public class LongleafTestHelpers {
 
     public static List<String> readOutput(String outputPath) throws IOException {
         String outputText = FileUtils.readFileToString(new File(outputPath), UTF_8);
+        if (StringUtils.isEmpty(outputText)) {
+            return Collections.emptyList();
+        }
         return Arrays.asList(outputText.split("\n"));
     }
 }

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/RegisterLongleafRouteTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/RegisterLongleafRouteTest.java
@@ -1,0 +1,242 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.services.camel.longleaf;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.net.URI;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Exchange;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.spring.CamelSpringRunner;
+import org.apache.camel.test.spring.CamelTestContextBootstrapper;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.io.FileUtils;
+import org.fusesource.hawtbuf.ByteArrayInputStream;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.BootstrapWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+
+import edu.unc.lib.dl.fcrepo4.BinaryObject;
+import edu.unc.lib.dl.fcrepo4.FileObject;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.model.DatastreamPids;
+import edu.unc.lib.dl.persist.api.storage.StorageLocation;
+import edu.unc.lib.dl.persist.api.storage.StorageLocationManager;
+import edu.unc.lib.dl.persist.api.transfer.BinaryTransferService;
+import edu.unc.lib.dl.persist.api.transfer.BinaryTransferSession;
+import edu.unc.lib.dl.test.TestHelper;
+
+/**
+ * @author bbpennel
+ */
+@RunWith(CamelSpringRunner.class)
+@BootstrapWith(CamelTestContextBootstrapper.class)
+@ContextHierarchy({
+    @ContextConfiguration("/spring-test/test-fedora-container.xml"),
+    @ContextConfiguration("/spring-test/cdr-client-container.xml"),
+    @ContextConfiguration("/spring-test/jms-context.xml"),
+    @ContextConfiguration("/register-longleaf-router-context.xml")
+})
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
+public class RegisterLongleafRouteTest extends AbstractLongleafRouteTest {
+    private static final String TEXT1_BODY = "Some content";
+    private static final String TEXT1_SHA1 = DigestUtils.sha1Hex(TEXT1_BODY);
+
+    @Produce(uri = "direct-vm:filter.longleaf")
+    private ProducerTemplate template;
+
+    @EndpointInject(uri = "mock:direct:longleaf.dlq")
+    private MockEndpoint mockDlq;
+
+    @Rule
+    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+    @Autowired
+    private String baseAddress;
+    @Autowired
+    private CamelContext cdrLongleaf;
+
+    @Autowired
+    private RepositoryObjectFactory repoObjFactory;
+
+    @Autowired
+    private StorageLocationManager locManager;
+    @Autowired
+    private BinaryTransferService transferService;
+    private BinaryTransferSession transferSession;
+    @Autowired
+    private RegisterToLongleafProcessor processor;
+
+    private String longleafScript;
+
+    @Before
+    public void init() throws Exception {
+        TestHelper.setContentBase(baseAddress);
+        tmpFolder.create();
+
+        outputPath = tmpFolder.newFile().getPath();
+        output = null;
+        longleafScript = LongleafTestHelpers.getLongleafScript(outputPath);
+        processor.setLongleafBaseCommand(longleafScript);
+
+        StorageLocation loc = locManager.getStorageLocationById("loc1");
+        transferSession = transferService.getSession(loc);
+    }
+
+    @Test
+    public void registerSingleFileWithSha1() throws Exception {
+        mockDlq.expectedMessageCount(0);
+
+        FileObject fileObj = repoObjFactory.createFileObject(null);
+        BinaryObject origBin = createOriginalBinary(fileObj, TEXT1_BODY, TEXT1_SHA1, null);
+        URI contentUri = origBin.getContentUri();
+
+        NotifyBuilder notify = new NotifyBuilder(cdrLongleaf)
+                .whenCompleted(2)
+                .create();
+
+        template.sendBodyAndHeaders("", createEvent(origBin.getPid()));
+
+        boolean result1 = notify.matches(5l, TimeUnit.SECONDS);
+        assertTrue("Register route not satisfied", result1);
+
+        mockDlq.assertIsSatisfied();
+
+        assertSubmittedPaths(2000, contentUri.toString());
+    }
+
+    @Test
+    public void registerBinaryNotFound() throws Exception {
+        mockDlq.expectedMessageCount(0);
+
+        FileObject fileObj = repoObjFactory.createFileObject(null);
+        PID binPid = DatastreamPids.getOriginalFilePid(fileObj.getPid());
+
+        NotifyBuilder notify = new NotifyBuilder(cdrLongleaf)
+                .whenCompleted(2)
+                .create();
+
+        template.sendBodyAndHeaders("", createEvent(binPid));
+
+        boolean result1 = notify.matches(5l, TimeUnit.SECONDS);
+        assertTrue("Register route not satisfied", result1);
+
+        mockDlq.assertIsSatisfied();
+
+        assertNoSubmittedPaths();
+    }
+
+    @Test
+    public void registerExecuteFails() throws Exception {
+        mockDlq.expectedMessageCount(1);
+
+        FileUtils.writeStringToFile(new File(longleafScript), "exit 1", UTF_8);
+
+        FileObject fileObj = repoObjFactory.createFileObject(null);
+        BinaryObject origBin = createOriginalBinary(fileObj, TEXT1_BODY, TEXT1_SHA1, null);
+
+        NotifyBuilder notify = new NotifyBuilder(cdrLongleaf)
+                .whenDone(2)
+                .create();
+
+        template.sendBodyAndHeaders("", createEvent(origBin.getPid()));
+
+        boolean result1 = notify.matches(5l, TimeUnit.SECONDS);
+        assertTrue("Register route not satisfied", result1);
+
+        mockDlq.assertIsSatisfied(1000);
+
+        assertNoSubmittedPaths();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void registerPartiallySucceeds() throws Exception {
+        mockDlq.expectedMessageCount(1);
+
+        FileObject fileObj1 = repoObjFactory.createFileObject(null);
+        BinaryObject origBin1 = createOriginalBinary(fileObj1, TEXT1_BODY, TEXT1_SHA1, null);
+        URI contentUri1 = origBin1.getContentUri();
+        FileObject fileObj2 = repoObjFactory.createFileObject(null);
+        BinaryObject origBin2 = createOriginalBinary(fileObj2, TEXT1_BODY, TEXT1_SHA1, null);
+        URI contentUri2 = origBin2.getContentUri();
+
+        // Append to existing script
+        FileUtils.writeStringToFile(new File(longleafScript),
+                "\necho \"SUCCESS register " + Paths.get(contentUri1).toString() + "\"" +
+                "\necho \"FAILURE register " + Paths.get(contentUri2).toString() + " bad stuff\"" +
+                "\nexit 2",
+                UTF_8, true);
+
+        NotifyBuilder notify = new NotifyBuilder(cdrLongleaf)
+                .whenDone(2)
+                .create();
+
+        template.sendBodyAndHeaders("", createEvent(origBin1.getPid()));
+        template.sendBodyAndHeaders("", createEvent(origBin2.getPid()));
+
+        boolean result1 = notify.matches(5l, TimeUnit.SECONDS);
+        assertTrue("Register route not satisfied", result1);
+
+        assertSubmittedPaths(2000, contentUri1.toString(), contentUri2.toString());
+
+        mockDlq.assertIsSatisfied(1000);
+        List<Exchange> dlqExchanges = mockDlq.getExchanges();
+
+        Exchange failed = dlqExchanges.get(0);
+        List<String> failedList = failed.getIn().getBody(List.class);
+        assertEquals("Only one uri should be in the failed message body", 1, failedList.size());
+        assertTrue("Exchange in DLQ must contain the fcrepo uri of the failed binary",
+                failedList.contains(origBin2.getPid().getRepositoryPath()));
+
+    }
+
+    private BinaryObject createOriginalBinary(FileObject fileObj, String content, String sha1, String md5) {
+        PID originalPid = DatastreamPids.getOriginalFilePid(fileObj.getPid());
+        URI storageUri = transferSession.transfer(originalPid, new ByteArrayInputStream(content.getBytes(UTF_8)));
+        return fileObj.addOriginalFile(storageUri, "original.txt", "plain/text", sha1, md5);
+    }
+
+    private static Map<String, Object> createEvent(PID pid) {
+        final Map<String, Object> headers = new HashMap<>();
+        headers.put(FCREPO_URI, pid.getRepositoryPath());
+
+        return headers;
+    }
+}

--- a/services-camel/src/test/resources/deregister-longleaf-router-config.properties
+++ b/services-camel/src/test/resources/deregister-longleaf-router-config.properties
@@ -1,3 +1,0 @@
-longleaf.register.consumers=1
-longleaf.register.completionTimeout=100
-longleaf.register.completionSize=5

--- a/services-camel/src/test/resources/enhancement-router-it-config.properties
+++ b/services-camel/src/test/resources/enhancement-router-it-config.properties
@@ -76,6 +76,13 @@ conductor.solr.beforeExecuteDelay=50
 conductor.solr.beforeUpdateDelay=0
 conductor.solr.recoverableDelay=30000
 
-longleaf.register.consumers=1
-longleaf.register.completionTimeout=1000
-longleaf.register.completionSize=1
+longleaf.register.dest=sjms:register.longleaf?transacted=true
+longleaf.register.consumer=sjms-batch:register.longleaf?completionTimeout=100&completionSize=1&consumerCount=1&aggregationStrategy=#longleafAggregationStrategy&connectionFactory=jmsFactory
+
+longleaf.deregister.dest=sjms:deregister.longleaf?transacted=true
+longleaf.deregister.consumer=sjms-batch:deregister.longleaf?completionTimeout=100&completionSize=1&consumerCount=1&aggregationStrategy=#longleafAggregationStrategy&connectionFactory=jmsFactory
+
+longleaf.dlq.dest=activemq:queue:longleaf.dlq
+
+longleaf.maxRedelivieries=2
+longleaf.redeliveryDelay=100

--- a/services-camel/src/test/resources/longleaf-router-config.properties
+++ b/services-camel/src/test/resources/longleaf-router-config.properties
@@ -1,0 +1,10 @@
+longleaf.register.dest=sjms:register.longleaf?transacted=true
+longleaf.register.consumer=sjms-batch:register.longleaf?completionTimeout=100&completionSize=5&consumerCount=1&aggregationStrategy=#longleafAggregationStrategy&connectionFactory=jmsFactory
+
+longleaf.deregister.dest=sjms:deregister.longleaf?transacted=true
+longleaf.deregister.consumer=sjms-batch:deregister.longleaf?completionTimeout=100&completionSize=5&consumerCount=1&aggregationStrategy=#longleafAggregationStrategy&connectionFactory=jmsFactory
+
+longleaf.dlq.dest=mock:direct:longleaf.dlq
+
+longleaf.maxRedelivieries=2
+longleaf.redeliveryDelay=1

--- a/services-camel/src/test/resources/register-longleaf-router-context.xml
+++ b/services-camel/src/test/resources/register-longleaf-router-context.xml
@@ -27,21 +27,13 @@
     <bean id="longleafAggregationStrategy" class="edu.unc.lib.dl.services.camel.longleaf.LongleafAggregationStrategy">
     </bean>
     
-    <bean id="registerLongleafProcessor" class="org.mockito.Mockito" factory-method="mock">
-        <constructor-arg value="edu.unc.lib.dl.services.camel.longleaf.RegisterToLongleafProcessor" />
+    <bean id="registerLongleafProcessor" class="edu.unc.lib.dl.services.camel.longleaf.RegisterToLongleafProcessor">
+        <property name="fcrepoClient" ref="fcrepoClient" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
     </bean>
     
-    <bean id="binaryDestroyedJmsTemplate" class="org.springframework.jms.core.JmsTemplate">
-        <property name="connectionFactory" ref="jmsFactory" />
-        <property name="defaultDestinationName" value="activemq:queue:filter.longleaf.deregister" />
-        <property name="pubSubDomain" value="false" />
-    </bean>
-    
-    <bean id="binaryDestroyedMessageSender" class="edu.unc.lib.dl.services.MessageSender">
-        <property name="jmsTemplate" ref="binaryDestroyedJmsTemplate" />
-    </bean>
-    
-    <bean id="deregisterLongleafProcessor" class="edu.unc.lib.dl.services.camel.longleaf.DeregisterLongleafProcessor">
+    <bean id="deregisterLongleafProcessor" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.services.camel.longleaf.DeregisterLongleafProcessor" />
     </bean>
     
     <camel:camelContext id="cdrLongleaf">


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2690

* Failed longleaf batch messages will be sent to a longleaf dead letter queue
    * If some files were successfully (de)registered within a batch, they are trimmed from the message before it is retried or sent to the dead letter queue
* Extends longleaf aggregation strategy to allow for incoming messages containing lists of files, as is the case when requeuing a failed deregister message
* definition of longleaf batch endpoints moved to a property rather than creating separate properties for each config option
* adjustments to activemq config, including removing a duplicate connection pool and allowing for Lists to be serialized
* Adds a test for longleaf registrations routes

To requeue failed longleaf messages that have run out of retries, at the moment they would need to be moved back to the appropriate longleaf queue via activemq. This could be automated with a script later.