### PR TITLE
BXC-2856 - Fix user based permissions issues

### DIFF
--- a/access-common/src/main/java/edu/unc/lib/dl/ui/access/StoreAccessLevelFilter.java
+++ b/access-common/src/main/java/edu/unc/lib/dl/ui/access/StoreAccessLevelFilter.java
@@ -73,9 +73,9 @@ public class StoreAccessLevelFilter extends OncePerRequestFilter implements Serv
                 session.removeAttribute("accessLevel");
                 accessLevel = new AccessLevel(username);
                 session.setAttribute("accessLevel", accessLevel);
-                AccessGroupSet groups = GroupsThreadStore.getGroups();
-                if (globalPermissionEvaluator.hasGlobalPrincipal(groups)) {
-                    Set<UserRole> roles = globalPermissionEvaluator.getGlobalUserRoles(groups);
+                AccessGroupSet principals = GroupsThreadStore.getAgentPrincipals().getPrincipals();
+                if (globalPermissionEvaluator.hasGlobalPrincipal(principals)) {
+                    Set<UserRole> roles = globalPermissionEvaluator.getGlobalUserRoles(principals);
                     if (roles.contains(UserRole.administrator)) {
                         accessLevel.setHighestRole(UserRole.administrator);
                     } else {
@@ -83,7 +83,7 @@ public class StoreAccessLevelFilter extends OncePerRequestFilter implements Serv
                     }
                 } else {
                     // Check for viewAdmin
-                    boolean viewAdmin = queryLayer.hasAdminViewPermission(groups);
+                    boolean viewAdmin = queryLayer.hasAdminViewPermission(principals);
                     if (viewAdmin) {
                         // See which exact type of admin we're dealing with
                         // Comment out until we start using these

--- a/access-common/src/main/java/edu/unc/lib/dl/ui/access/StoreAccessLevelFilter.java
+++ b/access-common/src/main/java/edu/unc/lib/dl/ui/access/StoreAccessLevelFilter.java
@@ -73,7 +73,7 @@ public class StoreAccessLevelFilter extends OncePerRequestFilter implements Serv
                 session.removeAttribute("accessLevel");
                 accessLevel = new AccessLevel(username);
                 session.setAttribute("accessLevel", accessLevel);
-                AccessGroupSet principals = GroupsThreadStore.getAgentPrincipals().getPrincipals();
+                AccessGroupSet principals = GroupsThreadStore.getPrincipals();
                 if (globalPermissionEvaluator.hasGlobalPrincipal(principals)) {
                     Set<UserRole> roles = globalPermissionEvaluator.getGlobalUserRoles(principals);
                     if (roles.contains(UserRole.administrator)) {

--- a/access-common/src/main/java/edu/unc/lib/dl/ui/controller/AbstractSolrSearchController.java
+++ b/access-common/src/main/java/edu/unc/lib/dl/ui/controller/AbstractSolrSearchController.java
@@ -173,7 +173,7 @@ public abstract class AbstractSolrSearchController {
 
     protected Map<String, Object> getResults(SearchResultResponse resp, String queryMethod,
                                              HttpServletRequest request) {
-        AccessGroupSet principals = GroupsThreadStore.getAgentPrincipals().getPrincipals();
+        AccessGroupSet principals = GroupsThreadStore.getPrincipals();
 
         childrenCountService.addChildrenCounts(resp.getResultList(),
                 principals);

--- a/access-common/src/main/java/edu/unc/lib/dl/ui/controller/AbstractSolrSearchController.java
+++ b/access-common/src/main/java/edu/unc/lib/dl/ui/controller/AbstractSolrSearchController.java
@@ -26,14 +26,12 @@ import java.util.regex.Pattern;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 
-import edu.unc.lib.dl.acl.util.GroupsThreadStore;
-import edu.unc.lib.dl.search.solr.util.SearchStateUtil;
-import edu.unc.lib.dl.ui.util.SerializationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import edu.unc.lib.dl.acl.util.AccessGroupSet;
+import edu.unc.lib.dl.acl.util.GroupsThreadStore;
 import edu.unc.lib.dl.search.solr.exception.InvalidHierarchicalFacetException;
 import edu.unc.lib.dl.search.solr.model.HierarchicalBrowseRequest;
 import edu.unc.lib.dl.search.solr.model.SearchRequest;
@@ -43,7 +41,9 @@ import edu.unc.lib.dl.search.solr.service.ChildrenCountService;
 import edu.unc.lib.dl.search.solr.service.SearchActionService;
 import edu.unc.lib.dl.search.solr.service.SearchStateFactory;
 import edu.unc.lib.dl.search.solr.util.SearchSettings;
+import edu.unc.lib.dl.search.solr.util.SearchStateUtil;
 import edu.unc.lib.dl.ui.service.SolrQueryLayerService;
+import edu.unc.lib.dl.ui.util.SerializationUtil;
 
 /**
  * Abstract base class for controllers which interact with solr services.
@@ -173,12 +173,12 @@ public abstract class AbstractSolrSearchController {
 
     protected Map<String, Object> getResults(SearchResultResponse resp, String queryMethod,
                                              HttpServletRequest request) {
-        AccessGroupSet groups = GroupsThreadStore.getGroups();
+        AccessGroupSet principals = GroupsThreadStore.getAgentPrincipals().getPrincipals();
 
         childrenCountService.addChildrenCounts(resp.getResultList(),
-                groups);
+                principals);
 
-        List<Map<String, Object>> resultList = SerializationUtil.resultsToList(resp, groups);
+        List<Map<String, Object>> resultList = SerializationUtil.resultsToList(resp, principals);
         Map<String, Object> results = new HashMap<>();
         results.put("metadata", resultList);
 
@@ -194,7 +194,7 @@ public abstract class AbstractSolrSearchController {
         results.put("email", GroupsThreadStore.getEmail());
 
         if (resp.getSelectedContainer() != null) {
-            results.put("container", SerializationUtil.metadataToMap(resp.getSelectedContainer(), groups));
+            results.put("container", SerializationUtil.metadataToMap(resp.getSelectedContainer(), principals));
         }
 
         return results;

--- a/access-common/src/main/java/edu/unc/lib/dl/ui/controller/StructureResultsController.java
+++ b/access-common/src/main/java/edu/unc/lib/dl/ui/controller/StructureResultsController.java
@@ -109,6 +109,6 @@ public class StructureResultsController extends AbstractStructureResultsControll
                 selectedContainer.getAncestorPathFacet().getSearchKey(),
                 "true".equals(includeFiles), false, false, request);
 
-        return SerializationUtil.structureToJSON(result, GroupsThreadStore.getAgentPrincipals().getPrincipals());
+        return SerializationUtil.structureToJSON(result, GroupsThreadStore.getPrincipals());
     }
 }

--- a/access-common/src/main/java/edu/unc/lib/dl/ui/controller/StructureResultsController.java
+++ b/access-common/src/main/java/edu/unc/lib/dl/ui/controller/StructureResultsController.java
@@ -109,6 +109,6 @@ public class StructureResultsController extends AbstractStructureResultsControll
                 selectedContainer.getAncestorPathFacet().getSearchKey(),
                 "true".equals(includeFiles), false, false, request);
 
-        return SerializationUtil.structureToJSON(result, GroupsThreadStore.getGroups());
+        return SerializationUtil.structureToJSON(result, GroupsThreadStore.getAgentPrincipals().getPrincipals());
     }
 }

--- a/access-common/src/main/java/edu/unc/lib/dl/ui/service/SolrQueryLayerService.java
+++ b/access-common/src/main/java/edu/unc/lib/dl/ui/service/SolrQueryLayerService.java
@@ -283,8 +283,8 @@ public class SolrQueryLayerService extends SolrSearchService {
                         searchState.getFacets().get(SearchFieldKeys.CONTENT_TYPE.name()));
                 contentTypeSearchState.setResultFields(Arrays.asList(SearchFieldKeys.CONTENT_TYPE.name()));
 
-                SearchRequest contentTypeRequest =
-                        new SearchRequest(contentTypeSearchState, GroupsThreadStore.getGroups());
+                SearchRequest contentTypeRequest = new SearchRequest(contentTypeSearchState, GroupsThreadStore
+                                .getAgentPrincipals().getPrincipals());
                 SearchResultResponse contentTypeResponse = getSearchResults(contentTypeRequest);
                 if (contentTypeResponse.getResultCount() > 0) {
                     resultResponse.extractCrumbDisplayValueFromRepresentative(

--- a/access/src/main/java/edu/unc/lib/dl/ui/controller/AdvancedSearchFormController.java
+++ b/access/src/main/java/edu/unc/lib/dl/ui/controller/AdvancedSearchFormController.java
@@ -77,7 +77,7 @@ public class AdvancedSearchFormController extends AbstractSolrSearchController {
         //If the user is coming to this servlet without any parameters set then send them to form.
         if (request.getQueryString() == null || request.getQueryString().length() == 0) {
             //Populate the list of collections for the advanced search page drop down
-            AccessGroupSet accessGroups = GroupsThreadStore.getGroups();
+            AccessGroupSet accessGroups = GroupsThreadStore.getAgentPrincipals().getPrincipals();
 
             SearchResultResponse collectionResultResponse = queryLayer.getCollectionList(accessGroups);
             model.addAttribute("collectionList", collectionResultResponse.getResultList());

--- a/access/src/main/java/edu/unc/lib/dl/ui/controller/AdvancedSearchFormController.java
+++ b/access/src/main/java/edu/unc/lib/dl/ui/controller/AdvancedSearchFormController.java
@@ -77,7 +77,7 @@ public class AdvancedSearchFormController extends AbstractSolrSearchController {
         //If the user is coming to this servlet without any parameters set then send them to form.
         if (request.getQueryString() == null || request.getQueryString().length() == 0) {
             //Populate the list of collections for the advanced search page drop down
-            AccessGroupSet accessGroups = GroupsThreadStore.getAgentPrincipals().getPrincipals();
+            AccessGroupSet accessGroups = GroupsThreadStore.getPrincipals();
 
             SearchResultResponse collectionResultResponse = queryLayer.getCollectionList(accessGroups);
             model.addAttribute("collectionList", collectionResultResponse.getResultList());

--- a/access/src/main/java/edu/unc/lib/dl/ui/controller/FrontPageController.java
+++ b/access/src/main/java/edu/unc/lib/dl/ui/controller/FrontPageController.java
@@ -40,7 +40,7 @@ public class FrontPageController extends AbstractSolrSearchController {
     @RequestMapping(method = RequestMethod.GET)
     public String handleRequest(Model model, HttpServletRequest request) {
         LOG.debug("In front page controller");
-        AccessGroupSet groups = GroupsThreadStore.getGroups();
+        AccessGroupSet groups = GroupsThreadStore.getAgentPrincipals().getPrincipals();
 
         // Retrieve collection stats
         model.addAttribute("formatCounts", this.queryLayer.getFormatCounts(groups));

--- a/access/src/main/java/edu/unc/lib/dl/ui/controller/FrontPageController.java
+++ b/access/src/main/java/edu/unc/lib/dl/ui/controller/FrontPageController.java
@@ -40,7 +40,7 @@ public class FrontPageController extends AbstractSolrSearchController {
     @RequestMapping(method = RequestMethod.GET)
     public String handleRequest(Model model, HttpServletRequest request) {
         LOG.debug("In front page controller");
-        AccessGroupSet groups = GroupsThreadStore.getAgentPrincipals().getPrincipals();
+        AccessGroupSet groups = GroupsThreadStore.getPrincipals();
 
         // Retrieve collection stats
         model.addAttribute("formatCounts", this.queryLayer.getFormatCounts(groups));

--- a/admin/src/main/java/edu/unc/lib/dl/admin/controller/MODSController.java
+++ b/admin/src/main/java/edu/unc/lib/dl/admin/controller/MODSController.java
@@ -74,7 +74,7 @@ public class MODSController extends AbstractSolrSearchController {
     public String editDescription(@PathVariable("pid") String pid, Model model,
             HttpServletRequest request) {
 
-        AccessGroupSet accessGroups = GroupsThreadStore.getGroups();
+        AccessGroupSet accessGroups = GroupsThreadStore.getAgentPrincipals().getPrincipals();
         // Retrieve the record for the object being edited
         SimpleIdRequest objectRequest = new SimpleIdRequest(pid, accessGroups);
         BriefObjectMetadataBean resultObject = queryLayer.getObjectById(objectRequest);
@@ -94,7 +94,7 @@ public class MODSController extends AbstractSolrSearchController {
 
         Map<String, Object> results = new LinkedHashMap<>();
 
-        AccessGroupSet accessGroups = GroupsThreadStore.getGroups();
+        AccessGroupSet accessGroups = GroupsThreadStore.getAgentPrincipals().getPrincipals();
 
         // Retrieve the record for the object being edited
         SimpleIdRequest objectRequest = new SimpleIdRequest(pid, accessGroups);

--- a/admin/src/main/java/edu/unc/lib/dl/admin/controller/MODSController.java
+++ b/admin/src/main/java/edu/unc/lib/dl/admin/controller/MODSController.java
@@ -74,7 +74,7 @@ public class MODSController extends AbstractSolrSearchController {
     public String editDescription(@PathVariable("pid") String pid, Model model,
             HttpServletRequest request) {
 
-        AccessGroupSet accessGroups = GroupsThreadStore.getAgentPrincipals().getPrincipals();
+        AccessGroupSet accessGroups = GroupsThreadStore.getPrincipals();
         // Retrieve the record for the object being edited
         SimpleIdRequest objectRequest = new SimpleIdRequest(pid, accessGroups);
         BriefObjectMetadataBean resultObject = queryLayer.getObjectById(objectRequest);
@@ -94,7 +94,7 @@ public class MODSController extends AbstractSolrSearchController {
 
         Map<String, Object> results = new LinkedHashMap<>();
 
-        AccessGroupSet accessGroups = GroupsThreadStore.getAgentPrincipals().getPrincipals();
+        AccessGroupSet accessGroups = GroupsThreadStore.getPrincipals();
 
         // Retrieve the record for the object being edited
         SimpleIdRequest objectRequest = new SimpleIdRequest(pid, accessGroups);

--- a/admin/src/main/java/edu/unc/lib/dl/admin/controller/ResultEntryController.java
+++ b/admin/src/main/java/edu/unc/lib/dl/admin/controller/ResultEntryController.java
@@ -53,7 +53,7 @@ public class ResultEntryController extends AbstractSearchController {
     public @ResponseBody
     String getResultEntry(@PathVariable("pid") String pid, Model model, HttpServletResponse response) {
         response.setContentType("application/json");
-        AccessGroupSet accessGroups = GroupsThreadStore.getAgentPrincipals().getPrincipals();
+        AccessGroupSet accessGroups = GroupsThreadStore.getPrincipals();
 
         SimpleIdRequest entryRequest = new SimpleIdRequest(pid, resultsFieldList, accessGroups);
         BriefObjectMetadataBean entryBean = queryLayer.getObjectById(entryRequest);

--- a/admin/src/main/java/edu/unc/lib/dl/admin/controller/ResultEntryController.java
+++ b/admin/src/main/java/edu/unc/lib/dl/admin/controller/ResultEntryController.java
@@ -53,7 +53,7 @@ public class ResultEntryController extends AbstractSearchController {
     public @ResponseBody
     String getResultEntry(@PathVariable("pid") String pid, Model model, HttpServletResponse response) {
         response.setContentType("application/json");
-        AccessGroupSet accessGroups = GroupsThreadStore.getGroups();
+        AccessGroupSet accessGroups = GroupsThreadStore.getAgentPrincipals().getPrincipals();
 
         SimpleIdRequest entryRequest = new SimpleIdRequest(pid, resultsFieldList, accessGroups);
         BriefObjectMetadataBean entryBean = queryLayer.getObjectById(entryRequest);

--- a/admin/src/main/java/edu/unc/lib/dl/admin/controller/VocabularyController.java
+++ b/admin/src/main/java/edu/unc/lib/dl/admin/controller/VocabularyController.java
@@ -76,7 +76,7 @@ public class VocabularyController extends AbstractSearchController {
     }
 
     public Map<String, Object> getInvalidVocab(SearchRequest searchRequest) {
-        AccessGroupSet groups = GroupsThreadStore.getAgentPrincipals().getPrincipals();
+        AccessGroupSet groups = GroupsThreadStore.getPrincipals();
 
         BriefObjectMetadata selectedContainer = queryLayer.addSelectedContainer(searchRequest.getRootPid(),
                 searchRequest.getSearchState(), false, groups);

--- a/security/src/main/java/edu/unc/lib/dl/acl/util/GroupsThreadStore.java
+++ b/security/src/main/java/edu/unc/lib/dl/acl/util/GroupsThreadStore.java
@@ -111,7 +111,7 @@ public abstract class GroupsThreadStore {
     }
 
     /**
-     * Get all principals for the agent on the current thread.
+     * Get the AgentPrincipal object on the current thread
      *
      * @return
      */
@@ -122,6 +122,15 @@ public abstract class GroupsThreadStore {
             agentPrincipals.set(principals);
         }
         return principals;
+    }
+
+    /**
+     * Get all the principals for the agent on the current thread
+     * @return
+     */
+    public static AccessGroupSet getPrincipals() {
+        AgentPrincipals agent = getAgentPrincipals();
+        return agent.getPrincipals();
     }
 
     /**

--- a/security/src/main/java/edu/unc/lib/dl/acl/util/GroupsThreadStore.java
+++ b/security/src/main/java/edu/unc/lib/dl/acl/util/GroupsThreadStore.java
@@ -119,6 +119,7 @@ public abstract class GroupsThreadStore {
         AgentPrincipals principals = GroupsThreadStore.agentPrincipals.get();
         if (principals == null) {
             principals = new AgentPrincipals(username.get(), groups.get());
+            agentPrincipals.set(principals);
         }
         return principals;
     }

--- a/security/src/test/java/edu/unc/lib/dl/acl/filter/StoreUserAccessControlFilterTest.java
+++ b/security/src/test/java/edu/unc/lib/dl/acl/filter/StoreUserAccessControlFilterTest.java
@@ -94,7 +94,7 @@ public class StoreUserAccessControlFilterTest {
         assertEquals("user", GroupsThreadStore.getUsername());
         assertEquals("user@example.com", GroupsThreadStore.getEmail());
 
-        AccessGroupSet accessGroups = GroupsThreadStore.getAgentPrincipals().getPrincipals();
+        AccessGroupSet accessGroups = GroupsThreadStore.getPrincipals();
         verify(request).setAttribute("accessGroupSet", accessGroups);
 
         assertTrue("Public must be assigned", accessGroups.contains(PUBLIC_PRINC));
@@ -112,7 +112,7 @@ public class StoreUserAccessControlFilterTest {
         assertEquals("user", GroupsThreadStore.getUsername());
         assertEquals("user@example.com", GroupsThreadStore.getEmail());
 
-        AccessGroupSet accessGroups = GroupsThreadStore.getAgentPrincipals().getPrincipals();
+        AccessGroupSet accessGroups = GroupsThreadStore.getPrincipals();
         verify(request).setAttribute("accessGroupSet", accessGroups);
 
         assertTrue("Public must be assigned", accessGroups.contains(PUBLIC_PRINC));
@@ -131,7 +131,7 @@ public class StoreUserAccessControlFilterTest {
         assertEquals("user", GroupsThreadStore.getUsername());
         assertEquals("user@example.com", GroupsThreadStore.getEmail());
 
-        AccessGroupSet accessGroups = GroupsThreadStore.getAgentPrincipals().getPrincipals();
+        AccessGroupSet accessGroups = GroupsThreadStore.getPrincipals();
         verify(request).setAttribute("accessGroupSet", accessGroups);
 
         assertTrue("Public must be assigned", accessGroups.contains(PUBLIC_PRINC));

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/processing/XMLExportService.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/processing/XMLExportService.java
@@ -93,7 +93,8 @@ public class XMLExportService {
             searchState.setRowsPerPage(Integer.MAX_VALUE);
             searchState.setIgnoreMaxRows(true);
 
-            SearchRequest searchRequest = new SearchRequest(searchState, GroupsThreadStore.getGroups());
+            SearchRequest searchRequest = new SearchRequest(searchState,
+                    GroupsThreadStore.getAgentPrincipals().getPrincipals());
             searchRequest.setRootPid(pid);
             searchRequest.setApplyCutoffs(false);
             SearchResultResponse resultResponse = queryLayer.performSearch(searchRequest);

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/processing/XMLExportService.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/processing/XMLExportService.java
@@ -94,7 +94,7 @@ public class XMLExportService {
             searchState.setIgnoreMaxRows(true);
 
             SearchRequest searchRequest = new SearchRequest(searchState,
-                    GroupsThreadStore.getAgentPrincipals().getPrincipals());
+                    GroupsThreadStore.getPrincipals());
             searchRequest.setRootPid(pid);
             searchRequest.setApplyCutoffs(false);
             SearchResultResponse resultResponse = queryLayer.performSearch(searchRequest);

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/SearchRestController.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/SearchRestController.java
@@ -32,6 +32,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import edu.unc.lib.dl.acl.util.AccessGroupSet;
 import edu.unc.lib.dl.acl.util.GroupsThreadStore;
 import edu.unc.lib.dl.search.solr.model.BriefObjectMetadata;
 import edu.unc.lib.dl.search.solr.model.BriefObjectMetadataBean;
@@ -130,11 +131,12 @@ public class SearchRestController extends AbstractSolrSearchController {
         childrenCountService.addChildrenCounts(resultResponse.getResultList(),
                 searchRequest.getAccessGroups());
 
+        AccessGroupSet principals = GroupsThreadStore.getAgentPrincipals().getPrincipals();
         Map<String, Object> response = new HashMap<>();
         response.put("numFound", resultResponse.getResultCount());
         List<Map<String, Object>> results = new ArrayList<>(resultResponse.getResultList().size());
         for (BriefObjectMetadata metadata: resultResponse.getResultList()) {
-            results.add(SerializationUtil.metadataToMap(metadata, GroupsThreadStore.getGroups()));
+            results.add(SerializationUtil.metadataToMap(metadata, principals));
         }
         response.put("results", results);
 
@@ -153,7 +155,8 @@ public class SearchRestController extends AbstractSolrSearchController {
             HttpServletRequest request, HttpServletResponse response) {
         List<String> resultFields = this.getResultFields(request);
 
-        SimpleIdRequest idRequest = new SimpleIdRequest(id, resultFields, getAgentPrincipals().getPrincipals());
+        AccessGroupSet principals = getAgentPrincipals().getPrincipals();
+        SimpleIdRequest idRequest = new SimpleIdRequest(id, resultFields, principals);
         BriefObjectMetadataBean briefObject = queryLayer.getObjectById(idRequest);
         if (briefObject == null) {
             response.setStatus(404);
@@ -164,9 +167,9 @@ public class SearchRestController extends AbstractSolrSearchController {
         // If there's a jsonp callback, do some overzealous cleanup to remove any bad stuff
         if (callback != null) {
             callback = jsonpCleanupPattern.matcher(callback).replaceAll("");
-            return callback + "(" + SerializationUtil.metadataToJSON(briefObject, GroupsThreadStore.getGroups()) + ")";
+            return callback + "(" + SerializationUtil.metadataToJSON(briefObject, principals) + ")";
         }
 
-        return SerializationUtil.metadataToJSON(briefObject, GroupsThreadStore.getGroups());
+        return SerializationUtil.metadataToJSON(briefObject, principals);
     }
 }

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/SearchRestController.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/SearchRestController.java
@@ -131,7 +131,7 @@ public class SearchRestController extends AbstractSolrSearchController {
         childrenCountService.addChildrenCounts(resultResponse.getResultList(),
                 searchRequest.getAccessGroups());
 
-        AccessGroupSet principals = GroupsThreadStore.getAgentPrincipals().getPrincipals();
+        AccessGroupSet principals = GroupsThreadStore.getPrincipals();
         Map<String, Object> response = new HashMap<>();
         response.put("numFound", resultResponse.getResultCount());
         List<Map<String, Object>> results = new ArrayList<>(resultResponse.getResultList().size());

--- a/solr-search/src/main/java/edu/unc/lib/dl/search/solr/service/StructureQueryService.java
+++ b/solr-search/src/main/java/edu/unc/lib/dl/search/solr/service/StructureQueryService.java
@@ -84,7 +84,9 @@ public class StructureQueryService extends AbstractQueryService {
 
         // Start hierarchy tree at root of the repository
         BriefObjectMetadata contentRootMd = getContentRootMetadata(principals);
-        browseResponse.getResultList().add(contentRootMd);
+        if (contentRootMd != null) {
+            browseResponse.getResultList().add(contentRootMd);
+        }
 
         // Get the path of the root object being requested for iteration
         CutoffFacet path = getObjectPath(browseRequest.getRootPid(), principals);


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2856
* Make sure that the user principal is provided for most ACL checks by using getAgentPrincipal instead of getGroups.
* Store agent principals in the group thread store rather than regenerating on each method call.
* Fix NPE when accessing structure browse in admin interface with no permissions to the content root