### PR TITLE
BXC-2811 - Ingest count for simple file deposit, fix destination log events

### DIFF
--- a/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJobTest.java
@@ -241,6 +241,7 @@ public class IngestContentObjectsJobTest extends AbstractDepositJobTest {
         when(depositStatusFactory.get(anyString())).thenReturn(depositStatus);
 
         destinationObj = mock(FolderObject.class);
+        when(destinationObj.getPremisLog()).thenReturn(mockPremisLogger);
         when(destinationObj.getPid()).thenReturn(destinationPid);
         when(repoObjLoader.getRepositoryObject(eq(destinationPid))).thenReturn(destinationObj);
     }
@@ -564,6 +565,7 @@ public class IngestContentObjectsJobTest extends AbstractDepositJobTest {
     public void ingestAdminUnitTest() {
         destinationObj = mock(ContentRootObject.class);
         when(destinationObj.getPid()).thenReturn(destinationPid);
+        when(destinationObj.getPremisLog()).thenReturn(mockPremisLogger);
         when(repoObjLoader.getRepositoryObject(eq(destinationPid))).thenReturn(destinationObj);
 
         AdminUnit adminUnit = mock(AdminUnit.class);
@@ -620,6 +622,7 @@ public class IngestContentObjectsJobTest extends AbstractDepositJobTest {
     public void ingestCollectionTest() {
         destinationObj = mock(AdminUnit.class);
         when(destinationObj.getPid()).thenReturn(destinationPid);
+        when(destinationObj.getPremisLog()).thenReturn(mockPremisLogger);
         when(repoObjLoader.getRepositoryObject(eq(destinationPid))).thenReturn(destinationObj);
 
         CollectionObject collection = mock(CollectionObject.class);

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/test/RepositoryObjectTreeIndexer.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/test/RepositoryObjectTreeIndexer.java
@@ -78,7 +78,7 @@ public class RepositoryObjectTreeIndexer {
      * @param model Model to index
      * @throws Exception
      */
-    private void indexTree(Model model) throws Exception {
+    public void indexTree(Model model) throws Exception {
         queryModel.add(model);
 
         indexRelated(model, Ldp.contains);


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2811

* Immediately increment ingested count for file is the file is at the root of the deposit instead of in a work
* Add child ingested event to the destination objects log directly, fixing a bug which caused the event to be lost on the destination object
* Fixes unclosed object warning on premis logger
* Allow individual object models to be indexed in tests.