### PR TITLE
BXC-2961 - Parallel Binary Transfers

### DIFF
--- a/deposit/src/main/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJob.java
@@ -147,8 +147,6 @@ public class TransferBinariesToStorageJob extends AbstractDepositJob {
                 transferFutures.poll().get();
             }
 
-            doneTransfers.set(true);
-
             // Wait for results
             while (!resultsQueue.isEmpty()) {
                 TimeUnit.MILLISECONDS.sleep(10l);
@@ -157,6 +155,8 @@ public class TransferBinariesToStorageJob extends AbstractDepositJob {
             // Wait if a flush of registrations is still active
             synchronized (flushingLock) {
             }
+
+            doneTransfers.set(true);
         } catch (InterruptedException e) {
             isInterrupted.set(true);
             throw new JobInterruptedException("Binary Transfer job interrupted", e);

--- a/deposit/src/main/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJob.java
@@ -475,4 +475,8 @@ public class TransferBinariesToStorageJob extends AbstractDepositJob {
     public void setFlushRate(int flushRate) {
         this.flushRate = flushRate;
     }
+
+    public void setMaxQueuedJobs(int maxQueuedJobs) {
+        this.maxQueuedJobs = maxQueuedJobs;
+    }
 }

--- a/deposit/src/main/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJob.java
@@ -337,7 +337,8 @@ public class TransferBinariesToStorageJob extends AbstractDepositJob {
 
         private void transferFitsHistoryFile() {
             if (datastreamNotTransferred(CdrDeposit.hasDatastreamFitsHistory)) {
-                Resource historyResc = DepositModelHelpers.getDatastream(resc, DatastreamType.TECHNICAL_METADATA_HISTORY);
+                Resource historyResc = DepositModelHelpers.getDatastream(
+                        resc, DatastreamType.TECHNICAL_METADATA_HISTORY);
                 PID fitsPid = DatastreamPids.getTechnicalMetadataPid(objPid);
                 PID historyPid = DatastreamPids.getDatastreamHistoryPid(fitsPid);
 

--- a/deposit/src/main/java/edu/unc/lib/deposit/work/AbstractDepositJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/work/AbstractDepositJob.java
@@ -136,7 +136,7 @@ public abstract class AbstractDepositJob implements Runnable {
     protected boolean rollbackDatasetOnFailure = true;
 
     @Autowired
-    private DepositModelManager depositModelManager;
+    protected DepositModelManager depositModelManager;
 
     public AbstractDepositJob() {
     }

--- a/deposit/src/main/webapp/WEB-INF/deposit-jobs-context.xml
+++ b/deposit/src/main/webapp/WEB-INF/deposit-jobs-context.xml
@@ -258,8 +258,15 @@
         scope="prototype">
     </bean>
     
+    <bean id="transferBinariesExecutor" class="java.util.concurrent.Executors"
+            factory-method="newFixedThreadPool" destroy-method="shutdownNow">
+        <constructor-arg value="${job.transferBinaries.workers:5}"/>
+    </bean>
+    
     <bean id="transferBinariesToStorageJob" class="edu.unc.lib.deposit.transfer.TransferBinariesToStorageJob"
         scope="prototype">
+        <property name="executorService" ref="transferBinariesExecutor" />
+        <property name="flushRate" value="${job.transferBinaries.flushRate:2000}" />
     </bean>
     
     <bean id="ingestContentObjectsJob" class="edu.unc.lib.deposit.fcrepo4.IngestContentObjectsJob"

--- a/deposit/src/main/webapp/WEB-INF/deposit-jobs-context.xml
+++ b/deposit/src/main/webapp/WEB-INF/deposit-jobs-context.xml
@@ -264,9 +264,10 @@
     </bean>
     
     <bean id="transferBinariesToStorageJob" class="edu.unc.lib.deposit.transfer.TransferBinariesToStorageJob"
-        scope="prototype">
+            scope="prototype">
         <property name="executorService" ref="transferBinariesExecutor" />
         <property name="flushRate" value="${job.transferBinaries.flushRate:2000}" />
+        <property name="maxQueuedJobs" value="${job.transferBinaries.maxQueuedJobs:6}" />
     </bean>
     
     <bean id="ingestContentObjectsJob" class="edu.unc.lib.deposit.fcrepo4.IngestContentObjectsJob"

--- a/deposit/src/test/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJobTest.java
@@ -357,6 +357,7 @@ public class TransferBinariesToStorageJobTest extends AbstractNormalizationJobTe
 
         job.closeModel();
 
+        initializeJob();
         reset(jobStatusFactory);
         job.run();
 

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/deposit/DepositModelManager.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/deposit/DepositModelManager.java
@@ -293,7 +293,7 @@ public class DepositModelManager implements Closeable {
      */
     public void commit(Runnable actions, boolean inTx) {
         try {
-            if (inTx) {
+            if (inTx && dataset.isInTransaction()) {
                 dataset.end();
             }
             dataset.begin(ReadWrite.WRITE);
@@ -336,7 +336,9 @@ public class DepositModelManager implements Closeable {
      * End a transaction on the dataset
      */
     public void end() {
-        dataset.end();
+        if (dataset.isInTransaction()) {
+            dataset.end();
+        }
     }
 
     public void setDepositsPath(Path depositsPath) {


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2961

* Refactors binary transfers job to perform transfers in parallel to each, following a similar setup to https://github.com/UNC-Libraries/Carolina-Digital-Repository/pull/1164
    * All transfers per object happen in the same runnable executed in a thread pool
    * Updates to the deposit model every few seconds to reduce the number of write transactions against jena TDB
    * jobs are gradually submitted to the queue for execution in order to prevent one deposit from taking over all the workers for a long time, which would delay the other deposits.
* Due to needing to read from the jena tdb model in multiple threads, a read transaction must be opened in each transfer worker.
* Refactored job to process objects needing transfers based off a single query of the deposit model rather than following the deposit hierarchy, in order to prevent deadlock issues when spawning jobs.