### PR TITLE
BXC-2938 - Command for cleaning up deposits

### DIFF
--- a/deposit/src/main/java/edu/unc/lib/deposit/work/AbstractDepositJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/work/AbstractDepositJob.java
@@ -18,6 +18,7 @@ package edu.unc.lib.deposit.work;
 import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.HASHED_PATH_DEPTH;
 import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.HASHED_PATH_SIZE;
 import static edu.unc.lib.dl.fcrepo4.RepositoryPaths.idToPath;
+import static edu.unc.lib.dl.fedora.PIDConstants.DEPOSITS_QUALIFIER;
 import static edu.unc.lib.dl.util.DepositConstants.DESCRIPTION_DIR;
 import static edu.unc.lib.dl.util.DepositConstants.HISTORY_DIR;
 import static edu.unc.lib.dl.util.DepositConstants.TECHMD_DIR;
@@ -57,7 +58,6 @@ import edu.unc.lib.dl.event.PremisLoggerFactory;
 import edu.unc.lib.dl.exceptions.RepositoryException;
 import edu.unc.lib.dl.fcrepo4.PIDs;
 import edu.unc.lib.dl.fcrepo4.RepositoryPIDMinter;
-import edu.unc.lib.dl.fcrepo4.RepositoryPathConstants;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.metrics.TimerFactory;
 import edu.unc.lib.dl.persist.api.services.InterruptedLockException;
