### PR TITLE
BXC-2959 - Refactor fixity check job to run checks in parallel

### DIFF
--- a/deposit/src/main/java/edu/unc/lib/deposit/validate/FixityCheckJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/validate/FixityCheckJob.java
@@ -23,10 +23,19 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
@@ -34,9 +43,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import edu.unc.lib.deposit.work.AbstractDepositJob;
+import edu.unc.lib.deposit.work.JobInterruptedException;
 import edu.unc.lib.dl.event.PremisEventBuilder;
 import edu.unc.lib.dl.event.PremisLogger;
 import edu.unc.lib.dl.exceptions.InvalidChecksumException;
+import edu.unc.lib.dl.exceptions.RepositoryException;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.model.AgentPids;
 import edu.unc.lib.dl.persist.services.deposit.DepositModelHelpers;
@@ -49,6 +60,11 @@ import edu.unc.lib.dl.util.SoftwareAgentConstants.SoftwareAgent;
  * Calculates digests for staged files, performing a fixity check if existing
  * digests were provided with the deposit.
  *
+ * The job will perform fixity checks concurrently using a thread pool. The results of
+ * the checks are periodically flushed the deposit model and premis logs. The number of
+ * fixity check jobs queued at one time is limited in order to avoid blocking other
+ * deposit jobs for long periods of time.
+ *
  * @author bbpennel
  */
 public class FixityCheckJob extends AbstractDepositJob {
@@ -57,9 +73,26 @@ public class FixityCheckJob extends AbstractDepositJob {
     private static final Collection<DigestAlgorithm> REQUIRED_ALGS = Collections.singleton(
             DigestAlgorithm.DEFAULT_ALGORITHM);
 
+    private ExecutorService executorService;
+
+    private AtomicBoolean donePerformingChecks;
+    private AtomicBoolean isInterrupted;
+    private Object flushingLock = new Object();
+
+    private int flushRate = 5000;
+    // Should be higher than the number of workers
+    private int maxQueuedJobs = 10;
+
+    private Deque<Future<?>> fixityFutures;
+    private BlockingDeque<FixityCheckResult> fixityResults;
+
     public FixityCheckJob(String uuid, String depositUUID) {
         super(uuid, depositUUID);
         this.rollbackDatasetOnFailure = false;
+        donePerformingChecks = new AtomicBoolean(false);
+        isInterrupted = new AtomicBoolean(false);
+        fixityResults = new LinkedBlockingDeque<>();
+        fixityFutures = new ConcurrentLinkedDeque<>();
     }
 
     @Override
@@ -70,39 +103,64 @@ public class FixityCheckJob extends AbstractDepositJob {
         List<Entry<PID, String>> stagingList = getOriginalStagingPairList(model);
         setTotalClicks(stagingList.size());
 
-        for (Entry<PID, String> stagingEntry : stagingList) {
-            PID rescPid = stagingEntry.getKey();
-            // Skip already checked files
-            if (isObjectCompleted(rescPid)) {
-                continue;
+        startResultRegistrar();
+
+        try {
+            for (Entry<PID, String> stagingEntry : stagingList) {
+                PID rescPid = stagingEntry.getKey();
+                // Skip already checked files
+                if (isObjectCompleted(rescPid)) {
+                    log.debug("Skipping over already completed fixity check for {}", rescPid.getId());
+                    continue;
+                }
+
+                interruptJobIfStopped();
+
+                // Wait for some of the jobs to finish before queuing more to avoid blocking all other deposits
+                while (fixityFutures.size() > maxQueuedJobs) {
+                    fixityFutures.pop().get();
+                }
+
+                log.debug("Queuing fixity check for {}", rescPid.getId());
+
+                String stagedPath = stagingEntry.getValue();
+                URI stagedUri = URI.create(stagedPath);
+
+                Resource objResc = model.getResource(rescPid.getRepositoryPath());
+                Resource origResc = DepositModelHelpers.getDatastream(objResc);
+
+                Map<DigestAlgorithm, String> existingDigests = getDigestsForResource(origResc);
+
+                Future<?> future = executorService.submit(new FixityCheckRunnable(rescPid, stagedUri, origResc, existingDigests));
+                fixityFutures.offer(future);
             }
 
-            interruptJobIfStopped();
-
-            String stagedPath = stagingEntry.getValue();
-            URI stagedUri = URI.create(stagedPath);
-
-            Resource objResc = model.getResource(rescPid.getRepositoryPath());
-            Resource origResc = DepositModelHelpers.getDatastream(objResc);
-
-            try (InputStream fStream = Files.newInputStream(Paths.get(stagedUri))) {
-                log.debug("Calculating digests for {}", stagedUri);
-                MultiDigestInputStreamWrapper digestWrapper = new MultiDigestInputStreamWrapper(
-                        fStream, getDigestsForResource(origResc), REQUIRED_ALGS);
-                digestWrapper.checkFixity();
-                log.debug("Verified fixity of {}", stagedUri);
-                recordDigestsForResource(rescPid, origResc, digestWrapper.getDigests());
-                markObjectCompleted(rescPid);
-                log.debug("Completed fixity recording for {}", stagedUri);
-                addClicks(1);
-            } catch (InvalidChecksumException e) {
-                failJob(String.format("Fixity check failed for %s belonging to %s",
-                        stagedUri, objResc.getURI()),
-                        e.getMessage());
-            } catch (IOException e) {
-                failJob(e, "Failed to read file {0} for fixity check", stagedUri);
+            // Wait for the remaining jobs
+            while (!fixityFutures.isEmpty()) {
+                fixityFutures.pop().get();
             }
+
+            // Wait for results
+            while (!fixityResults.isEmpty()) {
+                TimeUnit.MILLISECONDS.sleep(10);
+            }
+        } catch (InterruptedException e) {
+            isInterrupted.set(true);
+            throw new JobInterruptedException("Fixity check job interrupted", e);
+        } catch (ExecutionException e) {
+            isInterrupted.set(true);
+            if (e.getCause() instanceof RuntimeException) {
+                throw (RuntimeException) e.getCause();
+            } else {
+                throw new RuntimeException(e.getCause());
+            }
+        } finally {
+            donePerformingChecks.set(true);
         }
+        // Wait if a flush of registrations is still active
+        synchronized (flushingLock) {
+        }
+        log.debug("Completed FixityCheckJob {} in deposit {}", jobUUID, depositUUID);
     }
 
     private Map<DigestAlgorithm, String> getDigestsForResource(Resource resc) {
@@ -115,26 +173,147 @@ public class FixityCheckJob extends AbstractDepositJob {
         return digests;
     }
 
-    private void recordDigestsForResource(PID pid, Resource resc, Map<DigestAlgorithm, String> digests) {
-        List<String> details = new ArrayList<>();
-        // Store newly calculate digests into deposit model
-        commit(() -> {
-            digests.forEach((alg, digest) -> {
-                if (resc.hasProperty(alg.getDepositProperty())) {
-                    log.debug("{} fixity check for {} passed with value {}", alg.getName(), resc.getURI(), digest);
-                } else {
-                    log.debug("Storing {} digest for {} with value {}", alg.getName(), resc.getURI(), digest);
-                    resc.addLiteral(alg.getDepositProperty(), digest);
-                }
-                details.add(alg.getName().toUpperCase() + " checksum calculated: " + digest);
-            });
-        });
+    private void receiveFixityResult(FixityCheckResult result) {
+        fixityResults.add(result);
+    }
 
-        // Store event for calculation of checksums
-        PremisLogger premisDepositLogger = getPremisLogger(pid);
-        PremisEventBuilder builder = premisDepositLogger.buildEvent(Premis.MessageDigestCalculation)
-                .addSoftwareAgent(AgentPids.forSoftware(SoftwareAgent.depositService));
-        details.forEach(builder::addEventDetail);
-        builder.write();
+    private void startResultRegistrar() {
+        Thread flushThread = new Thread(() -> {
+            try {
+                while (!isInterrupted.get()) {
+                    registerResults();
+                    if (donePerformingChecks.get() && fixityResults.isEmpty()) {
+                        return;
+                    }
+                    TimeUnit.MILLISECONDS.sleep(flushRate);
+                }
+            } catch (InterruptedException e) {
+                throw new JobInterruptedException("Interrupted fixity check result registrar", e);
+            }
+        });
+        // Allow exceptions from the registrar thread to make it to the main thread
+        flushThread.setUncaughtExceptionHandler( new Thread.UncaughtExceptionHandler() {
+            @Override
+            public void uncaughtException(Thread th, Throwable ex) {
+                isInterrupted.set(true);
+                if (ex instanceof RuntimeException) {
+                    throw (RuntimeException) ex;
+                } else {
+                    new RepositoryException(ex);
+                }
+            }
+        });
+        flushThread.start();
+    }
+
+    private void registerResults() {
+        if (fixityResults.isEmpty()) {
+            return;
+        }
+        // Start a flush lock so that the job will not end until it finishes
+        synchronized (flushingLock) {
+            // Capture the current set of results, in case it grows during registration
+            List<FixityCheckResult> results = new ArrayList<>();
+            fixityResults.drainTo(results);
+            log.debug("Registering batch of {} fixity check results", results.size());
+            // Commit any newly generated digests to the deposit model and record results
+            commit(() -> {
+                results.forEach(result -> {
+                    result.digests.forEach((alg, digest) -> {
+                        if (result.origResc.hasProperty(alg.getDepositProperty())) {
+                            log.debug("{} fixity check for {} passed with value {}",
+                                    alg.getName(), result.origResc, digest);
+                        } else {
+                            log.debug("Storing {} digest for {} with value {}",
+                                    alg.getName(), result.origResc, digest);
+                            result.origResc.addLiteral(alg.getDepositProperty(), digest);
+                        }
+                        result.details.add(alg.getName().toUpperCase() + " checksum calculated: " + digest);
+                    });
+                });
+            });
+            // Record events and progress state
+            results.forEach(result -> {
+                // Store event for calculation of checksums
+                PremisLogger premisDepositLogger = getPremisLogger(result.rescPid);
+                PremisEventBuilder builder = premisDepositLogger.buildEvent(Premis.MessageDigestCalculation)
+                        .addSoftwareAgent(AgentPids.forSoftware(SoftwareAgent.depositService));
+                result.details.forEach(builder::addEventDetail);
+                builder.write();
+
+                markObjectCompleted(result.rescPid);
+                log.debug("Completed fixity recording for {}", result.stagedUri);
+                addClicks(1);
+            });
+        }
+    }
+
+    private class FixityCheckRunnable implements Runnable {
+        private URI stagedUri;
+        private Resource origResc;
+        private PID rescPid;
+        private Map<DigestAlgorithm, String> existingDigests;
+
+        public FixityCheckRunnable(PID rescPid, URI stagedUri, Resource origResc,
+                Map<DigestAlgorithm, String> existingDigests) {
+            this.stagedUri = stagedUri;
+            this.origResc = origResc;
+            this.rescPid = rescPid;
+            this.existingDigests = existingDigests;
+        }
+
+        @Override
+        public void run() {
+            if (isInterrupted.get()) {
+                return;
+            }
+
+            try (InputStream fStream = Files.newInputStream(Paths.get(stagedUri))) {
+                log.debug("Calculating digests for {}", stagedUri);
+                MultiDigestInputStreamWrapper digestWrapper = new MultiDigestInputStreamWrapper(
+                        fStream, existingDigests, REQUIRED_ALGS);
+                digestWrapper.checkFixity();
+                log.debug("Verified fixity of {}", stagedUri);
+
+                receiveFixityResult(new FixityCheckResult(rescPid, stagedUri, origResc, digestWrapper.getDigests()));
+            } catch (InvalidChecksumException e) {
+                failJob(String.format("Fixity check failed for %s belonging to %s",
+                        stagedUri, origResc.getURI()), e.getMessage());
+            } catch (IOException e) {
+                failJob(e, "Failed to read file {0} for fixity check", stagedUri);
+            }
+        }
+    }
+
+    /**
+     * Result from a fixity check job
+     * @author bbpennel
+     */
+    private class FixityCheckResult {
+        private PID rescPid;
+        private URI stagedUri;
+        private Resource origResc;
+        private Map<DigestAlgorithm, String> digests;
+        private List<String> details;
+
+        public FixityCheckResult(PID rescPid, URI stagedUri, Resource origResc, Map<DigestAlgorithm, String> digests) {
+            this.rescPid = rescPid;
+            this.stagedUri = stagedUri;
+            this.origResc = origResc;
+            this.digests = digests;
+            details = new ArrayList<>();
+        }
+    }
+
+    public void setExecutorService(ExecutorService executorService) {
+        this.executorService = executorService;
+    }
+
+    public void setFlushRate(int flushRate) {
+        this.flushRate = flushRate;
+    }
+
+    public void setMaxQueuedJobs(int maxQueuedJobs) {
+        this.maxQueuedJobs = maxQueuedJobs;
     }
 }

--- a/deposit/src/main/webapp/WEB-INF/deposit-jobs-context.xml
+++ b/deposit/src/main/webapp/WEB-INF/deposit-jobs-context.xml
@@ -192,6 +192,11 @@
             factory-method="newFixedThreadPool" destroy-method="shutdownNow">
         <constructor-arg value="${job.fileValidation.workers:1}"/>
     </bean>
+    
+    <bean id="fixityCheckExecutor" class="java.util.concurrent.Executors"
+            factory-method="newFixedThreadPool" destroy-method="shutdownNow">
+        <constructor-arg value="${job.fileValidation.workers:1}"/>
+    </bean>
 
     <bean id="VirusScanJob" class="edu.unc.lib.deposit.validate.VirusScanJob"
             scope="prototype">
@@ -201,6 +206,9 @@
     
     <bean id="FixityCheckJob" class="edu.unc.lib.deposit.validate.FixityCheckJob"
         scope="prototype">
+        <property name="executorService" ref="fixityCheckExecutor" />
+        <property name="maxQueuedJobs" value="${job.fileValidation.workers:5}" />
+        <property name="flushRate" value="${job.fixityCheck.flushRate:2000}" />
     </bean>
     
     <bean id="ValidateDestinationJob" class="edu.unc.lib.deposit.validate.ValidateDestinationJob"


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2959
* Refactors FixityCheckJob to run fixity check jobs in parallel
    * Each fixity check job runs in a separate worker thread using a pool thread
    * Updates to the deposit model and PREMIS logs are flushed ever ~2 seconds to reduce the number of transactions against jena TDB
    * Fixity check jobs are gradually submitted to the queue for execution in order to prevent one deposit from taking over all the workers for a long time, which would delay the other deposits.
* Has its own thread pool for the moment since VirusScanJob is not currently setup to play nice with other jobs in terms of number of tasks queued at once.