### PR TITLE
Fix filtering/indexing issues with content root object and fedora:timemap

### DIFF
--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryInitializer.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryInitializer.java
@@ -15,12 +15,15 @@
  */
 package edu.unc.lib.dl.fcrepo4;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 import java.net.URI;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.vocabulary.DC;
+import org.slf4j.Logger;
 
 import edu.unc.lib.dl.util.URIUtil;
 
@@ -31,6 +34,7 @@ import edu.unc.lib.dl.util.URIUtil;
  *
  */
 public class RepositoryInitializer {
+    private static final Logger log = getLogger(RepositoryInitializer.class);
 
     private RepositoryObjectFactory objFactory;
 
@@ -59,6 +63,8 @@ public class RepositoryInitializer {
             return containerUri;
         }
 
+        log.warn("Initializing object '{}' with id {}", title, id);
+
         Model model = ModelFactory.createDefaultModel();
         Resource resc = model.createResource(containerString);
         resc.addProperty(DC.title, title);
@@ -77,6 +83,8 @@ public class RepositoryInitializer {
         if (objFactory.objectExists(contentRootUri)) {
             return contentRootUri;
         }
+
+        log.warn("Initializing content root object {}", contentRootUri);
 
         Model model = ModelFactory.createDefaultModel();
         Resource resc = model.createResource(contentRootString);

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/routing/FedoraIdFilters.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/routing/FedoraIdFilters.java
@@ -55,7 +55,8 @@ public class FedoraIdFilters {
         // Exclude fcr:versions, audit path
         return !(fcrepoId.contains(RepositoryPathConstants.FCR_VERSIONS)
                 || fcrepoId.endsWith("/audit")
-                || fcrepoId.endsWith(RepositoryPathConstants.FCR_TOMBSTONE));
+                || fcrepoId.endsWith(RepositoryPathConstants.FCR_TOMBSTONE)
+                || fcrepoId.endsWith("/fedora:timemap"));
     }
 
     /**
@@ -75,7 +76,7 @@ public class FedoraIdFilters {
                 || eventType.contains(EventTypes.EVENT_UPDATE));
     }
 
-    private static final Pattern IGNORE_SUFFIX = Pattern.compile(".*fcr:.+");
+    private static final Pattern IGNORE_SUFFIX = Pattern.compile(".*(fcr|fedora):.+");
 
     /**
      * Filter Fedora messages to exclude any messages that should not undergoing enhancement processing
@@ -99,12 +100,17 @@ public class FedoraIdFilters {
             log.debug("Failed to parse fcrepo id {} as PID while filtering: {}", fcrepoId, e.getMessage());
             return false;
         }
+        if (pid == null) {
+            log.error("Received null PID for object with fcrepo URI {}", fcrepoBaseUrl + fcrepoId);
+            return false;
+        }
         // Filter out non-content objects
         if (!PIDConstants.CONTENT_QUALIFIER.equals(pid.getQualifier())) {
             return false;
         }
+        // Allow for content root object to be indexed
         if (RepositoryPathConstants.CONTENT_ROOT_ID.equals(pid.getId())) {
-            return false;
+            return true;
         }
         String componentPath = pid.getComponentPath();
         // No component path, is a full content object


### PR DESCRIPTION
Allow content root object to be indexed, prevent processing of fedora:timemap uris, add logging for initializer