@@ -202,7 +202,7 @@ public abstract class AbstractDepositJob implements Runnable {
     public void setDepositUUID(String depositUUID) {
         this.depositUUID = depositUUID;
         if (depositUUID != null) {
-            this.depositPID = PIDs.get(RepositoryPathConstants.DEPOSIT_RECORD_BASE, depositUUID);
+            this.depositPID = PIDs.get(DEPOSITS_QUALIFIER, depositUUID);
         }
     }
 

--- a/migration-util/pom.xml
+++ b/migration-util/pom.xml
@@ -186,5 +186,9 @@
             <groupId>org.fcrepo</groupId>
             <artifactId>fcrepo-http-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>it.ozimov</groupId>
+            <artifactId>embedded-redis</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/CleanupDepositsCommand.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/CleanupDepositsCommand.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dcr.migration;
+
+import static edu.unc.lib.dcr.migration.MigrationConstants.OUTPUT_LOGGER;
+import static edu.unc.lib.dl.fedora.PIDConstants.DEPOSITS_QUALIFIER;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.nio.file.Files;
+import java.util.concurrent.Callable;
+
+import org.slf4j.Logger;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.persist.services.deposit.DepositDirectoryManager;
+import edu.unc.lib.dl.persist.services.deposit.DepositModelManager;
+import edu.unc.lib.dl.util.DepositStatusFactory;
+import edu.unc.lib.dl.util.JobStatusFactory;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.ParentCommand;
+
+/**
+ * Utility for cleaning up incomplete deposits
+ * @author bbpennel
+ */
+@Command(name = "cleanup_deposits",
+    description = "Cleans up deposits, including the data dir, redis values and deposit model")
+public class CleanupDepositsCommand implements Callable<Integer> {
+
+    private static final Logger output = getLogger(OUTPUT_LOGGER);
+
+    @ParentCommand
+    private MigrationCLI parentCommand;
+
+    @Parameters(index = "0",
+            description = "Deposit ID, or a comma separate list of deposit ids")
+    private String depositIds;
+
+    private String applicationContextPath = "spring/cleanup-deposits-context.xml";
+
+    @Override
+    public Integer call() throws Exception {
+        long start = System.currentTimeMillis();
+
+        String[] ids = depositIds.split(",");
+
+        output.info("Requesting cleanup of {} deposit(s)", ids.length);
+
+        try (
+                ConfigurableApplicationContext context = new ClassPathXmlApplicationContext(applicationContextPath);
+                DepositModelManager depositModelManager = new DepositModelManager(parentCommand.tdbDir);
+                ){
+            DepositStatusFactory depositStatusFactory = context.getBean(DepositStatusFactory.class);
+            JobStatusFactory jobStatusFactory = context.getBean(JobStatusFactory.class);
+
+            for (String id : ids) {
+                String depositId = id.trim();
+                PID depositPid = PIDs.get(DEPOSITS_QUALIFIER, depositId);
+
+                output.info("===========================================");
+                output.info("Cleaning up deposit: {}", depositId);
+                output.info("===========================================");
+
+                depositModelManager.removeModel(depositPid);
+                output.info("    Removed deposit model");
+
+                DepositDirectoryManager depositDirectoryManager = new DepositDirectoryManager(
+                        depositPid, parentCommand.depositBaseDir, true, false);
+                if (Files.exists(depositDirectoryManager.getDepositDir())) {
+                    depositDirectoryManager.cleanupDepositDirectory();
+                    output.info("    Deleted deposit directory: {}", depositDirectoryManager.getDepositDir());
+                } else {
+                    output.info("    No Deposit directory present");
+                }
+
+                depositStatusFactory.expireKeys(depositId, 0);
+                jobStatusFactory.expireKeys(depositId, 0);
+                output.info("    Deleted deposit/job status details");
+            }
+        }
+
+        output.info("===========================================");
+        output.info("Finished cleanup in {}ms", System.currentTimeMillis() - start);
+        output.info("===========================================");
+
+        return 0;
+    }
+
+    public void setApplicationContextPath(String applicationContextPath) {
+        this.applicationContextPath = applicationContextPath;
+    }
+}

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/CleanupDepositsCommand.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/CleanupDepositsCommand.java
@@ -66,7 +66,7 @@ public class CleanupDepositsCommand implements Callable<Integer> {
         try (
                 ConfigurableApplicationContext context = new ClassPathXmlApplicationContext(applicationContextPath);
                 DepositModelManager depositModelManager = new DepositModelManager(parentCommand.tdbDir);
-                ){
+                ) {
             DepositStatusFactory depositStatusFactory = context.getBean(DepositStatusFactory.class);
             JobStatusFactory jobStatusFactory = context.getBean(JobStatusFactory.class);
 

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/MigrationCLI.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/MigrationCLI.java
@@ -42,7 +42,8 @@ import picocli.CommandLine.Option;
         SubmitDepositCommand.class,
         UpdateModelCommand.class,
         RecalculateDigestsCommand.class,
-        VerifyPremisLogsCommand.class
+        VerifyPremisLogsCommand.class,
+        CleanupDepositsCommand.class
     })
 public class MigrationCLI implements Callable<Integer> {
     private static final Logger output = getLogger(OUTPUT_LOGGER);

--- a/migration-util/src/main/resources/spring/cleanup-deposits-context.xml
+++ b/migration-util/src/main/resources/spring/cleanup-deposits-context.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+    http://www.springframework.org/schema/beans/spring-beans.xsd
+    http://www.springframework.org/schema/context
+    http://www.springframework.org/schema/context/spring-context-4.3.xsd">
+
+    <context:annotation-config />
+    
+    <import resource="service-context.xml"/>
+    
+    <bean id="jedisPool" class="redis.clients.jedis.JedisPool"
+        destroy-method="destroy">
+        <constructor-arg ref="poolConfig"/>
+        <constructor-arg type="String" value="${redis.host:localhost}" />
+        <constructor-arg type="int" value="${redis.port:46380}" />
+    </bean>
+    
+    <bean id="jesqueConfig" class="net.greghaines.jesque.Config">
+        <constructor-arg value="${redis.host:localhost}" type="java.lang.String" />
+        <constructor-arg value="${redis.port:46380}" type="int" />
+        <constructor-arg value="2000" type="int" />
+        <constructor-arg type="java.lang.String">
+            <null />
+        </constructor-arg>
+        <constructor-arg value="resque" type="java.lang.String" />
+        <constructor-arg value="0" type="int" />
+    </bean>
+    
+    <bean id="poolConfig" class="redis.clients.jedis.JedisPoolConfig">
+        <property name="maxIdle" value="15"/>
+        <property name="minIdle" value="2"/>
+        <property name="maxTotal" value="25"/>
+    </bean>
+    
+    <bean id="depositStatusFactory" class="edu.unc.lib.dl.util.DepositStatusFactory">
+        <property name="jedisPool" ref="jedisPool" />
+    </bean>
+
+    <bean id="jobStatusFactory" class="edu.unc.lib.dl.util.JobStatusFactory" >
+        <property name="jedisPool" ref="jedisPool" />
+    </bean>
+</beans>

--- a/migration-util/src/test/java/edu/unc/lib/dcr/migration/CleanupDepositsCommandIT.java
+++ b/migration-util/src/test/java/edu/unc/lib/dcr/migration/CleanupDepositsCommandIT.java
@@ -1,0 +1,375 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dcr.migration;
+
+import static edu.unc.lib.dcr.migration.MigrationConstants.toBxc3Uri;
+import static edu.unc.lib.dl.fedora.PIDConstants.DEPOSITS_QUALIFIER;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.UUID;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Resource;
+import org.jdom2.Document;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import edu.unc.lib.dcr.migration.fcrepo3.ContentModelHelper.ContentModel;
+import edu.unc.lib.dcr.migration.fcrepo3.ContentModelHelper.Relationship;
+import edu.unc.lib.dcr.migration.fcrepo3.DatastreamVersion;
+import edu.unc.lib.dcr.migration.fcrepo3.FoxmlDocumentBuilder;
+import edu.unc.lib.dcr.migration.fcrepo3.FoxmlDocumentHelpers;
+import edu.unc.lib.dl.fcrepo4.CollectionObject;
+import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
+import edu.unc.lib.dl.fcrepo4.RepositoryPIDMinter;
+import edu.unc.lib.dl.fcrepo4.RepositoryPathConstants;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.persist.services.deposit.DepositDirectoryManager;
+import edu.unc.lib.dl.persist.services.deposit.DepositModelManager;
+import edu.unc.lib.dl.test.TestHelper;
+import edu.unc.lib.dl.util.DepositStatusFactory;
+import edu.unc.lib.dl.util.JobStatusFactory;
+import picocli.CommandLine;
+import redis.embedded.RedisServer;
+
+/**
+ * @author bbpennel
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextHierarchy({
+    @ContextConfiguration("/spring-test/test-fedora-container.xml"),
+    @ContextConfiguration("/spring-test/jedis-context.xml"),
+    @ContextConfiguration("/spring-test/cdr-client-container.xml")
+})
+public class CleanupDepositsCommandIT extends AbstractTransformationIT {
+    private static final Logger log = getLogger(CleanupDepositsCommandIT.class);
+
+    private static final String BINARY_CONTENT = "Binary stuff";
+    private static final String BINARY_MD5 = "74dec3bdb7c0cda2c3d501c145d73723";
+
+    @Rule
+    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    private File tdbDir;
+    private File depositBaseDir;
+
+    private DepositModelManager modelManager;
+
+    final PrintStream originalOut = System.out;
+    final ByteArrayOutputStream out = new ByteArrayOutputStream();
+    private String output;
+
+    CommandLine migrationCommand;
+
+    @Autowired
+    private DepositStatusFactory depositStatusFactory;
+    @Autowired
+    private JobStatusFactory jobStatusFactory;
+    @Autowired
+    private RepositoryPIDMinter pidMinter;
+    @Autowired
+    private RepositoryObjectFactory repoObjFactory;
+
+    private CollectionObject destCollObj;
+
+    private static final RedisServer redisServer;
+
+    static {
+        try {
+            redisServer = new RedisServer(46380);
+            redisServer.start();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        redisServer.stop();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        TestHelper.setContentBase("http://localhost:48085/rest");
+        resetOutput();
+
+        datastreamsPath = tmpFolder.newFolder("datastreams").toPath();
+        objectsPath = tmpFolder.newFolder("objects").toPath();
+
+        tdbDir = tmpFolder.newFolder("tdb");
+        depositBaseDir = tmpFolder.newFolder("deposits");
+        File dbFile = tmpFolder.newFile("index_db");
+        System.setProperty("dcr.deposit.dir", depositBaseDir.getAbsolutePath());
+        System.setProperty("dcr.tdb.dir", tdbDir.getAbsolutePath());
+        System.setProperty("dcr.migration.index.url", dbFile.toPath().toUri().toString());
+        System.setProperty("dcr.it.tdr.ingestSource", tmpFolder.getRoot().getAbsolutePath());
+
+        migrationCommand = new CommandLine(new MigrationCLI());
+
+        Map<String, CommandLine> subs = migrationCommand.getSubcommands();
+        CommandLine cleanupCommand = subs.get("cleanup_deposits");
+
+        CleanupDepositsCommand cCommand = (CleanupDepositsCommand) cleanupCommand.getCommand();
+        Path contextPath = Paths.get("src", "test", "resources", "spring-test",
+                "jedis-context.xml");
+        cCommand.setApplicationContextPath(contextPath.toUri().toString());
+
+        output = null;
+    }
+
+    private void resetOutput() {
+        out.reset();
+        System.setOut(new PrintStream(out));
+    }
+
+    @After
+    public void cleanup() {
+        System.setOut(originalOut);
+        System.clearProperty("dcr.tdb.dir");
+        System.clearProperty("dcr.deposit.dir");
+        if (modelManager != null) {
+            modelManager.close();
+        }
+    }
+
+    @Test
+    public void cleanupNonExistentDeposit() throws Exception {
+        String depositId = UUID.randomUUID().toString();
+        PID depositPid = PIDs.get(DEPOSITS_QUALIFIER, depositId);
+        String[] args = new String[] { "cleanup_deposits", depositId };
+        executeExpectSuccess(args);
+
+        assertTrue("Expected output state that model removed",
+                output.contains("Removed deposit model"));
+        assertTrue("Expected output state that directory not present",
+                output.contains("No Deposit directory present"));
+        assertTrue("Expected output state that status deleted",
+                output.contains("Deleted deposit/job status details"));
+
+        modelManager = new DepositModelManager(tdbDir.toString());
+        Model depModel = modelManager.getReadModel(depositPid);
+        assertTrue(depModel.isEmpty());
+
+        assertEquals(0, depositBaseDir.list().length);
+
+        assertTrue(jobStatusFactory.getAllJobs(depositId).isEmpty());
+        assertTrue(depositStatusFactory.get(depositId).isEmpty());
+    }
+
+    @Test
+    public void cleanupOneDepositWithMultiplePresent() throws Exception {
+        destCollObj = repoObjFactory.createCollectionObject(null);
+
+        setupTransformCommand();
+        PID depositPid1 = populateDeposit();
+        String depositId1 = depositPid1.getId();
+        PID depositPid2 = populateDeposit();
+        String depositId2 = depositPid2.getId();
+
+        // Check that data is present prior cleanup
+        modelManager = new DepositModelManager(tdbDir.toString());
+        assertFalse(modelManager.getReadModel(depositPid1).isEmpty());
+        modelManager.end();
+        assertFalse(modelManager.getReadModel(depositPid2).isEmpty());
+        modelManager.end();
+
+        assertFalse(depositStatusFactory.get(depositId1).isEmpty());
+        assertFalse(depositStatusFactory.get(depositId2).isEmpty());
+
+        String[] args = new String[] { "cleanup_deposits", depositId1 };
+        executeExpectSuccess(args);
+
+        DepositDirectoryManager dirManager1 = new DepositDirectoryManager(
+                depositPid1, depositBaseDir.toPath(), true, false);
+
+        assertTrue("Expected output state that model removed",
+                output.contains("Removed deposit model"));
+        assertTrue("Expected output state that directory deleted",
+                output.contains("Deleted deposit directory: " + dirManager1.getDepositDir()));
+        assertEquals("Only expected 1 occurance of cleanup message",
+                1, StringUtils.countMatches(output, "Deleted deposit directory"));
+        assertTrue("Expected output state that status deleted",
+                output.contains("Deleted deposit/job status details"));
+
+        // Verify that data is only gone for the cleaned up deposit
+        assertTrue(modelManager.getReadModel(depositPid1).isEmpty());
+        modelManager.end();
+        assertFalse(modelManager.getReadModel(depositPid2).isEmpty());
+        modelManager.end();
+
+        assertEquals("One deposit directory should still exist", 1, depositBaseDir.list().length);
+        assertEquals(depositPid2.getId(), depositBaseDir.list()[0]);
+
+        assertTrue(depositStatusFactory.get(depositId1).isEmpty());
+        assertFalse(depositStatusFactory.get(depositId2).isEmpty());
+    }
+
+    @Test
+    public void cleanupMultipleDeposits() throws Exception {
+        destCollObj = repoObjFactory.createCollectionObject(null);
+
+        setupTransformCommand();
+        PID depositPid1 = populateDeposit();
+        String depositId1 = depositPid1.getId();
+        PID depositPid2 = populateDeposit();
+        String depositId2 = depositPid2.getId();
+
+        String[] args = new String[] { "cleanup_deposits", depositId1 + "," + depositId2 };
+        executeExpectSuccess(args);
+
+        DepositDirectoryManager dirManager1 = new DepositDirectoryManager(
+                depositPid1, depositBaseDir.toPath(), true, false);
+        DepositDirectoryManager dirManager2 = new DepositDirectoryManager(
+                depositPid2, depositBaseDir.toPath(), true, false);
+
+        assertEquals("Expected 2 occurances of cleanup message",
+                2, StringUtils.countMatches(output, "Removed deposit model"));
+        assertTrue("Expected output state that directory deleted",
+                output.contains("Deleted deposit directory: " + dirManager1.getDepositDir()));
+        assertTrue("Expected output state that directory deleted",
+                output.contains("Deleted deposit directory: " + dirManager2.getDepositDir()));
+        assertEquals("Expected 2 occurances of cleanup message",
+                2, StringUtils.countMatches(output, "Deleted deposit directory"));
+        assertEquals("Expected 2 occurances of cleanup message",
+                2, StringUtils.countMatches(output, "Deleted deposit/job status details"));
+
+        modelManager = new DepositModelManager(tdbDir.toString());
+        // Verify that data is gone for both deposits
+        assertTrue(modelManager.getReadModel(depositPid1).isEmpty());
+        modelManager.end();
+        assertTrue(modelManager.getReadModel(depositPid2).isEmpty());
+        modelManager.end();
+
+        assertEquals(0, depositBaseDir.list().length);
+
+        assertTrue(depositStatusFactory.get(depositId1).isEmpty());
+        assertTrue(depositStatusFactory.get(depositId2).isEmpty());
+    }
+
+    private void setupTransformCommand() {
+        Map<String, CommandLine> subs = migrationCommand.getSubcommands();
+        CommandLine transformCommand = subs.get("tc");
+
+        TransformContentCommand tcCommand = (TransformContentCommand) transformCommand.getCommand();
+        Path contextPath = Paths.get("src", "test", "resources", "spring-test",
+                "cdr-client-container.xml");
+        tcCommand.setApplicationContextPath(contextPath.toUri().toString());
+    }
+
+    private PID populateDeposit() throws Exception {
+        PID filePid = pidMinter.mintContentPid();
+        writeDatastreamFile(filePid, FoxmlDocumentHelpers.ORIGINAL_DS, BINARY_CONTENT);
+        DatastreamVersion ds0 = new DatastreamVersion(BINARY_MD5,
+                FoxmlDocumentHelpers.ORIGINAL_DS, "0",
+                FoxmlDocumentBuilder.DEFAULT_CREATED_DATE,
+                Integer.toString(BINARY_CONTENT.length()),
+                "text/plain",
+                null);
+
+        Model fileModel = createModelWithTypes(filePid, ContentModel.SIMPLE);
+
+        Document foxml2 = new FoxmlDocumentBuilder(filePid, "file")
+                .relsExtModel(fileModel)
+                .withDatastreamVersion(ds0)
+                .build();
+        serializeFoxml(filePid, foxml2);
+
+        addPremisLog(filePid);
+
+        PID folderPid = pidMinter.mintContentPid();
+        Model folderModel = createModelWithTypes(folderPid, ContentModel.CONTAINER);
+        Resource folderResc = folderModel.getResource(toBxc3Uri(folderPid));
+        Resource fileResc = folderModel.getResource(toBxc3Uri(filePid));
+        folderResc.addProperty(Relationship.contains.getProperty(), fileResc);
+
+        serializeBasicObject(folderPid, "folder", folderModel);
+
+        indexFiles();
+
+        String[] args = new String[] {
+                "--redis-port", "46380",
+                "tc", folderPid.getId(),
+                "--deposit-into", destCollObj.getPid().getId()};
+        executeExpectSuccess(args);
+
+        assertTrue("Expected one transformation successful",
+                output.contains(" 2/2 "));
+
+        PID depositPid = extractDepositPid(output);
+        resetOutput();
+        return depositPid;
+    }
+
+    private PID extractDepositPid(String output) {
+        String fieldText = "Populating deposit: ";
+        int start = output.indexOf(fieldText);
+        if (start == -1) {
+            fail("No deposit id output");
+        }
+        start += fieldText.length();
+        int end = output.indexOf("\n", start);
+        String id = output.substring(start, end);
+        return PIDs.get(RepositoryPathConstants.DEPOSIT_RECORD_BASE, id);
+    }
+
+    private void indexFiles() {
+        String[] indexArgs = new String[] { "pi", "populate",
+                objectsPath.toString(),
+                datastreamsPath.toString(),
+                "-l" };
+        migrationCommand.execute(indexArgs);
+    }
+
+    private void serializeBasicObject(PID pid, String title, Model model) throws IOException {
+        Document foxml = new FoxmlDocumentBuilder(pid, title)
+                .relsExtModel(model)
+                .build();
+        serializeFoxml(pid, foxml);
+    }
+
+    private void executeExpectSuccess(String[] args) {
+        int result = migrationCommand.execute(args);
+        output = out.toString();
+        if (result != 0) {
+            System.setOut(originalOut);
+            log.error(output);
+            fail("Expected command to result in success: " + String.join(" ", args));
+        }
+    }
+}

--- a/migration-util/src/test/resources/spring-test/jedis-context.xml
+++ b/migration-util/src/test/resources/spring-test/jedis-context.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+
+    <context:property-placeholder />
+    
+    <bean id="jedisPool" class="redis.clients.jedis.JedisPool"
+        destroy-method="destroy">
+        <constructor-arg ref="poolConfig"/>
+        <constructor-arg type="String" value="${redis.host:localhost}" />
+        <constructor-arg type="int" value="${redis.port:46380}" />
+    </bean>
+    
+    <bean id="jesqueConfig" class="net.greghaines.jesque.Config">
+        <constructor-arg value="localhost" type="java.lang.String" />
+        <constructor-arg value="46380" type="int" />
+        <constructor-arg value="2000" type="int" />
+        <constructor-arg type="java.lang.String">
+            <null />
+        </constructor-arg>
+        <constructor-arg value="resque" type="java.lang.String" />
+        <constructor-arg value="0" type="int" />
+    </bean>
+    
+    <bean id="poolConfig" class="redis.clients.jedis.JedisPoolConfig">
+        <property name="maxIdle" value="15"/>
+        <property name="minIdle" value="2"/>
+        <property name="maxTotal" value="25"/>
+    </bean>
+    
+    <bean id="depositStatusFactory" class="edu.unc.lib.dl.util.DepositStatusFactory">
+        <property name="jedisPool" ref="jedisPool" />
+    </bean>
+    
+    <bean id="pipelineStatusFactory" class="edu.unc.lib.dl.util.DepositPipelineStatusFactory">
+        <property name="jedisPool" ref="jedisPool" />
+    </bean>
+    
+    <bean id="jobStatusFactory" class="edu.unc.lib.dl.util.JobStatusFactory" >
+        <property name="jedisPool" ref="jedisPool" />
+    </bean>
+    
+    <bean id="activityMetricsClient" class="edu.unc.lib.dl.reporting.ActivityMetricsClient" >
+        <property name="jedisPool" ref="jedisPool" />
+    </bean>
+</beans>

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/deposit/DepositDirectoryManager.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/deposit/DepositDirectoryManager.java
@@ -54,6 +54,10 @@ public class DepositDirectoryManager {
     private boolean hashNesting;
 
     public DepositDirectoryManager(PID depositPid, Path depositBaseDir, boolean hashNesting) {
+        this(depositPid, depositBaseDir, hashNesting, true);
+    }
+
+    public DepositDirectoryManager(PID depositPid, Path depositBaseDir, boolean hashNesting, boolean createDirs) {
         this.depositPid = depositPid;
         this.depositDir = depositBaseDir.resolve(this.depositPid.getId());
         this.descriptionDir = depositDir.resolve(DESCRIPTION_DIR);
@@ -61,7 +65,9 @@ public class DepositDirectoryManager {
         this.eventsDir = depositDir.resolve(EVENTS_DIR);
         this.hashNesting = hashNesting;
 
-        createDepositDirectory();
+        if (createDirs) {
+            createDepositDirectory();
+        }
     }
 
     public void createDepositDirectory() {

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/deposit/DepositModelManager.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/deposit/DepositModelManager.java
@@ -182,6 +182,7 @@ public class DepositModelManager implements Closeable {
             }
             dataset.begin(ReadWrite.WRITE);
         }
+        log.info("Removing deposit model for {}", uri);
         dataset.removeNamedModel(uri);
         dataset.commit();
     }


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2938

Adds a command for cleaning up one or more deposits. This includes removing the deposit directory, redis data, and jena TDB data. This command has no affect on objects already ingested into the repository, and is intended for use in cleaning up failed deposits.

This is very similar, but not quite the same as CleanupDepositJob, which also cleans up staged files.