### PR TITLE
Derivative regeneration without the force flag

### DIFF
--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/images/AddDerivativeProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/images/AddDerivativeProcessor.java
@@ -100,8 +100,9 @@ public class AddDerivativeProcessor implements Processor {
             moveFile(derivativeTmpPath, derivativeFinalPath);
             log.info("Added derivative for {} from {}", binaryUri, derivativeFinalPath);
         } catch (FileAlreadyExistsException e) {
-            log.warn("A derivative already exists for {} at {}. Regenerating without the force flag.",
+            log.warn("A derivative already exists for {} at {}. Attempting regeneration without the force flag.",
                     binaryUri, derivativeFinalPath);
+            throw e;
         } catch (IOException e) {
             String stderr = "";
             if (result != null && result.getStderr() != null) {

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/images/AddDerivativeProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/images/AddDerivativeProcessor.java
@@ -24,6 +24,7 @@ import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -98,6 +99,9 @@ public class AddDerivativeProcessor implements Processor {
 
             moveFile(derivativeTmpPath, derivativeFinalPath);
             log.info("Added derivative for {} from {}", binaryUri, derivativeFinalPath);
+        } catch (FileAlreadyExistsException e) {
+            log.warn("A derivative already exists for {} at {}. Regenerating without the force flag.",
+                    binaryUri, derivativeFinalPath);
         } catch (IOException e) {
             String stderr = "";
             if (result != null && result.getStderr() != null) {


### PR DESCRIPTION
Catch file exists exceptions. It's possible in some circumstances for "notExists" to report a file doesn't exist when it actually does, such as when the file is locked by another process.

https://jira.lib.unc.edu/browse/BXC-3036

