### PR TITLE
Set cdr version for software agents in services apps

### DIFF
--- a/services-camel/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel/src/main/webapp/WEB-INF/service-context.xml
@@ -25,6 +25,15 @@
         <property name="location" ref="propertiesURI"/>
     </bean>
     
+    <bean id="injectedCdrVersion" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+        <property name="staticMethod" value="edu.unc.lib.dl.util.SoftwareAgentConstants.setCdrVersion" />
+        <property name="arguments">
+            <list>
+                <value>5.0</value>
+            </list>
+        </property>
+    </bean>
+    
     <bean id="fcrepoClientFactory" class="edu.unc.lib.dl.fcrepo4.FcrepoClientFactory" factory-method="factory">
         <constructor-arg value="${fcrepo.baseUrl}" />
         <constructor-arg value="${fcrepo.auth.host}" />

--- a/services/src/main/webapp/WEB-INF/service-context.xml
+++ b/services/src/main/webapp/WEB-INF/service-context.xml
@@ -39,6 +39,15 @@
         </property>
         <property name="ignoreResourceNotFound" value="false"/>
     </bean>
+    
+    <bean id="injectedCdrVersion" class="org.springframework.beans.factory.config.MethodInvokingFactoryBean">
+        <property name="staticMethod" value="edu.unc.lib.dl.util.SoftwareAgentConstants.setCdrVersion" />
+        <property name="arguments">
+            <list>
+                <value>5.0</value>
+            </list>
+        </property>
+    </bean>
   
     <!-- a pooling based JMS provider -->
     <bean id="jmsFactory" class="org.apache.activemq.pool.PooledConnectionFactory" destroy-method="stop">


### PR DESCRIPTION
Followup for BXC-2790 to fix null versions showing up for embargo service. Sets application version number for services and services-camel