### PR TITLE
BXC-2968 - Avoid returning full text field in queries

### DIFF
--- a/services-camel/src/main/resources/solr.properties
+++ b/services-camel/src/main/resources/solr.properties
@@ -15,6 +15,7 @@ solr.field.ROLE_GROUP=roleGroup
 solr.field.READ_GROUP=readGroup
 solr.field.ADMIN_GROUP=adminGroup
 solr.field.STATUS=status
+solr.field.CONTENT_STATUS=contentStatus
 solr.field.RESOURCE_TYPE=resourceType
 solr.field.RESOURCE_TYPE_SORT=resourceTypeSort
 solr.field.DISPLAY_ORDER=displayOrder
@@ -55,6 +56,8 @@ solr.field.DEFAULT_INDEX=text
 solr.field.TITLE_INDEX=titleIndex
 solr.field.CONTRIBUTOR_INDEX=contributorIndex
 solr.field.SUBJECT_INDEX=subjectIndex
+solr.field.VERSION=_version_
+solr.field.IS_PART=isPart
 #Dynamic fields
 solr.field.RLA_SITE_CODE=rla_site_code_d
 solr.field.RLA_CATALOG_NUMBER=rla_catalog_number_d

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/processing/RunEnhancementsService.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/processing/RunEnhancementsService.java
@@ -18,6 +18,7 @@ package edu.unc.lib.dl.cdr.services.processing;
 import static edu.unc.lib.dl.model.DatastreamType.ORIGINAL_FILE;
 import static edu.unc.lib.dl.services.RunEnhancementsMessageHelpers.makeEnhancementOperationBody;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.jdom2.Document;
