### PR TITLE
BXC-2970 - Override provided mimetype in a deposit

### DIFF
--- a/deposit/src/main/java/edu/unc/lib/deposit/validate/ExtractTechnicalMetadataJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/validate/ExtractTechnicalMetadataJob.java
@@ -23,6 +23,7 @@ import static edu.unc.lib.dl.xml.SecureXMLFactory.createSAXBuilder;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.newBufferedWriter;
 import static org.apache.commons.lang3.StringUtils.substringBeforeLast;
+import static org.springframework.util.MimeTypeUtils.APPLICATION_OCTET_STREAM_VALUE;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -36,6 +37,7 @@ import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Objects;
 
 import javax.annotation.PostConstruct;
 
@@ -60,6 +62,7 @@ import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.util.MimeTypeUtils;
 
 import edu.unc.lib.deposit.work.AbstractDepositJob;
 import edu.unc.lib.deposit.work.JobFailedException;
@@ -67,6 +70,7 @@ import edu.unc.lib.deposit.work.JobInterruptedException;
 import edu.unc.lib.dl.fcrepo4.PIDs;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.model.DatastreamPids;
+import edu.unc.lib.dl.util.MimetypeHelpers;
 import edu.unc.lib.dl.util.URIUtil;
 
 /**
@@ -327,41 +331,69 @@ public class ExtractTechnicalMetadataJob extends AbstractDepositJob {
      * generated value is preferred.
      *
      * @param objResc
-     * @param fitsMimetype
+     * @param fitsExtractMimetype
      */
