### PR TITLE
BXC-2876 - Fix flapping test: DirectoryToBagJobTest.interruptionTest

### DIFF
--- a/deposit/src/main/java/edu/unc/lib/deposit/work/AbstractDepositJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/work/AbstractDepositJob.java
@@ -184,7 +184,8 @@ public abstract class AbstractDepositJob implements Runnable {
         if (root == null) {
             root = e;
         }
-        if (root instanceof ClosedByInterruptException || root instanceof ClosedChannelException) {
+        if (root instanceof ClosedByInterruptException || root instanceof ClosedChannelException
+                || root instanceof InterruptedException) {
             throw new JobInterruptedException("Job " + jobUUID
                     + " interrupted during TDB operation in deposit " + depositUUID, e);
         }


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2876
* Interpret InterruptedExceptions causes as JobInterruptedExceptions, as these are thrown if an interrupt occurs while committing to tdb