@@ -54,6 +55,10 @@ public class RunEnhancementsService {
     private static final Logger LOG = LoggerFactory.getLogger(RunEnhancementsService.class);
     private static final Timer timer = TimerFactory.createTimerForClass(RunEnhancementsService.class);
 
+    private final List<String> resultsFieldList = Arrays.asList(
+            SearchFieldKeys.DATASTREAM.name(), SearchFieldKeys.ID.name(),
+            SearchFieldKeys.RESOURCE_TYPE.name());
+
     private AccessControlService aclService;
 
     private MessageSender messageSender;
@@ -83,6 +88,7 @@ public class RunEnhancementsService {
                 if (!(repositoryObjectLoader.getRepositoryObject(pid) instanceof FileObject)) {
                     SearchState searchState = new SearchState();
                     searchState.getFacets().put(SearchFieldKeys.RESOURCE_TYPE.name(), ResourceType.File.name());
+                    searchState.setResultFields(resultsFieldList);
 
                     SearchRequest searchRequest = new SearchRequest();
                     searchRequest.setAccessGroups(agent.getPrincipals());

--- a/solr-search/src/main/java/edu/unc/lib/dl/search/solr/service/AbstractQueryService.java
+++ b/solr-search/src/main/java/edu/unc/lib/dl/search/solr/service/AbstractQueryService.java
@@ -16,6 +16,7 @@
 package edu.unc.lib.dl.search.solr.service;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -37,6 +38,47 @@ import edu.unc.lib.dl.search.solr.util.SolrSettings;
  *
  */
 public abstract class AbstractQueryService {
+    private final static List<String> DEFAULT_RESULT_FIELDS = Arrays.asList(
+            SearchFieldKeys.ABSTRACT.name(),
+            SearchFieldKeys.ADMIN_GROUP.name(),
+            SearchFieldKeys.ANCESTOR_IDS.name(),
+            SearchFieldKeys.ANCESTOR_PATH.name(),
+            SearchFieldKeys.CITATION.name(),
+            SearchFieldKeys.COLLECTION_ID.name(),
+            SearchFieldKeys.CONTENT_STATUS.name(),
+            SearchFieldKeys.CONTENT_TYPE.name(),
+            SearchFieldKeys.CONTRIBUTOR.name(),
+            SearchFieldKeys.CREATOR.name(),
+            SearchFieldKeys.DATASTREAM.name(),
+            SearchFieldKeys.DATE_ADDED.name(),
+            SearchFieldKeys.DATE_CREATED.name(),
+            SearchFieldKeys.DATE_UPDATED.name(),
+            SearchFieldKeys.DEPARTMENT.name(),
+            SearchFieldKeys.FILESIZE.name(),
+            SearchFieldKeys.FILESIZE_TOTAL.name(),
+            SearchFieldKeys.FINDING_AID_LINK.name(),
+            SearchFieldKeys.ID.name(),
+            SearchFieldKeys.IDENTIFIER.name(),
+            SearchFieldKeys.IS_PART.name(),
+            SearchFieldKeys.KEYWORD.name(),
+            SearchFieldKeys.LABEL.name(),
+            SearchFieldKeys.LANGUAGE.name(),
+            SearchFieldKeys.LAST_INDEXED.name(),
+            SearchFieldKeys.OTHER_TITLES.name(),
+            SearchFieldKeys.PARENT_COLLECTION.name(),
+            SearchFieldKeys.PARENT_UNIT.name(),
+            SearchFieldKeys.READ_GROUP.name(),
+            SearchFieldKeys.RELATIONS.name(),
+            SearchFieldKeys.RESOURCE_TYPE.name(),
+            SearchFieldKeys.ROLE_GROUP.name(),
+            SearchFieldKeys.ROLLUP_ID.name(),
+            SearchFieldKeys.STATUS.name(),
+            SearchFieldKeys.STATUS_TAGS.name(),
+            SearchFieldKeys.SUBJECT.name(),
+            SearchFieldKeys.TIMESTAMP.name(),
+            SearchFieldKeys.TITLE.name(),
+            SearchFieldKeys.VERSION.name());
+
     @Autowired
     protected SearchSettings searchSettings;
     @Autowired
@@ -109,6 +151,24 @@ public abstract class AbstractQueryService {
                     sortOrder = sortOrder.reverse();
                 }
                 solrQuery.addSort(solrSettings.getFieldName(sortField.getFieldName()), sortOrder);
+            }
+        }
+    }
+
+    /**
+     * Adds the specified result fields to the solrQuery, or if no resultFields
+     * are provided, then the default result fields are added.
+     * @param resultFields
+     * @param solrQuery
+     */
+    protected void addResultFields(List<String> resultFields, SolrQuery solrQuery) {
+        if (resultFields == null) {
+            resultFields = DEFAULT_RESULT_FIELDS;
+        }
+        for (String field : resultFields) {
+            String solrFieldName = solrSettings.getFieldName(field);
+            if (solrFieldName != null) {
+                solrQuery.addField(solrFieldName);
             }
         }
     }

--- a/solr-search/src/main/java/edu/unc/lib/dl/search/solr/service/NeighborQueryService.java
+++ b/solr-search/src/main/java/edu/unc/lib/dl/search/solr/service/NeighborQueryService.java
@@ -85,7 +85,7 @@ public class NeighborQueryService extends AbstractQueryService {
 
         // Query for a window of results to either side of the target
         solrQuery.setRows(windowSize - 1);
-        solrQuery.setFields(new String[0]);
+        addResultFields(null, solrQuery);
 
         // Clone base query for reuse in getting succeeding neighbors
         SolrQuery succeedingQuery = solrQuery.getCopy();

--- a/solr-search/src/main/java/edu/unc/lib/dl/search/solr/service/SolrSearchService.java
+++ b/solr-search/src/main/java/edu/unc/lib/dl/search/solr/service/SolrSearchService.java
@@ -102,12 +102,7 @@ public class SolrSearchService extends AbstractQueryService {
             return null;
         }
 
-        // Restrict the result fields if set
-        if (idRequest.getResultFields() != null) {
-            for (String field : idRequest.getResultFields()) {
-                solrQuery.addField(solrSettings.getFieldName(field));
-            }
-        }
+        addResultFields(idRequest.getResultFields(), solrQuery);
 
         solrQuery.setQuery(query.toString());
         solrQuery.setRows(1);
@@ -157,12 +152,7 @@ public class SolrSearchService extends AbstractQueryService {
 
         query.append(")");
 
-        // Restrict the result fields if set
-        if (listRequest.getResultFields() != null) {
-            for (String field : listRequest.getResultFields()) {
-                solrQuery.addField(solrSettings.getFieldName(field));
-            }
-        }
+        addResultFields(listRequest.getResultFields(), solrQuery);
 
         solrQuery.setQuery(query.toString());
         solrQuery.setRows(listRequest.getIds().size());
@@ -333,14 +323,7 @@ public class SolrSearchService extends AbstractQueryService {
         // Add query
         solrQuery.setQuery(query.toString());
 
-        if (searchState.getResultFields() != null) {
-            for (String field : searchState.getResultFields()) {
-                String solrFieldName = solrSettings.getFieldName(field);
-                if (solrFieldName != null) {
-                    solrQuery.addField(solrFieldName);
-                }
-            }
-        }
+        addResultFields(searchState.getResultFields(), solrQuery);
 
         if (searchState.getRollup() != null && searchState.getRollup()) {
             solrQuery.set(GroupParams.GROUP, true);


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2968
* Add a default set of solr result fields when none is provided, to avoid returning OOM issues caused by returning fields intended for searching.
* Set list of result fields for run enhancements query