### PR TITLE
BXC-2873 - Allow visibility of root and unit objects for all admin users

### DIFF
--- a/access-common/src/main/java/edu/unc/lib/dl/ui/util/SerializationUtil.java
+++ b/access-common/src/main/java/edu/unc/lib/dl/ui/util/SerializationUtil.java
@@ -68,7 +68,9 @@ public class SerializationUtil {
 
     public static String structureToJSON(HierarchicalBrowseResultResponse response, AccessGroupSet groups) {
         Map<String, Object> result = new HashMap<>();
-        result.put("root", structureStep(response.getRootNode(), groups));
+        if (response.getRootNode() != null) {
+            result.put("root", structureStep(response.getRootNode(), groups));
+        }
         return objectToJSON(result);
     }
 

--- a/access-common/src/test/java/edu/unc/lib/dl/ui/service/StoreAccessLevelFilterTest.java
+++ b/access-common/src/test/java/edu/unc/lib/dl/ui/service/StoreAccessLevelFilterTest.java
@@ -1,0 +1,182 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.ui.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import edu.unc.lib.dl.acl.fcrepo4.GlobalPermissionEvaluator;
+import edu.unc.lib.dl.acl.util.AccessGroupSet;
+import edu.unc.lib.dl.acl.util.AccessPrincipalConstants;
+import edu.unc.lib.dl.acl.util.GroupsThreadStore;
+import edu.unc.lib.dl.acl.util.UserRole;
+import edu.unc.lib.dl.ui.access.AccessLevel;
+import edu.unc.lib.dl.ui.access.StoreAccessLevelFilter;
+
+/**
+ * @author bbpennel
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class StoreAccessLevelFilterTest {
+    @Mock
+    private HttpServletRequest request;
+    @Mock
+    private HttpServletResponse response;
+    @Mock
+    private HttpSession session;
+    @Mock
+    private FilterChain filterChain;
+    @Mock
+    private SolrQueryLayerService queryLayer;
+    @Mock
+    private GlobalPermissionEvaluator globalPermissionEvaluator;
+    @Captor
+    private ArgumentCaptor<AccessLevel> accessLevelCaptor;
+    private AccessGroupSet principals;
+
+    @InjectMocks
+    private StoreAccessLevelFilter filter;
+
+    @Before
+    public void setup() {
+        initMocks(StoreAccessLevelFilterTest.class);
+        principals = new AccessGroupSet();
+        GroupsThreadStore.storeGroups(principals);
+
+        when(request.getSession(true)).thenReturn(session);
+    }
+
+    @After
+    public void tearDown() {
+        GroupsThreadStore.clearStore();
+    }
+
+    @Test
+    public void noUsername() throws Exception {
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(session).removeAttribute("accessLevel");
+        verify(session, never()).setAttribute(anyString(), any(AccessLevel.class));
+
+        assertAdminAccessPrincipalNotGranted();
+    }
+
+    @Test
+    public void accessFromLocalPermissions() throws Exception {
+        GroupsThreadStore.storeUsername("user");
+        when(queryLayer.hasAdminViewPermission(any(AccessGroupSet.class))).thenReturn(true);
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(session).setAttribute(anyString(), accessLevelCaptor.capture());
+        AccessLevel level = accessLevelCaptor.getValue();
+        assertEquals(UserRole.canAccess, level.getHighestRole());
+
+        verify(filterChain).doFilter(request, response);
+
+        assertHasAdminAccessPrincipal();
+    }
+
+    @Test
+    public void noAccess() throws Exception {
+        filter.setRequireViewAdmin(true);
+        GroupsThreadStore.storeUsername("user");
+        when(queryLayer.hasAdminViewPermission(any(AccessGroupSet.class))).thenReturn(false);
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(session).setAttribute(anyString(), accessLevelCaptor.capture());
+        AccessLevel level = accessLevelCaptor.getValue();
+        assertNull(level.getHighestRole());
+
+        verify(response).setStatus(401);
+        verify(filterChain, never()).doFilter(request, response);
+
+        assertAdminAccessPrincipalNotGranted();
+    }
+
+    @Test
+    public void accessFromGlobalPermissions() throws Exception {
+        GroupsThreadStore.storeUsername("user");
+        when(globalPermissionEvaluator.hasGlobalPrincipal(any())).thenReturn(true);
+        when(globalPermissionEvaluator.getGlobalUserRoles(any())).thenReturn(new HashSet<>(
+                Arrays.asList(UserRole.canIngest)));
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(session).setAttribute(anyString(), accessLevelCaptor.capture());
+        AccessLevel level = accessLevelCaptor.getValue();
+        assertEquals(UserRole.canAccess, level.getHighestRole());
+
+        verify(filterChain).doFilter(request, response);
+
+        assertHasAdminAccessPrincipal();
+    }
+
+    @Test
+    public void adminAccessFromGlobalPermissions() throws Exception {
+        GroupsThreadStore.storeUsername("user");
+        when(globalPermissionEvaluator.hasGlobalPrincipal(any())).thenReturn(true);
+        when(globalPermissionEvaluator.getGlobalUserRoles(any())).thenReturn(new HashSet<>(
+                Arrays.asList(UserRole.administrator)));
+
+        filter.doFilterInternal(request, response, filterChain);
+
+        verify(session).setAttribute(anyString(), accessLevelCaptor.capture());
+        AccessLevel level = accessLevelCaptor.getValue();
+        assertEquals(UserRole.administrator, level.getHighestRole());
+
+        verify(filterChain).doFilter(request, response);
+
+        assertHasAdminAccessPrincipal();
+    }
+
+    private void assertHasAdminAccessPrincipal() {
+        assertTrue("Did not set admin_access principal for the request",
+                GroupsThreadStore.getPrincipals().contains(AccessPrincipalConstants.ADMIN_ACCESS_PRINC));
+    }
+
+    private void assertAdminAccessPrincipalNotGranted() {
+        assertFalse("Was granted admin_access principal, which must not be present",
+                GroupsThreadStore.getPrincipals().contains(AccessPrincipalConstants.ADMIN_ACCESS_PRINC));
+    }
+}

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/acl/PatronAccessAssignmentServiceIT.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/acl/PatronAccessAssignmentServiceIT.java
@@ -595,7 +595,7 @@ public class PatronAccessAssignmentServiceIT {
         assertMessageSent(pid);
     }
 
-    @Test
+    @Test(expected = InvalidAssignmentException.class)
     public void addPatronRoleToStaffPrincipal() throws Exception {
         createCollectionInUnit(null);
         PID pid = collObj.getPid();
@@ -603,20 +603,9 @@ public class PatronAccessAssignmentServiceIT {
 
         PatronAccessDetails accessDetails = new PatronAccessDetails();
         accessDetails.setRoles(asList(
-                new RoleAssignment(AUTHENTICATED_PRINC, canViewMetadata)));
+                new RoleAssignment(GRP_PRINC, canViewMetadata)));
 
         patronService.updatePatronAccess(agent, pid, accessDetails);
-
-        RepositoryObject target = repoObjLoader.getRepositoryObject(pid);
-        assertHasAssignment(AUTHENTICATED_PRINC, canViewMetadata, target);
-
-        assertNoEmbargo(target);
-
-        List<String> eventDetails = getEventDetails(target);
-        assertEquals(1, eventDetails.size());
-        assertEventWithDetail(eventDetails, AUTHENTICATED_PRINC + ": " + canViewMetadata.getPropertyString());
-
-        assertMessageSent(pid);
     }
 
     private void createCollectionInUnit(Model collModel) {

--- a/security/src/main/java/edu/unc/lib/dl/acl/util/AccessPrincipalConstants.java
+++ b/security/src/main/java/edu/unc/lib/dl/acl/util/AccessPrincipalConstants.java
@@ -26,5 +26,6 @@ public abstract class AccessPrincipalConstants {
     public final static String PUBLIC_PRINC = "everyone";
     public final static String AUTHENTICATED_PRINC = "authenticated";
     public final static String USER_NAMESPACE = "unc:onyen:";
+    public final static String ADMIN_ACCESS_PRINC = "admin_access";
 
 }

--- a/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetAccessControlFilter.java
+++ b/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetAccessControlFilter.java
@@ -24,9 +24,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import edu.unc.lib.dl.acl.fcrepo4.InheritedAclFactory;
+import edu.unc.lib.dl.acl.util.AccessPrincipalConstants;
 import edu.unc.lib.dl.acl.util.RoleAssignment;
 import edu.unc.lib.dl.data.ingest.solr.exception.IndexingException;
 import edu.unc.lib.dl.data.ingest.solr.indexing.DocumentIndexingPackage;
+import edu.unc.lib.dl.fcrepo4.AdminUnit;
+import edu.unc.lib.dl.fcrepo4.RepositoryPaths;
 import edu.unc.lib.dl.search.solr.model.IndexDocumentBean;
 
 /**
@@ -56,6 +59,12 @@ public class SetAccessControlFilter implements IndexDocumentFilter {
             readPrincipals.add(assignment.getPrincipal());
             staffPrincipals.add(assignment.getPrincipal());
         });
+
+        // Grant visibility to the collections object
+        if (RepositoryPaths.getContentRootPid().equals(dip.getPid())
+                || dip.getContentObject() instanceof AdminUnit) {
+            staffPrincipals.add(AccessPrincipalConstants.ADMIN_ACCESS_PRINC);
+        }
 
         List<RoleAssignment> patronAssignments = aclFactory.getPatronAccess(dip.getPid());
         patronAssignments.forEach(assignment -> {

--- a/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/indexing/DocumentIndexingPackage.java
+++ b/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/indexing/DocumentIndexingPackage.java
@@ -34,6 +34,7 @@ public class DocumentIndexingPackage {
     private PID parentPid;
     private Element mods;
     private IndexDocumentBean document;
+    private ContentObject contentObject;
 
     public DocumentIndexingPackage(PID pid, DocumentIndexingPackage parentDip,
             DocumentIndexingPackageDataLoader loader) {
@@ -55,7 +56,10 @@ public class DocumentIndexingPackage {
     }
 
     public ContentObject getContentObject() throws IndexingException {
-        return loader.getContentObject(this);
+        if (contentObject == null) {
+            contentObject = loader.getContentObject(this);
+        }
+        return contentObject;
     }
 
     public IndexDocumentBean getDocument() {

--- a/static/js/admin/src/ResultObjectActionMenu.js
+++ b/static/js/admin/src/ResultObjectActionMenu.js
@@ -118,7 +118,9 @@ define('ResultObjectActionMenu', [ 'jquery', 'jquery-ui', 'StringUtilities',  'A
 
 			items["viewFits"] = {name: "View FITS"}
 		}
-    items["viewEventLog"] = {name : "View Event Log"};
+		if ($.inArray('viewHidden', metadata.permissions) != -1) {
+			items["viewEventLog"] = {name : "View Event Log"};
+		}
 		
 		// Modification options
 		items["sepedit"] = "";
@@ -167,7 +169,7 @@ define('ResultObjectActionMenu', [ 'jquery', 'jquery-ui', 'StringUtilities',  'A
 		// Export actions
 		if (!isContentRoot) {
 			items["sepexport"] = "";
-			if (metadata.type !== 'File' ) {
+			if (metadata.type !== 'File' && $.inArray('viewHidden', metadata.permissions) != -1) {
 				items["exportCSV"] = {name : 'Export as CSV'};
 			}
 


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2873
* Addresses issue where users that only have staff permissions on a collection can't navigate to that collection
* Fixes error that caused the structure browse not to appear in these scenarios
* Introduces an admin_access group, which is granted to users with admin access
    * This group is granted non-inheriting, view only access to the collections root and all units
* Adjusts query for determining admin ui access to make it safer from user error, only check collections/units for permission grants, and to only consider staff principals.
* Hides "Export as CSV" and "View event log" actions when users don't have sufficient permission to perform them
* During solr indexing, holds a reference to the ContentObject with the DocumentIndexingPackage so it doesn't have to be reloaded from Fedora for each indexing filter.