### PR TITLE
Swallow tx errors in FedoraTransaction.cancelAndIgnore

### DIFF
--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/FedoraTransaction.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/FedoraTransaction.java
@@ -68,7 +68,11 @@ public class FedoraTransaction {
     }
 
     public void cancelAndIgnore() {
-        cancelTx();
+        try {
+            cancelTx();
+        } catch (TransactionCancelledException e) {
+            // ignore
+        }
     }
 
     public void cancel(Throwable t) {


### PR DESCRIPTION
* Fixes issue where we were not receiving the actual error causing deposits to fail. Also, this is the intent of the method.