### PR TITLE
Minor jedis and embedded redis updates

### DIFF
--- a/deposit/pom.xml
+++ b/deposit/pom.xml
@@ -186,7 +186,7 @@
             <artifactId>fcrepo-http-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.kstyrc</groupId>
+            <groupId>it.ozimov</groupId>
             <artifactId>embedded-redis</artifactId>
         </dependency>
     </dependencies>

--- a/metadata/pom.xml
+++ b/metadata/pom.xml
@@ -107,7 +107,7 @@
             <type>pom</type>
         </dependency>
         <dependency>
-            <groupId>com.github.kstyrc</groupId>
+            <groupId>it.ozimov</groupId>
             <artifactId>embedded-redis</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -121,8 +121,8 @@
         <jstl.version>1.2</jstl.version>
         <jsp-api.version>2.2</jsp-api.version>
         
-        <jedis.version>2.9.0</jedis.version>
-        <embedded-redis.version>0.6</embedded-redis.version>
+        <jedis.version>2.9.3</jedis.version>
+        <embedded-redis.version>0.7.3</embedded-redis.version>
         <solr.version>8.5.2</solr.version>
         <metrics.version>5.0.0</metrics.version>
         <jena.version>3.9.0</jena.version>
@@ -905,7 +905,7 @@
                 <version>${jedis.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.github.kstyrc</groupId>
+                <groupId>it.ozimov</groupId>
                 <artifactId>embedded-redis</artifactId>
                 <version>${embedded-redis.version}</version>
                 <scope>test</scope>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -200,7 +200,7 @@
             <type>test-jar</type>
         </dependency>
         <dependency>
-            <groupId>com.github.kstyrc</groupId>
+            <groupId>it.ozimov</groupId>
             <artifactId>embedded-redis</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
Related to https://jira.lib.unc.edu/browse/BXC-2888.
Jesque 2.x is not compatible with Jedis 3, so only a minor upgrade