### PR TITLE
Update jena version and fcrepo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "clamavj"]
 	url = https://github.com/UNC-Libraries/clamavj.git
 	path = clamavj
+[submodule "fcrepo"]
+	path = fcrepo
+	url = git@github.com:fcrepo/fcrepo.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	path = clamavj
 [submodule "fcrepo"]
 	path = fcrepo
-	url = git@github.com:fcrepo/fcrepo.git
+	url = https://github.com/fcrepo/fcrepo.git

--- a/Makefile
+++ b/Makefile
@@ -108,17 +108,11 @@ ifeq ($(DEPLOY_TYPE), prod)
 endif
 SUSPEND = "n"
 
-run-access:
-	cd access && export MAVEN_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,address=48008,server=y,suspend=$(SUSPEND)"; mvn jetty:run
+build-bxc:
+	mvn clean install -DskipTests -pl access,access-common,admin,deposit,fcrepo-clients,metadata,persistence,security,services,services-camel,solr-ingest,solr-search,sword-server,migration-util
 
-run-admin:
-	cd admin && export MAVEN_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,address=48009,server=y,suspend=$(SUSPEND)"; mvn jetty:run
-	
-run-deposit:
-	cd deposit && export MAVEN_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,address=48010,server=y,suspend=$(SUSPEND)"; mvn jetty:run
-	
-run-services-camel:
-	cd services-camel && export MAVEN_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,address=48011,server=y,suspend=$(SUSPEND)"; mvn jetty:run
+verify-bxc:
+	mvn verify -pl access,access-common,admin,deposit,fcrepo-clients,metadata,persistence,security,services,services-camel,solr-ingest,solr-search,sword-server,migration-util
 
 ifneq ($(VERSION), "")
 	for i in static/js/public/*.js; do \

--- a/access/pom.xml
+++ b/access/pom.xml
@@ -174,7 +174,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.ext</groupId>
-            <artifactId>jersey-spring3</artifactId>
+            <artifactId>jersey-spring5</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>

--- a/checkstyle-suppressions.xml
+++ b/checkstyle-suppressions.xml
@@ -3,6 +3,7 @@
      "-//Puppy Crawl//DTD Suppressions 1.1//EN"
      "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 <suppressions>
+    <suppress checks=".*" files="/fcrepo/" />
     <suppress checks=".*" files="/fcrepo-cdr-fesl/" />
     <suppress checks=".*" files="/fcrepo-irods-storage/" />
     <suppress checks=".*" files="/jaxb/" />

--- a/deposit/pom.xml
+++ b/deposit/pom.xml
@@ -169,7 +169,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.ext</groupId>
-            <artifactId>jersey-spring3</artifactId>
+            <artifactId>jersey-spring5</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>

--- a/fcrepo-clients/pom.xml
+++ b/fcrepo-clients/pom.xml
@@ -181,7 +181,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.ext</groupId>
-            <artifactId>jersey-spring3</artifactId>
+            <artifactId>jersey-spring5</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>
@@ -199,7 +199,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
-            <artifactId>jena-fuseki-embedded</artifactId>
+            <artifactId>jena-fuseki-main</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/migration-util/pom.xml
+++ b/migration-util/pom.xml
@@ -170,7 +170,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.ext</groupId>
-            <artifactId>jersey-spring3</artifactId>
+            <artifactId>jersey-spring5</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>

--- a/persistence/pom.xml
+++ b/persistence/pom.xml
@@ -181,7 +181,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.ext</groupId>
-            <artifactId>jersey-spring3</artifactId>
+            <artifactId>jersey-spring5</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,7 @@
         <module>access-common</module>
         <module>deposit</module>
         <module>clamavj</module>
+        <module>fcrepo</module>
         <module>spoof</module>
         
         <module>migration-util</module>
@@ -324,6 +325,7 @@
                     </includes>
                     <excludes>
                         <exclude>clamavj/**</exclude>
+                        <exclude>fcrepo/**</exclude>
                         <exclude>**/*.properties</exclude>
                     </excludes>
                     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         
         <cdr.version>5.0-SNAPSHOT</cdr.version>
         <fcrepo.version>3.8.0</fcrepo.version>
