### PR TITLE
Prevent migration failure when property is not set

### DIFF
--- a/deposit/src/main/java/edu/unc/lib/deposit/work/AbstractDepositJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/work/AbstractDepositJob.java
@@ -54,6 +54,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import edu.unc.lib.dl.event.PremisLogger;
 import edu.unc.lib.dl.event.PremisLoggerFactory;
+import edu.unc.lib.dl.exceptions.RepositoryException;
 import edu.unc.lib.dl.fcrepo4.PIDs;
 import edu.unc.lib.dl.fcrepo4.RepositoryPIDMinter;
 import edu.unc.lib.dl.fcrepo4.RepositoryPathConstants;
@@ -492,10 +493,15 @@ public abstract class AbstractDepositJob implements Runnable {
         while (i.hasNext()) {
             Statement s = i.nextStatement();
             PID fileObjPid = PIDs.get(s.getSubject().getURI());
-            Resource originalResc = s.getResource();
-            String href = originalResc.getProperty(CdrDeposit.stagingLocation).getString();
-            Entry<PID, String> entry = new SimpleEntry<>(fileObjPid, href);
-            results.add(entry);
+            try {
+                Resource originalResc = s.getResource();
+
+                String href = originalResc.getProperty(CdrDeposit.stagingLocation).getString();
+                Entry<PID, String> entry = new SimpleEntry<>(fileObjPid, href);
+                results.add(entry);
+            } catch (Exception e) {
+                throw new RepositoryException("Failed to get stagingLocation for " + fileObjPid, e);
+            }
         }
 
         return results;

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformer.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformer.java
@@ -68,6 +68,7 @@ import java.util.concurrent.RecursiveAction;
 import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.rdf.model.Bag;
 import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
@@ -367,10 +368,9 @@ public class ContentObjectTransformer extends RecursiveAction {
         List<DatastreamVersion> originalVersions = listDatastreamVersions(foxml, ORIGINAL_DS);
         if (originalVersions.size() > 0) {
             DatastreamVersion lastV = originalVersions.get(originalVersions.size() - 1);
-            origResc.addLiteral(CdrDeposit.md5sum, lastV.getMd5());
-            fileResc.addLiteral(CdrDeposit.createTime, lastV.getCreated());
-            fileResc.addLiteral(CdrDeposit.lastModifiedTime, lastV.getCreated());
-            origResc.addProperty(CdrDeposit.size, lastV.getSize());
+            addLiteralIfNotNull(origResc, CdrDeposit.md5sum, lastV.getMd5());
+            addLiteralIfNotNull(fileResc, CdrDeposit.createTime, lastV.getCreated());
+            addLiteralIfNotNull(fileResc, CdrDeposit.lastModifiedTime, lastV.getCreated());
         }
 
         // Populate the original file path
@@ -446,6 +446,12 @@ public class ContentObjectTransformer extends RecursiveAction {
                 .addEventDetail("Object migrated from Boxc 3 to Boxc 5")
                 .addSoftwareAgent(AgentPids.forSoftware(SoftwareAgent.migrationUtil))
                 .writeAndClose();
+    }
+
+    private void addLiteralIfNotNull(Resource subjResc, Property property, Object object) {
+        if (object != null) {
+            subjResc.addLiteral(property, object);
+        }
     }
 
     /**

--- a/migration-util/src/test/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformerTest.java
+++ b/migration-util/src/test/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformerTest.java
@@ -528,7 +528,6 @@ public class ContentObjectTransformerTest {
         // datastreams only have a created time
         assertTrue(child1Resc.hasLiteral(CdrDeposit.lastModifiedTime, DEFAULT_CREATED_DATE));
         assertTrue(origResc.hasLiteral(CdrDeposit.mimetype, "text/xml"));
-        assertTrue(origResc.hasLiteral(CdrDeposit.size, DATA_FILE_SIZE));
         assertTrue(origResc.hasLiteral(CdrDeposit.stagingLocation, dataFilePath.toUri().toString()));
         assertTrue(child1Resc.hasProperty(CdrDeposit.label, "file1"));
 
@@ -724,7 +723,6 @@ public class ContentObjectTransformerTest {
                 fileResc.hasLiteral(CdrDeposit.createTime, DEFAULT_CREATED_DATE));
         // datastreams only have a created time
         assertTrue(fileResc.hasLiteral(CdrDeposit.lastModifiedTime, DEFAULT_CREATED_DATE));
-        assertTrue(origResc.hasLiteral(CdrDeposit.size, DATA_FILE_SIZE));
         assertTrue(origResc.hasLiteral(CdrDeposit.stagingLocation, dataFilePath.toUri().toString()));
         assertTrue(fileResc.hasProperty(CdrDeposit.label, "file1"));
 
@@ -1071,7 +1069,6 @@ public class ContentObjectTransformerTest {
         assertTrue(child1Resc.hasLiteral(CdrDeposit.createTime, DEFAULT_CREATED_DATE));
         assertTrue(child1Resc.hasLiteral(CdrDeposit.lastModifiedTime, DEFAULT_CREATED_DATE));
         assertFalse(origResc.hasProperty(CdrDeposit.mimetype));
-        assertTrue(origResc.hasLiteral(CdrDeposit.size, DATA_FILE_SIZE));
         assertTrue(origResc.hasLiteral(CdrDeposit.stagingLocation, dataFilePath.toUri().toString()));
         assertTrue(child1Resc.hasProperty(CdrDeposit.label, "file1"));
     }


### PR DESCRIPTION
Skip adding size property during migration, check some other values for nulls before adding to model. Add more details to exceptions thrown while pulling original binary list