### PR TITLE
Concurrency fixes

### DIFF
--- a/deposit/src/main/webapp/WEB-INF/deposit-jobs-context.xml
+++ b/deposit/src/main/webapp/WEB-INF/deposit-jobs-context.xml
@@ -226,12 +226,18 @@
         <property name="socketTimeout" value="${fits.http.client.socketTimeout:300000}" />
     </bean>
     
+    <bean id="fitsHttpConnectionManager" class="org.apache.http.impl.conn.PoolingHttpClientConnectionManager"
+            destroy-method="shutdown">
+        <property name="defaultMaxPerRoute" value="${job.extractTechnicalMetadata.workers:5}" />
+        <property name="maxTotal" value="${job.extractTechnicalMetadata.workers:5}" />
+    </bean>
+    
     <bean id="fitsHttpClientRequestConfig" factory-bean="fitsHttpClientRequestConfigBuilder"
         factory-method="build">
     </bean>
     
     <bean id="fitsPooledHttpClientBuilder" class="org.apache.http.impl.client.HttpClients" factory-method="custom">
-        <property name="connectionManager" ref="multiThreadedHttpConnectionManager" />
+        <property name="connectionManager" ref="fitsHttpConnectionManager" />
         <property name="defaultRequestConfig" ref="fitsHttpClientRequestConfig" />
     </bean>
     

--- a/deposit/src/main/webapp/WEB-INF/service-context.xml
+++ b/deposit/src/main/webapp/WEB-INF/service-context.xml
@@ -178,6 +178,8 @@
     
     <bean id="multiThreadedHttpConnectionManager" class="org.apache.http.impl.conn.PoolingHttpClientConnectionManager"
             destroy-method="shutdown">
+        <property name="defaultMaxPerRoute" value="8" />
+        <property name="maxTotal" value="24" />
     </bean>
     
     <bean id="httpClientRequestConfigBuilder" class="org.apache.http.client.config.RequestConfig"


### PR DESCRIPTION
Fixes two concurrency issues in the deposit pipeline:
* allows for more connections to FITS webapp, which was preventing more than 2 connections to it at a time
* calls `get` on futures when clearing them from queue of jobs so that any exceptions thrown by worker threads will be rethrown during `waitForQueueCapacity`