### PR TITLE
BXC-2844 - Tool for recalcuating metadata digests

### DIFF
--- a/metadata/src/main/java/edu/unc/lib/dl/util/RDFModelUtil.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/util/RDFModelUtil.java
@@ -22,6 +22,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.jena.rdf.model.Model;
@@ -115,5 +117,15 @@ public class RDFModelUtil {
         }
     }
 
-
+    /**
+     * Returns a model built from the file at the given path
+     *
+     * @param filePath
+     * @param lang serialization language
+     * @return
+     * @throws IOException
+     */
+    public static Model createModel(String filePath, String lang) throws IOException {
+        return createModel(Files.newInputStream(Paths.get(filePath)), lang);
+    }
 }

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/MigrationCLI.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/MigrationCLI.java
@@ -40,7 +40,8 @@ import picocli.CommandLine.Option;
         TransformDepositRecordsCommand.class,
         ViewDepositModelCommand.class,
         SubmitDepositCommand.class,
-        UpdateModelCommand.class
+        UpdateModelCommand.class,
+        RecalculateDigestsCommand.class
     })
 public class MigrationCLI implements Callable<Integer> {
     private static final Logger output = getLogger(OUTPUT_LOGGER);

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/RecalculateDigestsCommand.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/RecalculateDigestsCommand.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dcr.migration;
+
+import static edu.unc.lib.dcr.migration.MigrationConstants.OUTPUT_LOGGER;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QuerySolution;
+import org.apache.jena.query.ResultSet;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.vocabulary.RDF;
+import org.fcrepo.client.FcrepoClient;
+import org.fcrepo.client.FcrepoResponse;
+import org.fcrepo.client.FedoraHeaderConstants;
+import org.slf4j.Logger;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.model.DatastreamType;
+import edu.unc.lib.dl.rdf.Fcrepo4Repository;
+import edu.unc.lib.dl.sparql.SparqlQueryService;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+
+/**
+ * Command for recalculate sha1 digests of repository files
+ *
+ * @author bbpennel
+ */
+@Command(name = "recalculate_digests",
+    description = "Command which recalculates digests for repository files")
+public class RecalculateDigestsCommand implements Callable<Integer> {
+
+    private static final Logger output = getLogger(OUTPUT_LOGGER);
+
+    @ParentCommand
+    private MigrationCLI parentCommand;
+
+    @Option(names = {"-n", "--dry-run"},
+            description = "Perform the recalculation but do not save the results")
+    private boolean dryRun;
+
+    private String applicationContextPath = "spring/service-context.xml";
+
+    private final static String METADATA_SUFFIXES = String.join("|", Arrays.asList(
+            DatastreamType.MD_DESCRIPTIVE.getId(),
+            DatastreamType.MD_DESCRIPTIVE_HISTORY.getId(),
+            DatastreamType.MD_EVENTS.getId(),
+            DatastreamType.TECHNICAL_METADATA.getId()));
+
+    private final static String ALL_METADATA_BINS_QUERY =
+            "SELECT ?bin_pid" +
+            " WHERE { ?bin_pid <" + RDF.type.getURI() + "> <" + Fcrepo4Repository.Binary.getURI() + "> ." +
+                " FILTER(regex(str(?bin_pid), \"/(" + METADATA_SUFFIXES + ")$\")) }";
+
+    @Override
+    public Integer call() throws Exception {
+        long start = System.currentTimeMillis();
+
+        output.info("Using properties from {}", System.getProperty("config.properties.uri"));
+
+        try (ConfigurableApplicationContext context = new ClassPathXmlApplicationContext(applicationContextPath)) {
+            SparqlQueryService queryService = (SparqlQueryService) context.getBean("sparqlQueryService");
+
+            List<String> binUris = new ArrayList<>();
+            try (QueryExecution qexec = queryService.executeQuery(ALL_METADATA_BINS_QUERY)) {
+                ResultSet results = qexec.execSelect();
+
+                while (results.hasNext()) {
+                    QuerySolution soln = results.nextSolution();
+                    Resource binPidResc = soln.getResource("bin_pid");
+
+                    if (binPidResc == null) {
+                        continue;
+                    }
+
+                    binUris.add(binPidResc.getURI());
+                }
+            }
+
+            output.info("Retrieved list of {} binaries to update", binUris.size());
+            if (dryRun) {
+                output.info("Dry run -- only calculating SHA1 digests");
+            } else {
+                output.info("Recalculating SHA1 digests and updating in record");
+            }
+            output.info("===========================================");
+
+            RepositoryObjectFactory repoObjFactory = (RepositoryObjectFactory)
+                    context.getBean("repositoryObjectFactory");
+            FcrepoClient fcrepoClient = (FcrepoClient) context.getBean("fcrepoClient");
+
+            for (String binPath : binUris) {
+                PID binPid = PIDs.get(binPath);
+                String sha1;
+                String mimetype;
+                String filename;
+                URI storageUri;
+                // Calculate an up to date SHA1 for each binary
+                try (FcrepoResponse resp = fcrepoClient.head(binPid.getRepositoryUri()).wantDigest("sha").perform()) {
+                    String digest = resp.getHeaderValue(FedoraHeaderConstants.DIGEST);
+                    sha1 = digest.split("=")[1];
+                    mimetype = resp.getHeaderValue("Content-Type");
+                    filename = resp.getContentDisposition().get(FedoraHeaderConstants.CONTENT_DISPOSITION_FILENAME);
+                    storageUri = URI.create(resp.getHeaderValue("Content-Location"));
+                }
+                output.info("{}: {}", binPid.getQualifiedId(), sha1);
+
+                if (!dryRun) {
+                    // Update the binary with existing metadata plus the requested digest
+                    repoObjFactory.createOrUpdateBinary(binPid, storageUri, filename, mimetype, sha1, null, null);
+                }
+            }
+
+            output.info("Finished recalculating in {}ms", System.currentTimeMillis() - start);
+
+            return 0;
+        }
+    }
+
+    public void setApplicationContextPath(String applicationContextPath) {
+        this.applicationContextPath = applicationContextPath;
+    }
+}

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/RecalculateDigestsCommand.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/RecalculateDigestsCommand.java
@@ -64,6 +64,10 @@ public class RecalculateDigestsCommand implements Callable<Integer> {
             description = "Perform the recalculation but do not save the results")
     private boolean dryRun;
 
+    @Option(names = {"--count"},
+            description = "Count the number of matching objects")
+    private boolean countOnly;
+
     private String applicationContextPath = "spring/service-context.xml";
 
     private final static String METADATA_SUFFIXES = String.join("|", Arrays.asList(
@@ -103,6 +107,11 @@ public class RecalculateDigestsCommand implements Callable<Integer> {
             }
 
             output.info("Retrieved list of {} binaries to update", binUris.size());
+
+            if (countOnly) {
+                return 0;
+            }
+
             if (dryRun) {
                 output.info("Dry run -- only calculating SHA1 digests");
             } else {

--- a/migration-util/src/test/java/edu/unc/lib/dcr/migration/RecalculateDigestsCommandIT.java
+++ b/migration-util/src/test/java/edu/unc/lib/dcr/migration/RecalculateDigestsCommandIT.java
@@ -1,0 +1,240 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dcr.migration;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.jena.rdf.model.Model;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import edu.unc.lib.dl.fcrepo4.AdminUnit;
+import edu.unc.lib.dl.fcrepo4.BinaryObject;
+import edu.unc.lib.dl.fcrepo4.CollectionObject;
+import edu.unc.lib.dl.fcrepo4.ContentRootObject;
+import edu.unc.lib.dl.fcrepo4.FileObject;
+import edu.unc.lib.dl.fcrepo4.RepositoryInitializer;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
+import edu.unc.lib.dl.fcrepo4.RepositoryPaths;
+import edu.unc.lib.dl.fcrepo4.WorkObject;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.model.DatastreamPids;
+import edu.unc.lib.dl.persist.api.storage.StorageLocation;
+import edu.unc.lib.dl.persist.api.storage.StorageLocationManager;
+import edu.unc.lib.dl.persist.api.transfer.BinaryTransferOutcome;
+import edu.unc.lib.dl.persist.api.transfer.BinaryTransferService;
+import edu.unc.lib.dl.persist.api.transfer.BinaryTransferSession;
+import edu.unc.lib.dl.test.RepositoryObjectTreeIndexer;
+import edu.unc.lib.dl.test.TestHelper;
+import edu.unc.lib.dl.util.RDFModelUtil;
+import picocli.CommandLine;
+
+/**
+ * @author bbpennel
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextHierarchy({
+    @ContextConfiguration("/spring-test/test-fedora-container.xml"),
+    @ContextConfiguration("/spring-test/cdr-client-container.xml")
+})
+public class RecalculateDigestsCommandIT {
+    private static final Logger log = getLogger(RecalculateDigestsCommandIT.class);
+
+    @Rule
+    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    @Autowired
+    protected String baseAddress;
+    @Autowired
+    private RepositoryObjectFactory repoObjFactory;
+    @Autowired
+    private RepositoryObjectLoader repoObjLoader;
+    @Autowired
+    private StorageLocationManager storageLocManager;
+    @Autowired
+    private RepositoryObjectTreeIndexer treeIndexer;
+    @Autowired
+    private BinaryTransferService transferService;
+    @Autowired
+    private Model queryModel;
+    private File modelFile;
+
+    private RepositoryInitializer repositoryInitializer;
+
+    final PrintStream originalOut = System.out;
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    CommandLine migrationCommand;
+
+    private String output;
+
+    protected ContentRootObject rootObj;
+
+    private StorageLocation defaultStorageLoc;
+
+    @Before
+    public void setUp() throws Exception {
+        TestHelper.setContentBase("http://localhost:48085/rest");
+
+        tmpFolder.create();
+        modelFile = tmpFolder.newFile();
+        System.setProperty("dcr.it.rcd.model_file", modelFile.getAbsolutePath());
+
+        out.reset();
+        System.setOut(new PrintStream(out));
+
+        migrationCommand = new CommandLine(new MigrationCLI());
+
+        // Set the application context path for the test environment
+        Map<String, CommandLine> subs = migrationCommand.getSubcommands();
+        CommandLine recalcCommand = subs.get("recalculate_digests");
+
+        RecalculateDigestsCommand rcdCommand = (RecalculateDigestsCommand) recalcCommand.getCommand();
+        Path contextPath = Paths.get("src", "test", "resources", "spring-test",
+                "recalculate-digests-command-it.xml");
+        rcdCommand.setApplicationContextPath(contextPath.toUri().toString());
+
+        output = null;
+
+        repositoryInitializer = new RepositoryInitializer();
+        repositoryInitializer.setObjFactory(repoObjFactory);
+        repositoryInitializer.initializeRepository();
+        rootObj = repoObjLoader.getContentRootObject(RepositoryPaths.getContentRootPid());
+
+        defaultStorageLoc = storageLocManager.getStorageLocationById("loc1");
+    }
+
+    @After
+    public void cleanup() {
+        System.setOut(originalOut);
+        System.clearProperty("dcr.it.rcd.model_file");
+    }
+
+    @Test
+    public void recalculateWithNoMetadataDigests() throws Exception {
+        AdminUnit unit = repoObjFactory.createAdminUnit(null);
+        CollectionObject coll = repoObjFactory.createCollectionObject(null);
+        WorkObject work = repoObjFactory.createWorkObject(null);
+        FileObject file = repoObjFactory.createFileObject(null);
+        PID originalPid = DatastreamPids.getOriginalFilePid(file.getPid());
+        createBinary(originalPid, "content");
+
+        work.addMember(file);
+        coll.addMember(work);
+        unit.addMember(coll);
+        rootObj.addMember(unit);
+
+        PID collEventsPid = DatastreamPids.getMdEventsPid(coll.getPid());
+        createBinary(collEventsPid, "events go here");
+
+        PID workDescPid = DatastreamPids.getMdDescriptivePid(work.getPid());
+        createBinary(workDescPid, "descriptive");
+
+        PID techMdPid = DatastreamPids.getTechnicalMetadataPid(file.getPid());
+        createBinary(techMdPid, "highly technical");
+
+        treeIndexer.indexAll(baseAddress);
+
+        RDFModelUtil.serializeModel(queryModel, modelFile);
+
+        String[] dryArgs = new String[] { "recalculate_digests", "-n" };
+        executeExpectSuccess(dryArgs);
+
+        assertTrue("Incorrect number of binaries found",
+                output.contains("Retrieved list of 3 binaries to update"));
+        assertTrue("Did not process collections events",
+                output.contains(collEventsPid.getQualifiedId()));
+        assertTrue("Did not process description binary",
+                output.contains(workDescPid.getQualifiedId()));
+        assertTrue("Did not process techmd binary",
+                output.contains(techMdPid.getQualifiedId()));
+
+        // Dry run, so no SHA1s should be set
+        assertNoDigestPresent(originalPid);
+        assertNoDigestPresent(collEventsPid);
+        assertNoDigestPresent(workDescPid);
+        assertNoDigestPresent(techMdPid);
+
+        out.reset();
+
+        String[] args = new String[] { "recalculate_digests" };
+        executeExpectSuccess(args);
+
+        assertTrue("Incorrect number of binaries found",
+                output.contains("Retrieved list of 3 binaries to update"));
+
+        // Original should not be updated, but the rest should
+        assertNoDigestPresent(originalPid);
+        assertDigestPresent(collEventsPid);
+        assertDigestPresent(workDescPid);
+        assertDigestPresent(techMdPid);
+    }
+
+    private BinaryObject createBinary(PID binPid, String content) throws Exception {
+        BinaryTransferOutcome eventsOutcome = transferContent(binPid, content);
+        return repoObjFactory.createOrUpdateBinary(binPid, eventsOutcome.getDestinationUri(),
+                "somefile", "text/plain", null, null, null);
+    }
+
+    private BinaryTransferOutcome transferContent(PID binPid, String content) throws Exception {
+        try (BinaryTransferSession session = transferService.getSession(defaultStorageLoc)) {
+            return session.transfer(binPid, IOUtils.toInputStream("content", UTF_8));
+        }
+    }
+
+    private void assertNoDigestPresent(PID binPid) {
+        BinaryObject bin = repoObjLoader.getBinaryObject(binPid);
+        assertNull("Expected no digest for " + binPid, bin.getSha1Checksum());
+    }
+
+    private void assertDigestPresent(PID binPid) {
+        BinaryObject bin = repoObjLoader.getBinaryObject(binPid);
+        assertNotNull("Expected SHA1 digest for " + binPid, bin.getSha1Checksum());
+    }
+
+    private void executeExpectSuccess(String[] args) {
+        int result = migrationCommand.execute(args);
+        output = out.toString();
+        if (result != 0) {
+            System.setOut(originalOut);
+            log.error(output);
+            fail("Expected command to result in success: " + String.join(" ", args));
+        }
+    }
+}

--- a/migration-util/src/test/java/edu/unc/lib/dcr/migration/RecalculateDigestsCommandIT.java
+++ b/migration-util/src/test/java/edu/unc/lib/dcr/migration/RecalculateDigestsCommandIT.java
@@ -173,6 +173,14 @@ public class RecalculateDigestsCommandIT {
 
         RDFModelUtil.serializeModel(queryModel, modelFile);
 
+        String[] countArgs = new String[] { "recalculate_digests", "--count" };
+        executeExpectSuccess(countArgs);
+
+        assertTrue("Incorrect number of binaries found",
+                output.contains("Retrieved list of 3 binaries to update"));
+
+        out.reset();
+
         String[] dryArgs = new String[] { "recalculate_digests", "-n" };
         executeExpectSuccess(dryArgs);
 

--- a/migration-util/src/test/resources/spring-test/recalculate-digests-command-it.xml
+++ b/migration-util/src/test/resources/spring-test/recalculate-digests-command-it.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+
+    <import resource="cdr-client-container.xml" />
+    
+    <bean id="queryModel" class="edu.unc.lib.dl.util.RDFModelUtil" factory-method="createModel">
+        <constructor-arg value="${dcr.it.rcd.model_file}" />
+        <constructor-arg value="TURTLE" />
+    </bean>
+    
+    <bean id="sparqlQueryService" class="edu.unc.lib.dl.sparql.JenaSparqlQueryServiceImpl">
+        <constructor-arg ref="queryModel" />
+    </bean>
+    
+</beans>


### PR DESCRIPTION
Used to address https://jira.lib.unc.edu/browse/BXC-2844 in already ingested objects

* Adds a commandline tool for recalculating and storing SHA1 digests of metadata files, to fix issue where digest is out of sync with the file