### PR TITLE
Allow for triple store indexing of repo root

### DIFF
--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/PIDs.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/PIDs.java
@@ -186,6 +186,9 @@ public class PIDs {
             String idPart = id.split("/")[1];
             if (CONTENT_BASE.equals(idPart)) {
                 return RepositoryPaths.getContentBasePid();
+            } else if (REPOSITORY_ROOT_ID.equals(idPart)) {
+                // Matched based on qualified form of repository root
+                return RepositoryPaths.getRootPid();
             }
         } else if (CONTENT_BASE.equals(id)) {
             return RepositoryPaths.getContentBasePid();

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/PIDsTest.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/PIDsTest.java
@@ -274,6 +274,17 @@ public class PIDsTest {
         assertEquals(FEDORA_BASE, pid.getRepositoryPath());
         assertEquals(REPOSITORY_ROOT_ID, pid.getId());
         assertEquals(REPOSITORY_ROOT_ID, pid.getQualifier());
+        assertEquals(REPOSITORY_ROOT_ID + "/" + REPOSITORY_ROOT_ID, pid.getQualifiedId());
+    }
+
+    @Test
+    public void getRootFromQualifiedIdTest() {
+        PID pid = PIDs.get(RepositoryPaths.getRootPid().getQualifiedId());
+
+        assertEquals(FEDORA_BASE, pid.getRepositoryPath());
+        assertEquals(REPOSITORY_ROOT_ID, pid.getId());
+        assertEquals(REPOSITORY_ROOT_ID, pid.getQualifier());
+        assertEquals(REPOSITORY_ROOT_ID + "/" + REPOSITORY_ROOT_ID, pid.getQualifiedId());
     }
 
     @Test

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/triplesReindexing/IndexingMessageProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/triplesReindexing/IndexingMessageProcessor.java
@@ -43,13 +43,13 @@ public class IndexingMessageProcessor implements Processor {
 
     @Override
     public void process(Exchange exchange) throws Exception {
-        log.debug("Processing solr update");
         final Message in = exchange.getIn();
 
         Document msgBody = MessageUtil.getDocumentBody(in);
         Element body = msgBody.getRootElement();
 
         String pidValue = body.getChild("pid", ATOM_NS).getTextTrim();
+        log.debug("Processing indexing message for {}", pidValue);
         PID pid = PIDs.get(pidValue);
         String action = body.getChild("actionType", ATOM_NS).getTextTrim();
         IndexingActionType actionType = IndexingActionType.getAction(action);

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/triplesReindexing/TriplesReindexingRouterIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/triplesReindexing/TriplesReindexingRouterIT.java
@@ -58,6 +58,7 @@ import edu.unc.lib.dl.acl.util.Permission;
 import edu.unc.lib.dl.fcrepo4.AdminUnit;
 import edu.unc.lib.dl.fcrepo4.CollectionObject;
 import edu.unc.lib.dl.fcrepo4.ContentRootObject;
+import edu.unc.lib.dl.fcrepo4.DepositRecord;
 import edu.unc.lib.dl.fcrepo4.FileObject;
 import edu.unc.lib.dl.fcrepo4.FolderObject;
 import edu.unc.lib.dl.fcrepo4.RepositoryInitializer;
@@ -214,6 +215,33 @@ public class TriplesReindexingRouterIT {
         assertIndexed(folderObj2);
         assertIndexed(workObj);
         assertIndexed(fileObj);
+    }
+
+    @Test
+    public void testIndexingFromRepoRoot() throws Exception {
+        // Create a deposit record
+        DepositRecord depositRec = repositoryObjectFactory.createDepositRecord(null);
+
+        PID contentPid = RepositoryPaths.getRootPid();
+        messageSender.sendIndexingOperation("user", contentPid, RECURSIVE_REINDEX);
+
+        // Wait for roughly all of the objects to be indexed
+        NotifyBuilder notify = new NotifyBuilder(fcrepoTriplestoreIndexer)
+                .from(indexingEndpoint)
+                .whenCompleted(16)
+                .create();
+
+        notify.matches(25l, TimeUnit.SECONDS);
+
+        assertIndexed(rootObj);
+        assertIndexed(unitObj);
+        assertIndexed(collObj);
+        assertIndexed(folderObj1);
+        assertIndexed(folderObj2);
+        assertIndexed(workObj);
+        assertIndexed(fileObj);
+
+        assertIndexed(depositRec);
     }
 
     private void assertIndexed(RepositoryObject repoObj) {


### PR DESCRIPTION
Handle root pid parsing as a qualified ID. Add test to verify that triples indexing can reindex the repo root