### PR TITLE
BXC-2947/2948 - Fedora connection and imagemagick error fixes

### DIFF
--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/solr/SolrIngestProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/solr/SolrIngestProcessor.java
@@ -70,6 +70,8 @@ public class SolrIngestProcessor implements Processor {
         final Message in = exchange.getIn();
         String fcrepoUri = (String) in.getHeader(FCREPO_URI);
 
+        log.debug("Processing solr request for {}", fcrepoUri);
+
         List<PID> targetPids = new ArrayList<>();
         PID targetPid = PIDs.get(fcrepoUri);
         String resourceTypes = (String) in.getHeader(FCREPO_RESOURCE_TYPE);

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/images/AddDerivativeProcessorTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/images/AddDerivativeProcessorTest.java
@@ -119,6 +119,9 @@ public class AddDerivativeProcessorTest {
     @Test
     public void executionFailedTest() throws Exception {
         when(result.getExitValue()).thenReturn(1);
+        String stderr = "convert: no images defined `/tmp/testtxt-large.png'"
+                + " @ error/convert.c/ConvertImageCommand/3235.";
+        when(result.getStderr()).thenReturn(new ByteArrayInputStream(stderr.getBytes()));
 
         mvFile = new File(finalDir.getAbsolutePath() + "/"+ fileName + ".PNG");
         processor.process(exchange);
@@ -131,5 +134,16 @@ public class AddDerivativeProcessorTest {
         when(result.getStdout()).thenReturn(new ByteArrayInputStream(".png".getBytes()));
 
         processor.process(exchange);
+    }
+
+    @Test
+    public void executionExit1TagIgnoredErrorTest() throws Exception {
+        when(result.getExitValue()).thenReturn(1);
+        when(result.getStderr()).thenReturn(getClass().getResourceAsStream("/convert/ignore_tag_stderr.txt"));
+
+        mvFile = new File(finalDir.getAbsolutePath() + "/"+ fileName + ".PNG");
+        processor.process(exchange);
+
+        assertTrue(mvFile.exists());
     }
 }

--- a/services-camel/src/test/resources/convert/ignore_tag_stderr.txt
+++ b/services-camel/src/test/resources/convert/ignore_tag_stderr.txt
@@ -1,0 +1,10 @@
+convert: SamplesPerPixel tag is missing, applying correct SamplesPerPixel value of 3. `TIFFReadDirectory' @ warning/tiff.c/TIFFWarnings/958.
+convert: Subsampling tag is not set, yet subsampling inside JPEG data [2,1] does not match default values [2,2]; assuming subsampling inside JPEG data is correct. `OJPEGSubsamplingCorrect' @ warning/tiff.c/TIFFWarnings/958.
+convert: Incorrect count for "MakerNote"; tag ignored. `TIFFFetchNormalTag' @ error/tiff.c/TIFFErrors/609.
+convert: Wrong data type 3 for "PixelXDimension"; tag ignored. `TIFFReadCustomDirectory' @ warning/tiff.c/TIFFWarnings/958.
+convert: Wrong data type 3 for "PixelYDimension"; tag ignored. `TIFFReadCustomDirectory' @ warning/tiff.c/TIFFWarnings/958.
+convert: Unknown field with tag 40965 (0xa005) encountered. `TIFFReadCustomDirectory' @ warning/tiff.c/TIFFWarnings/958.
+convert: Photometric tag is missing, assuming data is YCbCr. `TIFFReadDirectory' @ warning/tiff.c/TIFFWarnings/958.
+convert: SamplesPerPixel tag is missing, applying correct SamplesPerPixel value of 3. `TIFFReadDirectory' @ warning/tiff.c/TIFFWarnings/958.
+convert: Subsampling tag is not set, yet subsampling inside JPEG data [2,1] does not match default values [2,2]; assuming subsampling inside JPEG data is correct. `OJPEGSubsamplingCorrect' @ warning/tiff.c/TIFFWarnings/958.
+convert: Depreciated and troublesome old-style JPEG compression mode, please convert to new-style JPEG compression and notify vendor of writing software. `OJPEGSetupDecode' @ warning/tiff.c/TIFFWarnings/958.


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2947
https://jira.lib.unc.edu/browse/BXC-2948

* Prevent running out of fedora connections by avoiding opening a connection inside of a connection
* Ignore some errors from imagemagick which don't appear to impact the derivative created