### PR TITLE
BXC-2995 - Redis connection retries

### DIFF
--- a/metadata/src/main/java/edu/unc/lib/dl/util/AbstractJedisFactory.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/util/AbstractJedisFactory.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.util;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.net.SocketTimeoutException;
+import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+
+import edu.unc.lib.dl.exceptions.RepositoryException;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+
+/**
+ * @author bbpennel
+ */
+public class AbstractJedisFactory {
+    private static final Logger log = getLogger(AbstractJedisFactory.class);
+
+    protected JedisPool jedisPool;
+    private int socketTimeoutRetries = 5;
+    private long socketTimeoutDelay = 15000l;
+
+    protected void connectWithRetries(Consumer<Jedis> block) {
+        int socketTimeoutRetriesRemaining = socketTimeoutRetries;
+        while (true) {
+            try (Jedis jedis = getJedisPool().getResource()) {
+                block.accept(jedis);
+                return;
+            } catch (JedisConnectionException e) {
+                if (e.getCause() instanceof SocketTimeoutException) {
+                    if (socketTimeoutRetriesRemaining-- <= 0) {
+                        throw e;
+                    } else {
+                        log.warn("Jedis connection interrupted, retrying: {}", e.getMessage());
+                        try {
+                            Thread.sleep(socketTimeoutDelay);
+                        } catch (InterruptedException e1) {
+                            throw new RepositoryException(e1);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public void setJedisPool(JedisPool jedisPool) {
+        this.jedisPool = jedisPool;
+    }
+
+    private JedisPool getJedisPool() {
+        return jedisPool;
+    }
+}

--- a/metadata/src/main/java/edu/unc/lib/dl/util/AbstractJedisFactory.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/util/AbstractJedisFactory.java
@@ -28,6 +28,8 @@ import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 
 /**
+ * Abstract client for interacting with redis data.
+ *
  * @author bbpennel
  */
 public class AbstractJedisFactory {
@@ -37,6 +39,12 @@ public class AbstractJedisFactory {
     private int socketTimeoutRetries = 5;
     private long socketTimeoutDelay = 15000l;
 
+    /**
+     * Connect to redis and perform the provided block of code. If the connection
+     * is interrupted, the block will be retried.
+     *
+     * @param block
+     */
     protected void connectWithRetries(Consumer<Jedis> block) {
         int socketTimeoutRetriesRemaining = socketTimeoutRetries;
         while (true) {
@@ -66,5 +74,13 @@ public class AbstractJedisFactory {
 
     private JedisPool getJedisPool() {
         return jedisPool;
+    }
+
+    public void setSocketTimeoutRetries(int socketTimeoutRetries) {
+        this.socketTimeoutRetries = socketTimeoutRetries;
+    }
+
+    public void setSocketTimeoutDelay(long socketTimeoutDelay) {
+        this.socketTimeoutDelay = socketTimeoutDelay;
     }
 }

--- a/metadata/src/test/java/edu/unc/lib/dl/util/JobStatusFactoryTest.java
+++ b/metadata/src/test/java/edu/unc/lib/dl/util/JobStatusFactoryTest.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.util;
+
+import static edu.unc.lib.dl.util.RedisWorkerConstants.JOB_STATUS_PREFIX;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.net.SocketTimeoutException;
+import java.util.UUID;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import edu.unc.lib.dl.exceptions.RepositoryException;
+import edu.unc.lib.dl.util.RedisWorkerConstants.JobField;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.exceptions.JedisConnectionException;
+
+/**
+ * @author bbpennel
+ */
+public class JobStatusFactoryTest {
+
+    @Mock
+    private JedisPool jedisPool;
+    @Mock
+    private Jedis jedis;
+
+    private String jobUUID;
+
+    private JobStatusFactory statusFactory;
+
+    @Before
+    public void setup() {
+        initMocks(this);
+
+        when(jedisPool.getResource()).thenReturn(jedis);
+
+        jobUUID = UUID.randomUUID().toString();
+
+        statusFactory = new JobStatusFactory();
+        statusFactory.setSocketTimeoutDelay(1);
+        statusFactory.setSocketTimeoutRetries(4);
+        statusFactory.setJedisPool(jedisPool);
+    }
+
+    @Test
+    public void incrCompletionSuccess() {
+        statusFactory.incrCompletion(jobUUID, 1);
+        statusFactory.incrCompletion(jobUUID, 2);
+
+        verify(jedis).hincrBy(JOB_STATUS_PREFIX + jobUUID, JobField.num.name(), 1);
+        verify(jedis).hincrBy(JOB_STATUS_PREFIX + jobUUID, JobField.num.name(), 2);
+    }
+
+    @Test
+    public void incrCompletionInterruptRecovery() {
+        SocketTimeoutException cause = new SocketTimeoutException("Timed out");
+        JedisConnectionException ex = new JedisConnectionException(cause);
+        when(jedis.hincrBy(anyString(), anyString(), anyInt())).thenThrow(ex).thenReturn(1l);
+
+        statusFactory.incrCompletion(jobUUID, 1);
+
+        verify(jedis, times(2)).hincrBy(JOB_STATUS_PREFIX + jobUUID, JobField.num.name(), 1);
+    }
+
+    @Test(expected = JedisConnectionException.class)
+    public void incrCompletionInterruptFail() {
+        SocketTimeoutException cause = new SocketTimeoutException("Timed out");
+        JedisConnectionException ex = new JedisConnectionException(cause);
+        when(jedis.hincrBy(anyString(), anyString(), anyInt())).thenThrow(ex);
+
+        statusFactory.incrCompletion(jobUUID, 1);
+    }
+
+    @Test(expected = RepositoryException.class)
+    public void incrCompletionUnexpectedException() {
+        Exception ex = new RepositoryException("Oops");
+        when(jedis.hincrBy(anyString(), anyString(), anyInt())).thenThrow(ex).thenReturn(1l);
+
+        statusFactory.incrCompletion(jobUUID, 1);
+    }
+}


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2995

Should attempt to retry redis operations when a socket timeout occurs, which is the primary jedis related cause of deposit failures.