### PR TITLE
BXC-3024 - Action/utility to completely remove objects

### DIFF
--- a/metadata/src/main/java/edu/unc/lib/dl/util/IndexingActionType.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/util/IndexingActionType.java
@@ -37,10 +37,8 @@ public enum IndexingActionType {
     RECURSIVE_REINDEX("In-place Reindex",
             "Performs a recursive reindex of this object and all its children "
             + "Updates this pid based off the originating structure, then cleans up any stale records."),
-    RECURSIVE_DELETE("Delete Path from Index",
-            "Recursively deletes from the index an object and all of its children, based on the original structure"),
     DELETE_SOLR_TREE("Delete Tree from Index",
-            "Deletes an object and all children that contained the object in their collection path"),
+            "Deletes an object and all children that contained by it based on ancestorPath"),
     CLEAN_REINDEX("Clean Reindex", "Cleans out the path starting at the object specified and then reindexes it"),
     DELETE_CHILDREN_PRIOR_TO_TIMESTAMP("Cleanup Outdated Records",
             "Deletes the trees of all children of the starting node"

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/DestroyObjectsCommand.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/DestroyObjectsCommand.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dcr.migration;
+
+import static edu.unc.lib.dcr.migration.MigrationConstants.OUTPUT_LOGGER;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import edu.unc.lib.dl.acl.util.AccessGroupSet;
+import edu.unc.lib.dl.acl.util.AgentPrincipals;
+import edu.unc.lib.dl.persist.services.destroy.DestroyObjectsService;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+
+/**
+ * @author bbpennel
+ */
+@Command(name = "destroy_objects",
+        description = "Destroy one or more objects")
+public class DestroyObjectsCommand implements Callable<Integer> {
+    private static final Logger output = getLogger(OUTPUT_LOGGER);
+
+    @ParentCommand
+    private MigrationCLI parentCommand;
+
+    @Option(names = {"--completely"},
+            defaultValue = "false",
+            description = "If provided, objects will be destroyed and completely cleaned up")
+    private boolean completely;
+
+    @Option(names = {"--from-file", "-f"},
+            description = "File path from which ids will be read. They should be newline separated")
+    private Path fromFile;
+
+    @Option(names = {"--ids", "-i"},
+            split = ",",
+            description = "Comma separated list of IDs. Must provide either this option of -f")
+    private String[] inputIds;
+
+    private String applicationContextPath = "spring/destroy-objects-context.xml";
+
+    private DestroyObjectsService destroyService;
+
+    @Override
+    public Integer call() throws Exception {
+        long start = System.currentTimeMillis();
+
+        if (fromFile == null && (inputIds == null || inputIds.length == 0)) {
+            output.error("Must provide IDs via either -f or -i parameters");
+            return 1;
+        }
+        if (fromFile != null && inputIds != null && inputIds.length > 0) {
+            output.error("Must only provide one of the following options: -f and -i");
+            return 1;
+        }
+
+        String[] ids;
+        if (fromFile != null) {
+            ids = FileUtils.readFileToString(fromFile.toFile(), UTF_8).split("\\r?\\n");
+        } else {
+            ids = inputIds;
+        }
+
+        output.info("Sending requests to destroy {} objects", ids.length);
+        if (completely) {
+            output.info("**Objects will be completely cleaned up**");
+        }
+        output.info(BannerUtility.getChompBanner("Destroy"));
+
+        AgentPrincipals agent = new AgentPrincipals(parentCommand.username, new AccessGroupSet(parentCommand.groups));
+
+        try (ConfigurableApplicationContext context = new ClassPathXmlApplicationContext(applicationContextPath)) {
+            destroyService = context.getBean(DestroyObjectsService.class);
+            destroyService.destroyObjects(agent, completely, ids);
+        }
+
+        output.info("Finished destroy requests in {}ms", System.currentTimeMillis() - start);
+        return 0;
+    }
+}

--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/MigrationCLI.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/MigrationCLI.java
@@ -46,7 +46,8 @@ import picocli.CommandLine.Option;
         CleanupDepositsCommand.class,
         SendMessageCommand.class,
         SendSolrMessageCommand.class,
-        RequeueDLQCommand.class
+        RequeueDLQCommand.class,
+        DestroyObjectsCommand.class
     })
 public class MigrationCLI implements Callable<Integer> {
     private static final Logger output = getLogger(OUTPUT_LOGGER);

--- a/migration-util/src/main/resources/spring/destroy-objects-context.xml
+++ b/migration-util/src/main/resources/spring/destroy-objects-context.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:context="http://www.springframework.org/schema/context"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+    http://www.springframework.org/schema/beans/spring-beans.xsd
+    http://www.springframework.org/schema/context
+    http://www.springframework.org/schema/context/spring-context-4.3.xsd">
+
+    <context:annotation-config />
+    
+    <import resource="service-context.xml" />
+    
+    <bean name="aclPropertiesURI" class="java.lang.System"
+            factory-method="getProperty">
+        <constructor-arg index="0" value="acl.properties.uri" />
+    </bean>
+    
+    <bean id="aclProperties"
+        class="org.springframework.beans.factory.config.PropertiesFactoryBean">
+        <property name="locations">
+            <list>
+                <ref bean="aclPropertiesURI" />
+            </list>
+        </property>
+        <property name="ignoreResourceNotFound" value="false" />
+    </bean>
+    
+    <bean id="globalPermissionEvaluator" class="edu.unc.lib.dl.acl.fcrepo4.GlobalPermissionEvaluator">
+        <constructor-arg ref="aclProperties" />
+    </bean>
+    
+    <bean id="aclService" class="edu.unc.lib.dl.acl.fcrepo4.AccessControlServiceImpl">
+        <property name="globalPermissionEvaluator" ref="globalPermissionEvaluator" />
+    </bean>
+    
+    <bean id="jmsFactory" class="org.apache.activemq.pool.PooledConnectionFactory"
+        destroy-method="stop">
+        <property name="connectionFactory">
+            <bean class="org.apache.activemq.ActiveMQConnectionFactory">
+                <property name="brokerURL">
+                    <value>${jms.broker.uri}</value>
+                </property>
+            </bean>
+        </property>
+    </bean>
+    
+    <bean id="destroyObjectsJmsTemplate" class="org.springframework.jms.core.JmsTemplate">
+        <property name="connectionFactory" ref="jmsFactory" />
+        <property name="defaultDestinationName" value="${cdr.destroy.stream}" />
+        <property name="pubSubDomain" value="false" />
+    </bean>
+    
+    <bean id="destroyObjectsService"
+        class="edu.unc.lib.dl.persist.services.destroy.DestroyObjectsService">
+        <property name="aclService" ref="aclService" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="jmsTemplate" ref="destroyObjectsJmsTemplate" />
+    </bean>
+</beans>

--- a/migration-util/src/main/resources/spring/send-message-context.xml
+++ b/migration-util/src/main/resources/spring/send-message-context.xml
@@ -24,7 +24,7 @@
     
     <bean id="fedoraJmsTemplate" class="org.springframework.jms.core.JmsTemplate">
         <property name="connectionFactory" ref="jmsFactory" />
-        <property name="defaultDestinationName" value="fedora" />
+        <property name="defaultDestinationName" value="${fcrepo.stream}" />
         <property name="pubSubDomain" value="false" />
     </bean>
 </beans>

--- a/migration-util/src/main/resources/spring/send-solr-message-context.xml
+++ b/migration-util/src/main/resources/spring/send-solr-message-context.xml
@@ -24,7 +24,7 @@
     
     <bean id="solrUpdateJmsTemplate" class="org.springframework.jms.core.JmsTemplate">
         <property name="connectionFactory" ref="jmsFactory" />
-        <property name="defaultDestinationName" value="activemq:queue:repository.solrupdate" />
+        <property name="defaultDestinationName" value="${cdr.solrupdate.stream}" />
         <property name="pubSubDomain" value="false" />
     </bean>
     

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/destroy/AbstractDestroyObjectsJob.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/destroy/AbstractDestroyObjectsJob.java
@@ -1,0 +1,194 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.persist.services.destroy;
+
+import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.FCR_TOMBSTONE;
+import static edu.unc.lib.dl.services.DestroyObjectsMessageHelpers.makeDestroyOperationBody;
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toList;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.fcrepo.client.FcrepoClient;
+import org.fcrepo.client.FcrepoOperationFailedException;
+import org.fcrepo.client.FcrepoResponse;
+import org.jdom2.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import edu.unc.lib.dl.acl.service.AccessControlService;
+import edu.unc.lib.dl.acl.util.AgentPrincipals;
+import edu.unc.lib.dl.fcrepo4.BinaryObject;
+import edu.unc.lib.dl.fcrepo4.FileObject;
+import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fcrepo4.RepositoryObject;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
+import edu.unc.lib.dl.fcrepo4.TransactionManager;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.fedora.ServiceException;
+import edu.unc.lib.dl.persist.api.storage.StorageLocation;
+import edu.unc.lib.dl.persist.api.storage.StorageLocationManager;
+import edu.unc.lib.dl.persist.api.transfer.BinaryTransferException;
+import edu.unc.lib.dl.persist.api.transfer.BinaryTransferService;
+import edu.unc.lib.dl.persist.api.transfer.MultiDestinationTransferSession;
+import edu.unc.lib.dl.services.IndexingMessageSender;
+import edu.unc.lib.dl.services.MessageSender;
+import edu.unc.lib.dl.util.ResourceType;
+
+/**
+ * @author bbpennel
+ */
+public abstract class AbstractDestroyObjectsJob implements Runnable {
+    private static final Logger log = LoggerFactory.getLogger(AbstractDestroyObjectsJob.class);
+
+    protected List<PID> objsToDestroy;
+    protected AgentPrincipals agent;
+
+    protected MultiDestinationTransferSession transferSession;
+
+    protected List<URI> cleanupBinaryUris;
+
+    protected RepositoryObjectFactory repoObjFactory;
+    protected RepositoryObjectLoader repoObjLoader;
+    protected IndexingMessageSender indexingMessageSender;
+    protected FcrepoClient fcrepoClient;
+    protected MessageSender binaryDestroyedMessageSender;
+    protected AccessControlService aclService;
+    protected StorageLocationManager locManager;
+    protected BinaryTransferService transferService;
+
+    protected TransactionManager txManager;
+
+
+    protected AbstractDestroyObjectsJob(DestroyObjectsRequest request) {
+        this.objsToDestroy = stream(request.getIds()).map(PIDs::get).collect(toList());
+        this.agent = request.getAgent();
+        this.cleanupBinaryUris = new ArrayList<>();
+    }
+
+    protected void sendDestroyDerivativesMsg(RepositoryObject repoObj) {
+        Map<String, String> metadata = new HashMap<>();
+        PID pid;
+        URI objUri;
+
+        if (repoObj instanceof FileObject) {
+            FileObject fileObj = (FileObject) repoObj;
+            BinaryObject binaryObj = fileObj.getOriginalFile();
+            String mimetype = binaryObj.getMimetype();
+            metadata.put("mimeType", mimetype);
+            pid = binaryObj.getPid();
+            objUri = fileObj.getOriginalFile().getContentUri();
+        } else {
+            pid = repoObj.getPid();
+            objUri = repoObj.getUri();
+        }
+
+        setCommonMetadata(metadata, repoObj, pid);
+
+        Document destroyMsg = makeDestroyOperationBody(agent.getUsername(), objUri, metadata);
+        binaryDestroyedMessageSender.sendMessage(destroyMsg);
+    }
+
+    private Map<String, String> setCommonMetadata(Map<String, String> metadata, RepositoryObject repoObj, PID pid) {
+        String objType = ResourceType.getResourceTypeForUris(repoObj.getTypes()).getUri();
+        metadata.put("objType", objType);
+        metadata.put("pid", pid.getQualifiedId());
+
+        return metadata;
+    }
+
+    protected void destroyBinaries() {
+        if (cleanupBinaryUris.isEmpty()) {
+            return;
+        }
+
+        if (transferSession == null) {
+            transferSession = transferService.getSession();
+        }
+        cleanupBinaryUris.forEach(contentUri -> {
+            try {
+                log.debug("Deleting destroyed binary {}", contentUri);
+                StorageLocation storageLoc = locManager.getStorageLocationForUri(contentUri);
+                transferSession.forDestination(storageLoc)
+                        .delete(contentUri);
+            } catch (BinaryTransferException e) {
+                String message = e.getCause() == null ? e.getMessage() : e.getCause().getMessage();
+                log.error("Failed to cleanup binary {} for destroyed object: {}", contentUri, message);
+            }
+        });
+    }
+
+    /**
+     * Remove the specified object and its fcr:tombstone from fedora
+     * @param objUri
+     */
+    protected void purgeObject(String objUri) {
+        log.debug("Deleting object {} from fedora", objUri);
+        try (FcrepoResponse resp = fcrepoClient.delete(URI.create(objUri)).perform()) {
+        } catch (FcrepoOperationFailedException | IOException e) {
+            throw new ServiceException("Unable to clean up child object " + objUri, e);
+        }
+
+        URI tombstoneUri = URI.create(objUri + "/" + FCR_TOMBSTONE);
+        try (FcrepoResponse resp = fcrepoClient.delete(tombstoneUri).perform()) {
+        } catch (FcrepoOperationFailedException | IOException e) {
+            throw new ServiceException("Unable to clean up child tombstone object " + objUri, e);
+        }
+    }
+
+    public void setRepoObjFactory(RepositoryObjectFactory repoObjFactory) {
+        this.repoObjFactory = repoObjFactory;
+    }
+
+    public void setRepoObjLoader(RepositoryObjectLoader repoObjLoader) {
+        this.repoObjLoader = repoObjLoader;
+    }
+
+    public void setTransactionManager(TransactionManager txManager) {
+        this.txManager = txManager;
+    }
+
+    public void setFcrepoClient(FcrepoClient fcrepoClient) {
+        this.fcrepoClient = fcrepoClient;
+    }
+
+    public void setAclService(AccessControlService aclService) {
+        this.aclService = aclService;
+    }
+
+
+    public void setStorageLocationManager(StorageLocationManager locManager) {
+        this.locManager = locManager;
+    }
+
+    public void setBinaryTransferService(BinaryTransferService transferService) {
+        this.transferService = transferService;
+    }
+
+    public void setIndexingMessageSender(IndexingMessageSender indexingMessageSender) {
+        this.indexingMessageSender = indexingMessageSender;
+    }
+
+    public void setBinaryDestroyedMessageSender(MessageSender binaryDestroyedMessageSender) {
+        this.binaryDestroyedMessageSender = binaryDestroyedMessageSender;
+    }
+}

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsCompletelyJob.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsCompletelyJob.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.persist.services.destroy;
+
+import static edu.unc.lib.dl.persist.services.destroy.DestroyObjectsHelper.assertCanDestroy;
+import static edu.unc.lib.dl.util.IndexingActionType.DELETE_SOLR_TREE;
+import static edu.unc.lib.dl.util.RDFModelUtil.TURTLE_MIMETYPE;
+import static org.springframework.http.HttpHeaders.CONTENT_LOCATION;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.NodeIterator;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.riot.Lang;
+import org.fcrepo.client.FcrepoOperationFailedException;
+import org.fcrepo.client.FcrepoResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import edu.unc.lib.dl.fcrepo4.ClientFaultResolver;
+import edu.unc.lib.dl.fcrepo4.ContentContainerObject;
+import edu.unc.lib.dl.fcrepo4.ContentObject;
+import edu.unc.lib.dl.fcrepo4.FileObject;
+import edu.unc.lib.dl.fcrepo4.FolderObject;
+import edu.unc.lib.dl.fcrepo4.RepositoryObject;
+import edu.unc.lib.dl.fcrepo4.WorkObject;
+import edu.unc.lib.dl.fedora.FedoraException;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.fedora.ServiceException;
+import edu.unc.lib.dl.rdf.Ldp;
+
+/**
+ * A job for destroying objects from the repository, which does not leave behind
+ * tombstones and cleans up all metadata files.
+ *
+ * @author bbpennel
+ */
+public class DestroyObjectsCompletelyJob extends AbstractDestroyObjectsJob {
+    private static final Logger log = LoggerFactory.getLogger(DestroyObjectsCompletelyJob.class);
+
+    private static final URI BINARY_TYPE_URI = URI.create(Ldp.NonRdfSource.getURI());
+
+    public DestroyObjectsCompletelyJob(DestroyObjectsRequest request) {
+        super(request);
+    }
+
+    @Override
+    public void run() {
+        for (PID pid : objsToDestroy) {
+            RepositoryObject repoObj = repoObjLoader.getRepositoryObject(pid);
+            destroyTree(repoObj);
+
+            indexingMessageSender.sendIndexingOperation(agent.getUsername(), pid, DELETE_SOLR_TREE);
+        }
+
+        // Defer binary cleanup until after fedora destroy transaction completes
+        destroyBinaries();
+    }
+
+    private void destroyTree(RepositoryObject rootOfTree) {
+        if (!(rootOfTree instanceof WorkObject || rootOfTree instanceof FileObject
+                || rootOfTree instanceof FolderObject)) {
+            throw new ServiceException("Refusing to destroy object " + rootOfTree.getPid()
+                    + " of type " + rootOfTree.getResourceType());
+        }
+
+        assertCanDestroy(agent, rootOfTree, aclService);
+
+        log.info("Completely destroying object {}", rootOfTree.getPid());
+        if (rootOfTree instanceof ContentContainerObject) {
+            ContentContainerObject container = (ContentContainerObject) rootOfTree;
+            List<ContentObject> members = container.getMembers();
+
+            for (ContentObject member : members) {
+                destroyTree(member);
+            }
+        }
+
+        addBinariesForCleanup(rootOfTree.getModel());
+
+        sendDestroyDerivativesMsg(rootOfTree);
+
+        purgeObject(rootOfTree.getPid().getRepositoryPath());
+    }
+
+    private void addBinariesForCleanup(Model model) {
+        NodeIterator iter = model.listObjectsOfProperty(Ldp.contains);
+        while (iter.hasNext()) {
+            RDFNode obj = iter.next();
+            String objPath = obj.asResource().getURI();
+            URI objUri = URI.create(objPath);
+
+            try (FcrepoResponse resp = fcrepoClient.head(objUri).perform()) {
+                if (resp.hasType(BINARY_TYPE_URI)) {
+                    String contentLoc = resp.getHeaderValue(CONTENT_LOCATION);
+                    cleanupBinaryUris.add(URI.create(contentLoc));
+                    continue;
+                }
+            } catch (IOException e) {
+                throw new FedoraException("Failed to make HEAD request for " + objUri, e);
+            } catch (FcrepoOperationFailedException e) {
+                throw ClientFaultResolver.resolve(e);
+            }
+
+            try (FcrepoResponse resp = fcrepoClient.get(objUri)
+                    .accept(TURTLE_MIMETYPE)
+                    .perform()) {
+
+                Model childModel = ModelFactory.createDefaultModel();
+                childModel.read(resp.getBody(), null, Lang.TURTLE.getName());
+                addBinariesForCleanup(childModel);
+            } catch (IOException e) {
+                throw new FedoraException("Failed to read model for " + objUri, e);
+            } catch (FcrepoOperationFailedException e) {
+                throw ClientFaultResolver.resolve(e);
+            }
+        }
+    }
+}

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsHelper.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsHelper.java
@@ -20,11 +20,13 @@ import java.io.IOException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
+import edu.unc.lib.dl.acl.exception.AccessRestrictionException;
 import edu.unc.lib.dl.acl.service.AccessControlService;
 import edu.unc.lib.dl.acl.util.AgentPrincipals;
 import edu.unc.lib.dl.acl.util.Permission;
 import edu.unc.lib.dl.exceptions.RepositoryException;
 import edu.unc.lib.dl.fcrepo4.AdminUnit;
+import edu.unc.lib.dl.fcrepo4.ContentRootObject;
 import edu.unc.lib.dl.fcrepo4.RepositoryObject;
 
 /**
@@ -52,6 +54,8 @@ public class DestroyObjectsHelper {
         if (repoObj instanceof AdminUnit) {
             aclService.assertHasAccess("User does not have permission to destroy admin unit", repoObj.getPid(),
                     agent.getPrincipals(), Permission.destroyUnit);
+        } else if (repoObj instanceof ContentRootObject) {
+            throw new AccessRestrictionException("Cannot destroy content root object");
         } else {
             aclService.assertHasAccess("User does not have permission to destroy this object", repoObj.getPid(),
                     agent.getPrincipals(), Permission.destroy);

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsRequest.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsRequest.java
@@ -32,6 +32,7 @@ public class DestroyObjectsRequest {
     private String[] ids;
     private String username;
     private AccessGroupSet principals;
+    private boolean completely;
 
     public DestroyObjectsRequest() {
     }
@@ -78,5 +79,13 @@ public class DestroyObjectsRequest {
 
     public void setJobId(String jobId) {
         this.jobId = jobId;
+    }
+
+    public boolean isDestroyCompletely() {
+        return completely;
+    }
+
+    public void setDestroyCompletely(boolean completely) {
+        this.completely = completely;
     }
 }

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsService.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsService.java
@@ -44,15 +44,20 @@ public class DestroyObjectsService extends MessageSender {
     private AccessControlService aclService;
     private RepositoryObjectLoader repoObjLoader;
 
+    public String destroyObjects(AgentPrincipals agent, String... ids) {
+        return destroyObjects(agent, false, ids);
+    }
+
     /**
      * Checks whether the active user has permissions to destroy the listed objects,
      * and then kicks off a job to destroy the permitted ones asynchronously
      *
      * @param agent security principals of the agent making request
+     * @param completely if true, the objects will be completely cleaned up
      * @param ids list of objects to destroy
      * @return the id of the destroy job created
      */
-    public String destroyObjects(AgentPrincipals agent, String... ids) {
+    public String destroyObjects(AgentPrincipals agent, boolean completely, String... ids) {
         if (ids.length == 0) {
             throw new IllegalArgumentException("Must provide ids for one or more objects to destroy");
         }
@@ -64,6 +69,7 @@ public class DestroyObjectsService extends MessageSender {
         }
         String jobId = UUID.randomUUID().toString();
         DestroyObjectsRequest request = new DestroyObjectsRequest(jobId, agent, ids);
+        request.setDestroyCompletely(completely);
         sendMessage(serializeDestroyRequest(request));
 
         log.info("Destroy job for {} objects started by {}", ids.length, agent.getUsernameUri());

--- a/persistence/src/main/java/edu/unc/lib/dl/services/DestroyObjectsMessageHelpers.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/services/DestroyObjectsMessageHelpers.java
@@ -19,6 +19,7 @@ import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.ATOM_NS;
 import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.CDR_MESSAGE_NS;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 
 import org.jdom2.Document;
@@ -34,14 +35,14 @@ public class DestroyObjectsMessageHelpers {
     }
 
     /**
-     * Sends a remove object message from the repository message
+     * Sends a remove object from the repository message
      *
      * @param  userid user making request
      * @param contentUri uri of object removed
      * @param metadata metadata for object removed
      * @return id of operation message
      */
-    public static Document makeDestroyOperationBody(String userid, URI contentUri, Map<String, String> metadata) {
+    public static Document makeDestroyOperationBody(String userid, List<URI> contentUris, Map<String, String> metadata) {
         Document msg = new Document();
         Element entry = new Element("entry", ATOM_NS);
 
@@ -51,8 +52,12 @@ public class DestroyObjectsMessageHelpers {
         Element objToDestroyEl = new Element("objToDestroy", CDR_MESSAGE_NS);
         entry.addContent(objToDestroyEl);
 
-        Element contentUriValue = new Element("contentUri", CDR_MESSAGE_NS).setText(contentUri.toString());
-        objToDestroyEl.addContent(contentUriValue);
+        if (contentUris != null) {
+            for (URI contentUri: contentUris) {
+                Element contentUriValue = new Element("contentUri", CDR_MESSAGE_NS).setText(contentUri.toString());
+                objToDestroyEl.addContent(contentUriValue);
+            }
+        }
         Element objType = new Element("objType", CDR_MESSAGE_NS).setText(metadata.get("objType"));
         objToDestroyEl.addContent(objType);
 

--- a/persistence/src/main/java/edu/unc/lib/dl/services/DestroyObjectsMessageHelpers.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/services/DestroyObjectsMessageHelpers.java
@@ -42,7 +42,8 @@ public class DestroyObjectsMessageHelpers {
      * @param metadata metadata for object removed
      * @return id of operation message
      */
-    public static Document makeDestroyOperationBody(String userid, List<URI> contentUris, Map<String, String> metadata) {
+    public static Document makeDestroyOperationBody(String userid, List<URI> contentUris,
+            Map<String, String> metadata) {
         Document msg = new Document();
         Element entry = new Element("entry", ATOM_NS);
 

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsCompletelyJobIT.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsCompletelyJobIT.java
@@ -1,0 +1,349 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.persist.services.destroy;
+
+import static edu.unc.lib.dl.fcrepo4.RepositoryPaths.getContentRootPid;
+import static edu.unc.lib.dl.sparql.SparqlUpdateHelper.createSparqlReplace;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.http.HttpStatus;
+import org.apache.jena.rdf.model.Model;
+import org.fcrepo.client.FcrepoClient;
+import org.fcrepo.client.FcrepoOperationFailedException;
+import org.fcrepo.client.FcrepoResponse;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import edu.unc.lib.dl.acl.exception.AccessRestrictionException;
+import edu.unc.lib.dl.acl.service.AccessControlService;
+import edu.unc.lib.dl.acl.util.AccessGroupSet;
+import edu.unc.lib.dl.acl.util.AgentPrincipals;
+import edu.unc.lib.dl.fcrepo4.AdminUnit;
+import edu.unc.lib.dl.fcrepo4.CollectionObject;
+import edu.unc.lib.dl.fcrepo4.ContentRootObject;
+import edu.unc.lib.dl.fcrepo4.FileObject;
+import edu.unc.lib.dl.fcrepo4.FolderObject;
+import edu.unc.lib.dl.fcrepo4.RepositoryInitializer;
+import edu.unc.lib.dl.fcrepo4.RepositoryObject;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
+import edu.unc.lib.dl.fcrepo4.WorkObject;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.fedora.ServiceException;
+import edu.unc.lib.dl.model.DatastreamPids;
+import edu.unc.lib.dl.persist.api.transfer.BinaryTransferService;
+import edu.unc.lib.dl.persist.services.edit.EditTitleService;
+import edu.unc.lib.dl.persist.services.storage.StorageLocationManagerImpl;
+import edu.unc.lib.dl.rdf.PcdmModels;
+import edu.unc.lib.dl.services.IndexingMessageSender;
+import edu.unc.lib.dl.services.MessageSender;
+import edu.unc.lib.dl.sparql.SparqlUpdateService;
+import edu.unc.lib.dl.test.AclModelBuilder;
+import edu.unc.lib.dl.test.RepositoryObjectTreeIndexer;
+import edu.unc.lib.dl.test.TestHelper;
+
+/**
+ * @author bbpennel
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextHierarchy({
+    @ContextConfiguration("/spring-test/test-fedora-container.xml"),
+    @ContextConfiguration("/spring-test/cdr-client-container.xml"),
+    @ContextConfiguration("/spring-test/acl-service-context.xml"),
+    @ContextConfiguration("/spring-test/destroy-completely-it-context.xml")
+})
+public class DestroyObjectsCompletelyJobIT {
+    private final static String LOC1_ID = "loc1";
+    private static final String USER_NAME = "user";
+    private static final String USER_GROUPS = "edu:lib:staff_grp";
+
+    @Rule
+    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+
+    @Autowired
+    private String baseAddress;
+    @Autowired
+    private RepositoryObjectFactory repoObjFactory;
+    @Autowired
+    private RepositoryObjectLoader repoObjLoader;
+    @Autowired
+    private FcrepoClient fcrepoClient;
+    @Autowired
+    private AccessControlService aclService;
+    @Autowired
+    private RepositoryInitializer repoInitializer;
+    @Mock
+    private IndexingMessageSender indexingMessageSender;
+    @Mock
+    private MessageSender binaryDestroyedMessageSender;
+
+    @Autowired
+    private StorageLocationManagerImpl locationManager;
+    @Autowired
+    private BinaryTransferService transferService;
+
+    @Autowired
+    private EditTitleService editTitleService;
+
+    private AgentPrincipals agent;
+
+    @Autowired
+    private SparqlUpdateService sparqlUpdateService;
+    @Autowired
+    private Model queryModel;
+    private RepositoryObjectTreeIndexer treeIndexer;
+
+    private ContentRootObject contentRoot;
+    private AdminUnit adminUnit;
+    private CollectionObject collection;
+
+    private DestroyObjectsCompletelyJob job;
+
+    @Before
+    public void init() throws Exception {
+        initMocks(this);
+        TestHelper.setContentBase(baseAddress);
+
+        AccessGroupSet testPrincipals = new AccessGroupSet(USER_GROUPS);
+        agent = new AgentPrincipals(USER_NAME, testPrincipals);
+
+        createContentTree();
+
+        treeIndexer = new RepositoryObjectTreeIndexer(queryModel, fcrepoClient);
+    }
+
+    private void createContentTree() throws Exception {
+        PID contentRootPid = getContentRootPid();
+        repoInitializer.initializeRepository();
+        contentRoot = repoObjLoader.getContentRootObject(contentRootPid);
+
+        adminUnit = repoObjFactory.createAdminUnit(new AclModelBuilder("Unit")
+                .addUnitOwner(agent.getUsernameUri())
+                .model);
+        contentRoot.addMember(adminUnit);
+
+        collection = repoObjFactory.createCollectionObject(null);
+        adminUnit.addMember(collection);
+    }
+
+    private void initializeJob(PID... objsToDestroy) {
+        DestroyObjectsRequest request = new DestroyObjectsRequest("jobid", agent,
+                Arrays.stream(objsToDestroy).map(PID::getQualifiedId).toArray(String[]::new));
+        job = new DestroyObjectsCompletelyJob(request);
+        job.setRepoObjFactory(repoObjFactory);
+        job.setRepoObjLoader(repoObjLoader);
+        job.setFcrepoClient(fcrepoClient);
+        job.setAclService(aclService);
+        job.setBinaryTransferService(transferService);
+        job.setStorageLocationManager(locationManager);
+        job.setIndexingMessageSender(indexingMessageSender);
+        job.setBinaryDestroyedMessageSender(binaryDestroyedMessageSender);
+    }
+
+    @Test
+    public void destroyBinaryObject() throws Exception {
+        WorkObject work = repoObjFactory.createWorkObject(null);
+        collection.addMember(work);
+
+        FileObject file = addFileToWork(work);
+
+        treeIndexer.indexAll(baseAddress);
+
+        PID originalPid = file.getOriginalFile().getPid();
+        File originalFile = new File(file.getOriginalFile().getContentUri());
+
+        initializeJob(originalPid);
+
+        try {
+            job.run();
+            fail("Must throw ServiceException");
+        } catch (ServiceException e) {
+            // expected
+            assertTrue(e.getMessage().contains("Refusing to destroy object"));
+        }
+        assertTrue(originalFile.exists());
+    }
+
+    @Test
+    public void destroyDescribedWork() throws Exception {
+        WorkObject work = repoObjFactory.createWorkObject(null);
+        collection.addMember(work);
+
+        editTitleService.editTitle(agent, work.getPid(), "first title");
+        editTitleService.editTitle(agent, work.getPid(), "second title");
+
+        FileObject file = addFileToWork(work);
+        File originalFile = new File(file.getOriginalFile().getContentUri());
+
+        treeIndexer.indexAll(baseAddress);
+
+        PID modsPid = DatastreamPids.getMdDescriptivePid(work.getPid());
+        File modsFile = new File(repoObjLoader.getBinaryObject(modsPid).getContentUri());
+        PID historyPid = DatastreamPids.getDatastreamHistoryPid(modsPid);
+        File historyFile = new File(repoObjLoader.getBinaryObject(historyPid).getContentUri());
+
+        assertTrue(originalFile.exists());
+        assertTrue(modsFile.exists());
+        assertTrue(historyFile.exists());
+
+        initializeJob(work.getPid());
+
+        job.run();
+
+        assertObjectRemoved(work);
+        assertObjectRemoved(file);
+
+        assertFalse(originalFile.exists());
+        assertFalse(modsFile.exists());
+        assertFalse(historyFile.exists());
+    }
+
+    // Ensure that an invalid membership relation can't result in destroying admin units
+    @Test
+    public void destroyContainerWithAdminUnitMember() throws Exception {
+        FolderObject folder = repoObjFactory.createFolderObject(null);
+        collection.addMember(folder);
+
+        AdminUnit unit2 = repoObjFactory.createAdminUnit(null);
+
+        // Force the admin unit as a member of the folder
+        String updateString = createSparqlReplace(unit2.getPid().getRepositoryPath(),
+                PcdmModels.memberOf, folder.getResource());
+        sparqlUpdateService.executeUpdate(unit2.getPid().getRepositoryPath(), updateString);
+
+        treeIndexer.indexAll(baseAddress);
+
+        initializeJob(folder.getPid());
+
+        try {
+            job.run();
+            fail("Must throw ServiceException");
+        } catch (ServiceException e) {
+            assertTrue(e.getMessage().contains("Refusing to destroy object"));
+        }
+        assertTrue(repoObjFactory.objectExists(adminUnit.getUri()));
+        assertTrue(repoObjFactory.objectExists(folder.getUri()));
+    }
+
+    @Test
+    public void destroyContentRoot() throws Exception {
+        treeIndexer.indexAll(baseAddress);
+
+        initializeJob(contentRoot.getPid());
+
+        try {
+            job.run();
+            fail("Must throw ServiceException");
+        } catch (ServiceException e) {
+            assertTrue(e.getMessage().contains("Refusing to destroy object"));
+        }
+        assertTrue(repoObjFactory.objectExists(contentRoot.getUri()));
+    }
+
+    @Test
+    public void destroyMultiple() throws Exception {
+        FolderObject folder = repoObjFactory.createFolderObject(null);
+        collection.addMember(folder);
+
+        FolderObject folder2 = repoObjFactory.createFolderObject(null);
+        collection.addMember(folder2);
+
+        WorkObject work = repoObjFactory.createWorkObject(null);
+        folder2.addMember(work);
+
+        FileObject file = addFileToWork(work);
+        File originalFile = new File(file.getOriginalFile().getContentUri());
+
+        treeIndexer.indexAll(baseAddress);
+
+        assertTrue(repoObjFactory.objectExists(folder.getUri()));
+        assertTrue(repoObjFactory.objectExists(folder2.getUri()));
+        assertTrue(repoObjFactory.objectExists(work.getUri()));
+        assertTrue(repoObjFactory.objectExists(file.getUri()));
+
+        initializeJob(folder.getPid(), folder2.getPid());
+
+        job.run();
+
+        assertObjectRemoved(folder);
+        assertObjectRemoved(folder2);
+        assertObjectRemoved(work);
+        assertObjectRemoved(file);
+        assertFalse(originalFile.exists());
+    }
+
+    @Test
+    public void destroyWorkInsufficientPermissions() throws Exception {
+        AccessGroupSet testPrincipals = new AccessGroupSet("please");
+        agent = new AgentPrincipals("letmein", testPrincipals);
+
+        WorkObject work = repoObjFactory.createWorkObject(null);
+        collection.addMember(work);
+
+        treeIndexer.indexAll(baseAddress);
+
+        initializeJob(work.getPid());
+
+        try {
+            job.run();
+            fail("Must throw AccessRestrictionException");
+        } catch (AccessRestrictionException e) {
+            // expected
+        }
+        assertTrue(repoObjFactory.objectExists(work.getUri()));
+    }
+
+    private FileObject addFileToWork(WorkObject work) throws Exception {
+        String bodyString = "Content";
+        String mimetype = "text/plain";
+        Path storagePath = Paths.get(locationManager.getStorageLocationById(LOC1_ID).getStorageUri(work.getPid()));
+        Files.createDirectories(storagePath);
+        File contentFile = Files.createTempFile(storagePath, "file", ".txt").toFile();
+        String filename = contentFile.getName();
+        FileUtils.writeStringToFile(contentFile, bodyString, "UTF-8");
+        return work.addDataFile(contentFile.toPath().toUri(), filename, mimetype, null, null);
+    }
+
+    private void assertObjectRemoved(RepositoryObject repoObj) throws Exception {
+        try (FcrepoResponse resp = fcrepoClient.head(repoObj.getUri()).perform()) {
+            fail("Expected object to not be found, but received response " + resp.getStatusCode());
+        } catch (FcrepoOperationFailedException e) {
+            if (e.getStatusCode() == HttpStatus.SC_NOT_FOUND) {
+                return;
+            } else {
+                throw e;
+            }
+        }
+    }
+}

--- a/persistence/src/test/resources/spring-test/destroy-completely-it-context.xml
+++ b/persistence/src/test/resources/spring-test/destroy-completely-it-context.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+  http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+
+    <bean id="versionedDatastreamService" class="edu.unc.lib.dl.persist.services.versioning.VersionedDatastreamService" >
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
+        <property name="binaryTransferService" ref="binaryTransferService" />
+    </bean>
+    
+    <bean id="updateDescriptionService" class="edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService" >
+        <property name="aclService" ref="aclService" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
+        <property name="operationsMessageSender" ref="operationsMessageSender" />
+        <property name="validate" value="false" />
+        <property name="versionedDatastreamService" ref="versionedDatastreamService" />
+    </bean>
+    
+    <bean id="editTitleService" class="edu.unc.lib.dl.persist.services.edit.EditTitleService">
+        <property name="aclService" ref="aclService" />
+        <property name="repoObjLoader" ref="repositoryObjectLoader" />
+        <property name="updateDescriptionService" ref="updateDescriptionService" />
+        <property name="operationsMessageSender" ref="operationsMessageSender" />
+    </bean>
+</beans>

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/destroy/DestroyObjectsProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/destroy/DestroyObjectsProcessor.java
@@ -32,6 +32,8 @@ import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
 import edu.unc.lib.dl.fcrepo4.TransactionManager;
 import edu.unc.lib.dl.persist.api.storage.StorageLocationManager;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferService;
+import edu.unc.lib.dl.persist.services.destroy.AbstractDestroyObjectsJob;
+import edu.unc.lib.dl.persist.services.destroy.DestroyObjectsCompletelyJob;
 import edu.unc.lib.dl.persist.services.destroy.DestroyObjectsJob;
 import edu.unc.lib.dl.persist.services.destroy.DestroyObjectsRequest;
 import edu.unc.lib.dl.search.solr.service.ObjectPathFactory;
@@ -68,24 +70,38 @@ public class DestroyObjectsProcessor implements Processor {
         final Message in = exchange.getIn();
 
         DestroyObjectsRequest request = MAPPER.readValue((String) in.getBody());
-        DestroyObjectsJob job = createJob(request);
+        AbstractDestroyObjectsJob job = createJob(request);
         job.run();
     }
 
-    private DestroyObjectsJob createJob(DestroyObjectsRequest request) {
-        DestroyObjectsJob job = new DestroyObjectsJob(request);
-        job.setFcrepoClient(fcrepoClient);
-        job.setPathFactory(pathFactory);
-        job.setRepoObjFactory(repoObjFactory);
-        job.setRepoObjLoader(repoObjLoader);
-        job.setTransactionManager(txManager);
-        job.setAclService(aclService);
-        job.setInheritedAclFactory(inheritedAclFactory);
-        job.setBinaryTransferService(transferService);
-        job.setStorageLocationManager(locManager);
-        job.setIndexingMessageSender(indexingMessageSender);
-        job.setBinaryDestroyedMessageSender(binaryDestroyedMessageSender);
-        return job;
+    private AbstractDestroyObjectsJob createJob(DestroyObjectsRequest request) {
+        if (request.isDestroyCompletely()) {
+            DestroyObjectsCompletelyJob job = new DestroyObjectsCompletelyJob(request);
+            job.setFcrepoClient(fcrepoClient);
+            job.setRepoObjFactory(repoObjFactory);
+            job.setRepoObjLoader(repoObjLoader);
+            job.setTransactionManager(txManager);
+            job.setAclService(aclService);
+            job.setBinaryTransferService(transferService);
+            job.setStorageLocationManager(locManager);
+            job.setIndexingMessageSender(indexingMessageSender);
+            job.setBinaryDestroyedMessageSender(binaryDestroyedMessageSender);
+            return job;
+        } else {
+            DestroyObjectsJob job = new DestroyObjectsJob(request);
+            job.setFcrepoClient(fcrepoClient);
+            job.setPathFactory(pathFactory);
+            job.setRepoObjFactory(repoObjFactory);
+            job.setRepoObjLoader(repoObjLoader);
+            job.setTransactionManager(txManager);
+            job.setAclService(aclService);
+            job.setInheritedAclFactory(inheritedAclFactory);
+            job.setBinaryTransferService(transferService);
+            job.setStorageLocationManager(locManager);
+            job.setIndexingMessageSender(indexingMessageSender);
+            job.setBinaryDestroyedMessageSender(binaryDestroyedMessageSender);
+            return job;
+        }
     }
 
     public void setAclService(AccessControlService aclService) {

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/destroyDerivatives/DestroyedMsgProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/destroyDerivatives/DestroyedMsgProcessor.java
@@ -84,7 +84,9 @@ public class DestroyedMsgProcessor implements Processor {
 
         if (mimeType == null) {
             mimeType = "";
-            log.info("No mimeType given for {} of object type {}", pidId, objType);
+            if (objType.equals(Cdr.FileObject.getURI())) {
+                log.warn("No mimeType given for {} of object type {}", pidId, objType);
+            }
         }
 
         in.setHeader(CdrBinaryMimeType, mimeType);

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/longleaf/GetUrisProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/longleaf/GetUrisProcessor.java
@@ -17,6 +17,9 @@ package edu.unc.lib.dl.services.camel.longleaf;
 
 import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.CDR_MESSAGE_NS;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
@@ -46,9 +49,10 @@ public class GetUrisProcessor implements Processor {
         }
 
         Element root = doc.getRootElement();
-        String contentUri = root.getChild("objToDestroy", CDR_MESSAGE_NS)
-                .getChildTextTrim("contentUri", CDR_MESSAGE_NS);
+        List<String> contentUris = root.getChild("objToDestroy", CDR_MESSAGE_NS)
+                .getChildren("contentUri", CDR_MESSAGE_NS)
+                .stream().map(Element::getTextTrim).collect(Collectors.toList());
 
-        in.setBody(contentUri);
+        in.setBody(contentUris);
     }
 }


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3024

* Adds Destroy Completely job, which completely removes objects from the repository, without leaving behind metadata or a tombstone
* Adds commandline interface for destroying objects
    * An option may be provided to completely destroy the objects
* Adds more restrictions on what objects can be targeted by destroy operations
* Allows destroy messages to list more than one binary
* Attempts to suppress some of the log spam from the triple store indexing service caused by objects being destroyed, although there is still some from within the triple store indexing service itself.
* Removes an unused solr indexing delete action