-        <fcrepo4.version>5.0.2</fcrepo4.version>
+        <fcrepo4.version>5.2.0-SNAPSHOT</fcrepo4.version>
         <fcrepo-indexing-triplestore.version>5.0.0</fcrepo-indexing-triplestore.version>
         <clamavj.version>0.3</clamavj.version>
         
@@ -71,9 +71,8 @@
         <quartz.version>2.3.2</quartz.version>
         
         <junit.version>4.13.1</junit.version>
-        <grizzly.version>2.3.28</grizzly.version>
-        <jersey.version>2.24</jersey.version>
-        <jersey.spring3.version>2.24</jersey.spring3.version>
+        <grizzly.version>2.4.4</grizzly.version>
+        <jersey.version>2.32</jersey.version>
         <mockito.version>1.10.19</mockito.version>
         <fcrepo.client.version>0.4.0</fcrepo.client.version>
         <mock.server.version>5.4.1</mock.server.version>
@@ -125,8 +124,8 @@
         <embedded-redis.version>0.7.3</embedded-redis.version>
         <solr.version>8.5.2</solr.version>
         <metrics.version>5.0.0</metrics.version>
-        <jena.version>3.9.0</jena.version>
-        <jena.fuseki.version>3.8.0</jena.fuseki.version>
+        <jena.version>3.17.0</jena.version>
+        <jena.fuseki.version>3.17.0</jena.fuseki.version>
         
         <fcrepo-camel.version>5.0.0</fcrepo-camel.version>
         <camel.version>2.20.4</camel.version>
@@ -978,7 +977,7 @@
             
             <dependency>
                 <groupId>org.apache.jena</groupId>
-                <artifactId>jena-fuseki-embedded</artifactId>
+                <artifactId>jena-fuseki-main</artifactId>
                 <version>${jena.fuseki.version}</version>
                 <scope>test</scope>
                 <exclusions>
@@ -1117,8 +1116,8 @@
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.ext</groupId>
-                <artifactId>jersey-spring3</artifactId>
-                <version>${jersey.spring3.version}</version>
+                <artifactId>jersey-spring5</artifactId>
+                <version>${jersey.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/services-camel/pom.xml
+++ b/services-camel/pom.xml
@@ -215,7 +215,7 @@
     </dependency>
     <dependency>
         <groupId>org.glassfish.jersey.ext</groupId>
-        <artifactId>jersey-spring3</artifactId>
+        <artifactId>jersey-spring5</artifactId>
     </dependency>
     <dependency>
         <groupId>org.glassfish.jersey.test-framework.providers</groupId>
@@ -257,7 +257,7 @@
     </dependency>
     <dependency>
         <groupId>org.apache.jena</groupId>
-        <artifactId>jena-fuseki-embedded</artifactId>
+        <artifactId>jena-fuseki-main</artifactId>
     </dependency>
     </dependencies>
 

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/triplesReindexing/TriplesReindexingRouterIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/triplesReindexing/TriplesReindexingRouterIT.java
@@ -34,7 +34,7 @@ import org.apache.camel.builder.NotifyBuilder;
 import org.apache.camel.test.spring.CamelSpringRunner;
 import org.apache.camel.test.spring.CamelTestContextBootstrapper;
 import org.apache.commons.io.FileUtils;
-import org.apache.jena.fuseki.embedded.FusekiServer;
+import org.apache.jena.fuseki.main.FusekiServer;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.QueryExecution;
 import org.apache.jena.query.ResultSet;

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -177,7 +177,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.ext</groupId>
-            <artifactId>jersey-spring3</artifactId>
+            <artifactId>jersey-spring5</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>


### PR DESCRIPTION
Updates from jena 3.9.0 to 3.17.0 in order to help with data corruption issue with jena tdb.
* In order to do this, adds fcrepo 5.2.0-SNAPSHOT as a submodule temporarily to make sure it is present during builds and tests. Should remove once a new fcrepo release is published.
* Adds make tasks to just build bxc projects (since building fcrepo triples the build/test time): `make build-bxc` and `make verify-bxc`
* Updates other dependencies that changed with the fcrepo update