-    private void overrideDepositMimetype(Resource objResc, String fitsMimetype) {
+    private void overrideDepositMimetype(Resource objResc, String fitsExtractMimetype) {
+        String rescId = objResc.getURI();
+        // normalize fits mimetype
+        final String fitsMimetype = MimetypeHelpers.formatMimetype(fitsExtractMimetype);
+
         // If the file was provided with a meaningful mimetype, continue using that
         Statement mimetypeStmt = objResc.getProperty(mimetype);
+        final String providedMimetype;
         if (mimetypeStmt != null) {
-            String providedMimetype = mimetypeStmt.getString();
-            if (isMimetypeMeaningful(providedMimetype)) {
-                log.debug("Provided mimetype {} used for {}", providedMimetype, objResc.getURI());
-                return;
-            }
+            providedMimetype = MimetypeHelpers.formatMimetype(mimetypeStmt.getString());
+        } else {
+            providedMimetype = null;
         }
 
-        commit(() -> {
-            // Not using a provided mimetype, so use the FITS mimetype
-            if (isMimetypeMeaningful(fitsMimetype)) {
-                objResc.removeAll(mimetype)
-                        .addProperty(mimetype, fitsMimetype);
-            } else {
-                objResc.removeAll(mimetype)
-                        .addProperty(mimetype, "application/octet-stream");
-            }
-        });
+        if (fitsMimetype != null && Objects.equals(providedMimetype, fitsMimetype)) {
+            log.debug("FITS mimetype and provided mimetype {} agree for {}, skipping override",
+                    providedMimetype, rescId);
+            return;
+        }
+
+        int fitsRank = rankMimetype(fitsMimetype);
+        int providedRank = rankMimetype(providedMimetype);
+
+        // No meaningful mimetypes, so remove provided and replace with default
+        if (providedRank < 0 && fitsRank < 0) {
+            commit(() -> {
+                if (providedMimetype != null) {
+                    objResc.removeAll(mimetype);
+                }
+                objResc.addProperty(mimetype, APPLICATION_OCTET_STREAM_VALUE);
+            });
+            log.warn("No meaningful mimetype for {}, removed provided value '{}' and added default",
+                    rescId, providedMimetype);
+            return;
+        }
+
+        if (fitsRank > providedRank) {
+            commit(() -> {
+                if (providedMimetype != null) {
+                    objResc.removeAll(mimetype);
+                }
+                objResc.addProperty(mimetype, fitsMimetype);
+            });
+            log.debug("Overrode provided mimetype {} for {} with extracted mimetype {}",
+                    providedMimetype, rescId, fitsMimetype);
+        } else {
+            log.debug("Retaining provided mimetype {} for {}", providedMimetype, objResc.getURI());
+        }
     }
 
-    /**
-     * Determines if the given mimetype is a meaningful value, meaning not empty
-     * or generic
-     *
-     * @param mimetype
-     * @return
-     */
-    private boolean isMimetypeMeaningful(String mimetype) {
-        return mimetype != null && mimetype.trim().length() > 0
-                && !mimetype.contains("octet-stream");
+    private int rankMimetype(String mimetype) {
+        if (!MimetypeHelpers.isValidMimetype(mimetype)) {
+            return -1;
+        }
+        if (mimetype.equals(APPLICATION_OCTET_STREAM_VALUE)) {
+            return  0;
+        }
+        if (mimetype.equals(MimeTypeUtils.TEXT_PLAIN_VALUE)) {
+            return  1;
+        }
+        return 2;
     }
 
     private Element getObjectCharacteristics(Document premisDoc) {

--- a/deposit/src/test/java/edu/unc/lib/deposit/validate/ExtractTechnicalMetadataJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/validate/ExtractTechnicalMetadataJobTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.util.MimeTypeUtils.APPLICATION_OCTET_STREAM_VALUE;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -53,6 +54,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.springframework.util.MimeTypeUtils;
 
 import edu.unc.lib.deposit.fcrepo4.AbstractDepositJobTest;
 import edu.unc.lib.dl.event.PremisEventBuilder;
@@ -227,6 +229,45 @@ public class ExtractTechnicalMetadataJobTest extends AbstractDepositJobTest {
 
         // Providing octet stream mimetype to be overrridden
         PID filePid = addFileObject(depositBag, IMAGE_FILEPATH, OCTET_MIMETYPE, null);
+        job.closeModel();
+
+        job.run();
+
+        verifyFileResults(filePid, IMAGE_MIMETYPE, IMAGE_FORMAT, IMAGE_MD5, IMAGE_FILEPATH, 1);
+    }
+
+    @Test
+    public void ignoreInvalidProvidedTest() throws Exception {
+        respondWithFile("/fitsReports/unknownReport.xml");
+
+        // Providing octet stream mimetype to be overrridden
+        PID filePid = addFileObject(depositBag, UNKNOWN_FILEPATH, "notvalid", null);
+        job.closeModel();
+
+        job.run();
+
+        verifyFileResults(filePid, APPLICATION_OCTET_STREAM_VALUE, UNKNOWN_FORMAT, UNKNOWN_MD5, UNKNOWN_FILEPATH, 1);
+    }
+
+    @Test
+    public void retainMoreMeaningfulProvidedMimetypeTest() throws Exception {
+        respondWithFile("/fitsReports/textReport.xml");
+
+        // Providing octet stream mimetype to be overrridden
+        PID filePid = addFileObject(depositBag, "/path/text.txt", "application/json", null);
+        job.closeModel();
+
+        job.run();
+
+        verifyFileResults(filePid, "application/json", "Text", IMAGE_MD5, "/path/text.txt", 1);
+    }
+
+    @Test
+    public void overrideProvidedTextPlainWithMoreMeaningful() throws Exception {
+        respondWithFile("/fitsReports/imageReport.xml");
+
+        // Providing octet stream mimetype to be overrridden
+        PID filePid = addFileObject(depositBag, IMAGE_FILEPATH, MimeTypeUtils.TEXT_PLAIN_VALUE, null);
         job.closeModel();
 
         job.run();

--- a/deposit/src/test/resources/fitsReports/textReport.xml
+++ b/deposit/src/test/resources/fitsReports/textReport.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<fits xmlns="http://hul.harvard.edu/ois/xml/ns/fits/fits_output" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hul.harvard.edu/ois/xml/ns/fits/fits_output http://hul.harvard.edu/ois/xml/xsd/fits/fits_output.xsd" version="1.0.5" timestamp="2/19/17 11:29 AM">
+  <identification>
+    <identity format="Text" mimetype="text/plain" toolname="FITS" toolversion="1.0.5">
+      <tool toolname="Jhove" toolversion="1.11" />
+      <tool toolname="file utility" toolversion="5.04" />
+    </identity>
+  </identification>
+  <fileinfo>
+    <size toolname="Jhove" toolversion="1.11">308910</size>
+    <filepath toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">/path/text.txt</filepath>
+    <filename toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">text.txt</filename>
+    <md5checksum toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">2b8dac0b2c0ca845dc8d517a2792dcf4</md5checksum>
+    <fslastmodified toolname="OIS File Information" toolversion="0.2" status="SINGLE_RESULT">1474571269000</fslastmodified>
+  </fileinfo>
+</fits>

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectFactory.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectFactory.java
@@ -17,6 +17,7 @@ package edu.unc.lib.dl.fcrepo4;
 
 import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.FCR_METADATA;
 import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.METADATA_CONTAINER;
+import static edu.unc.lib.dl.util.MimetypeHelpers.formatMimetype;
 import static edu.unc.lib.dl.util.RDFModelUtil.TURTLE_MIMETYPE;
 import static org.fcrepo.client.ExternalContentHandling.PROXY;
 import static org.fcrepo.client.FedoraTypes.LDP_NON_RDF_SOURCE;
@@ -691,10 +692,6 @@ public class RepositoryObjectFactory {
 
     private void persistTripleToFedora(URI subject, String sparqlUpdate) {
         sparqlUpdateService.executeUpdate(subject.toString(), sparqlUpdate);
-    }
-
-    private String formatMimetype(String mimetype) {
-        return (mimetype != null) ? mimetype.trim().split("[;,]")[0] : null;
     }
 
     private URI createContentContainerObject(URI path, Model model) throws FedoraException {

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/util/MimetypeHelpers.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/util/MimetypeHelpers.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.util;
+
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Helper methods for working with mimetypes
+ *
+ * @author bbpennel
+ */
+public class MimetypeHelpers {
+
+    private final static Pattern VALID_MIMETYPE_PATTERN = Pattern.compile("\\w+/[-+.\\w]+");
+
+    private MimetypeHelpers() {
+    }
+
+    /**
+     * @param mimetype
+     * @return true if the given mimetype appears to be a valid mimetype
+     */
+    public static boolean isValidMimetype(String mimetype) {
+        if (StringUtils.isBlank(mimetype)) {
+            return false;
+        }
+        return VALID_MIMETYPE_PATTERN.matcher(mimetype).matches();
+    }
+
+    /**
+     * Normalize the given mimetype, removing parameters and converting to lowercase
+     * @param mimetype
+     * @return
+     */
+    public static String formatMimetype(String mimetype) {
+        return (mimetype != null) ? mimetype.trim().toLowerCase().split("[;,]")[0] : null;
+    }
+}


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2970
* Override provided mimetype in a deposit with FITS mimetype if the latter is more meaningful. 
* Ranks mimetypes, with text/plain ranked lower than most other mimetypes
* Adds utility class for mimetypes