### PR TITLE
BXC-2880 - Transaction Aware Binary Transfers

### DIFF
--- a/access/src/test/resources/spring-test/cdr-client-container.xml
+++ b/access/src/test/resources/spring-test/cdr-client-container.xml
@@ -72,8 +72,13 @@
         <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
     </bean>
     
+    <bean id="binaryTransferService" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.persist.api.transfer.BinaryTransferService" />
+    </bean>
+    
     <bean id="transactionManager" class="edu.unc.lib.dl.fcrepo4.TransactionManager">
         <property name="client" ref="fcrepoClient" />
+        <property name="binaryTransferService" ref="binaryTransferService" />
     </bean>
     
     <bean id="sparqlUpdateService" class="edu.unc.lib.dl.sparql.FedoraSparqlUpdateService">

--- a/deposit/pom.xml
+++ b/deposit/pom.xml
@@ -37,6 +37,10 @@
             <artifactId>powermock-api-mockito</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+        </dependency>
+        <dependency>
             <groupId>edu.unc.lib.cdr</groupId>
             <artifactId>metadata</artifactId>
         </dependency>

--- a/deposit/src/main/webapp/WEB-INF/deposit-jobs-context.xml
+++ b/deposit/src/main/webapp/WEB-INF/deposit-jobs-context.xml
@@ -101,6 +101,7 @@
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
         <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
         <property name="binaryTransferService" ref="binaryTransferService" />
+        <property name="transactionManager" ref="transactionManager" />
     </bean>
     
     <bean id="updateDescriptionService" class="edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService" >

--- a/deposit/src/main/webapp/WEB-INF/fcrepo-clients-context.xml
+++ b/deposit/src/main/webapp/WEB-INF/fcrepo-clients-context.xml
@@ -67,6 +67,7 @@
     
     <bean id="transactionManager" class="edu.unc.lib.dl.fcrepo4.TransactionManager">
         <property name="client" ref="fcrepoClient" />
+        <property name="binaryTransferService" ref="binaryTransferService" />
     </bean>
     
     <bean id="repositoryInitializer" class="edu.unc.lib.dl.fcrepo4.RepositoryInitializer"

--- a/deposit/src/test/java/edu/unc/lib/deposit/validate/ExtractTechnicalMetadataJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/validate/ExtractTechnicalMetadataJobTest.java
@@ -18,6 +18,7 @@ package edu.unc.lib.deposit.validate;
 import static edu.unc.lib.dl.test.TestHelpers.setField;
 import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.FITS_NS;
 import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.PREMIS_V3_NS;
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -38,6 +39,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -344,6 +346,8 @@ public class ExtractTechnicalMetadataJobTest extends AbstractDepositJobTest {
 
         job.run();
 
+        await().atMost(Duration.ofSeconds(2))
+            .until(() -> techmdDir.list().length == 2);
         verifyFileResults(filePid, IMAGE_MIMETYPE, IMAGE_FORMAT, IMAGE_MD5, IMAGE_FILEPATH, 2);
     }
 

--- a/deposit/src/test/resources/spring-test/cdr-client-container.xml
+++ b/deposit/src/test/resources/spring-test/cdr-client-container.xml
@@ -131,6 +131,7 @@
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
         <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
         <property name="binaryTransferService" ref="binaryTransferService" />
+        <property name="transactionManager" ref="transactionManager" />
     </bean>
 
     <bean id="updateDescriptionService" class="edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService" >

--- a/deposit/src/test/resources/spring-test/cdr-client-container.xml
+++ b/deposit/src/test/resources/spring-test/cdr-client-container.xml
@@ -145,6 +145,7 @@
     
     <bean id="transactionManager" class="edu.unc.lib.dl.fcrepo4.TransactionManager">
         <property name="client" ref="fcrepoClient" />
+        <property name="binaryTransferService" ref="binaryTransferService" />
     </bean>
     
     <bean id="verifyObjectsAreInFedoraService" class="edu.unc.lib.deposit.validate.VerifyObjectsAreInFedoraService" >

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/DepositRecord.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/DepositRecord.java
@@ -47,19 +47,6 @@ public class DepositRecord extends RepositoryObject {
     }
 
     /**
-     *  Adds the given file as a manifest for this deposit.
-     *
-     * @param manifestUri URI of the binary content for this manifest
-     * @param mimetype mimetype string of the manifest file
-     * @return BinaryObject representing the newly created manifest object
-     * @throws FedoraException
-     */
-    public BinaryObject addManifest(URI manifestUri, String mimetype)
-            throws FedoraException {
-        return addManifest(manifestUri, null, mimetype, null, null);
-    }
-
-    /**
      * Adds the given inputstream as the content of a manifest for this deposit.
      *
      * @param manifestUri URI of the binary content for this manifest

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/FedoraTransaction.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/FedoraTransaction.java
@@ -54,6 +54,10 @@ public class FedoraTransaction {
         return rootTxThread.get() != null;
     }
 
+    public static FedoraTransaction getActiveTx() {
+        return rootTxThread.get();
+    }
+
     public URI getTxUri() {
         return txUri;
     }

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/TransactionManager.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/TransactionManager.java
@@ -75,6 +75,7 @@ public class TransactionManager {
             binaryTransferService.rollbackTransaction(txUri);
             throw new FedoraException("Unable to commit transaction", e);
         }
+        binaryTransferService.commitTransaction(txUri);
     }
 
     protected void keepTransactionAlive(URI txUri) {

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/TransactionManager.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/TransactionManager.java
@@ -24,6 +24,7 @@ import org.fcrepo.client.FcrepoOperationFailedException;
 import org.fcrepo.client.FcrepoResponse;
 
 import edu.unc.lib.dl.fedora.FedoraException;
+import edu.unc.lib.dl.persist.api.transfer.BinaryTransferService;
 import edu.unc.lib.dl.util.URIUtil;
 
 /**
@@ -38,8 +39,13 @@ public class TransactionManager {
     private static final String COMMIT_TX = "fcr:tx/fcr:commit";
     private static final String ROLLBACK_TX = "fcr:tx/fcr:rollback";
     private FcrepoClient client;
+    private BinaryTransferService binaryTransferService;
 
     public FedoraTransaction startTransaction() throws FedoraException {
+        if (FedoraTransaction.isStillAlive()) {
+            FedoraTransaction rootTx = FedoraTransaction.rootTxThread.get();
+            return new FedoraTransaction(rootTx.getTxUri(), this);
+        }
         URI repoBase = URI.create(RepositoryPaths.getBaseUri());
         // appends suffix for creating transaction
         URI createTxUri = URI.create(URIUtil.join(repoBase, CREATE_TX));
@@ -65,7 +71,8 @@ public class TransactionManager {
                 throw new FcrepoOperationFailedException(txUri, statusCode,
                         response.getHeaderValues("Status").toString());
             }
-        } catch (IOException | FcrepoOperationFailedException e) {
+        } catch (Exception e) {
+            binaryTransferService.rollbackTransaction(txUri);
             throw new FedoraException("Unable to commit transaction", e);
         }
     }
@@ -95,6 +102,8 @@ public class TransactionManager {
             }
         } catch (IOException | FcrepoOperationFailedException e) {
             throw new FedoraException("Unable to cancel transaction", e);
+        } finally {
+            binaryTransferService.rollbackTransaction(txUri);
         }
     }
 
@@ -106,4 +115,7 @@ public class TransactionManager {
         return client;
     }
 
+    public void setBinaryTransferService(BinaryTransferService binaryTransferService) {
+        this.binaryTransferService = binaryTransferService;
+    }
 }

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/persist/api/storage/StorageLocation.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/persist/api/storage/StorageLocation.java
@@ -16,6 +16,7 @@
 package edu.unc.lib.dl.persist.api.storage;
 
 import java.net.URI;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
@@ -69,6 +70,13 @@ public interface StorageLocation {
      * @return existing current storage URI for the given PID, or null it it does not exist
      */
     URI getCurrentStorageUri(PID pid);
+
+    /**
+     * Get a list containing all binary storage URIs for the resource with the given PID
+     * @param pid
+     * @return List of binary URIs
+     */
+    List<URI> getAllStorageUris(PID pid);
 
     /**
      * Returns true if the provided URI is a valid within this storage location.

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/persist/api/storage/StorageLocation.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/persist/api/storage/StorageLocation.java
@@ -55,12 +55,20 @@ public interface StorageLocation {
     StorageType getStorageType();
 
     /**
-     * Return the URI where a resource with the given PID should be stored.
+     * Get a new URI where a resource with the given PID should be stored.
      *
      * @param pid
-     * @return
+     * @return new storage URI
      */
-    URI getStorageUri(PID pid);
+    URI getNewStorageUri(PID pid);
+
+    /**
+     * Return the existing current URI where the resource with the given PID is stored
+     *
+     * @param pid
+     * @return existing current storage URI for the given PID, or null it it does not exist
+     */
+    URI getCurrentStorageUri(PID pid);
 
     /**
      * Returns true if the provided URI is a valid within this storage location.

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/persist/api/transfer/BinaryTransferOutcome.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/persist/api/transfer/BinaryTransferOutcome.java
@@ -17,6 +17,8 @@ package edu.unc.lib.dl.persist.api.transfer;
 
 import java.net.URI;
 
+import edu.unc.lib.dl.fedora.PID;
+
 /**
  * Information describing the outcome of a binary transfer operation
  *
@@ -25,9 +27,19 @@ import java.net.URI;
 public interface BinaryTransferOutcome {
 
     /**
+     * @return PID of the binary object the transferred file was associated with.
+     */
+    PID getBinaryPid();
+
+    /**
      * @return URI where the binary is stored after the transfer
      */
     URI getDestinationUri();
+
+    /**
+     * @return ID of the storage location where the binary was transferred to
+     */
+    String getDestinationId();
 
     /**
      * @return SHA1 calculated of the binary during transfer

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/persist/api/transfer/BinaryTransferService.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/persist/api/transfer/BinaryTransferService.java
@@ -15,6 +15,8 @@
  */
 package edu.unc.lib.dl.persist.api.transfer;
 
+import java.net.URI;
+
 import edu.unc.lib.dl.fcrepo4.RepositoryObject;
 import edu.unc.lib.dl.persist.api.storage.StorageLocation;
 
@@ -48,4 +50,17 @@ public interface BinaryTransferService {
      * @return new binary transfer session
      */
     BinaryTransferSession getSession(RepositoryObject repoObj);
+
+    /**
+     * Rolls back the binary transfers associated with the provided repository transaction
+     * @param txUri URI of the repository transaction to roll back
+     */
+    void rollbackTransaction(URI txUri);
+
+    /**
+     * Register the outcome of a transfer
+     * @param txUri URI of the repository transaction the transfer was a part of, or null if not in one.
+     * @param outcome results of the transfer
+     */
+    void registerOutcome(URI txUri, BinaryTransferOutcome outcome);
 }

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/persist/api/transfer/BinaryTransferService.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/persist/api/transfer/BinaryTransferService.java
@@ -58,9 +58,14 @@ public interface BinaryTransferService {
     void rollbackTransaction(URI txUri);
 
     /**
+     * Commits the binary transfers associated with the provided transaction
+     * @param txUri URI of the repository transaction committed
+     */
+    void commitTransaction(URI txUri);
+
+    /**
      * Register the outcome of a transfer
-     * @param txUri URI of the repository transaction the transfer was a part of, or null if not in one.
      * @param outcome results of the transfer
      */
-    void registerOutcome(URI txUri, BinaryTransferOutcome outcome);
+    BinaryTransferOutcome registerOutcome(BinaryTransferOutcome outcome);
 }

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/DepositRecordIT.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/DepositRecordIT.java
@@ -101,9 +101,10 @@ public class DepositRecordIT extends AbstractFedoraIT {
 
         String bodyString2 = "Second manifest";
         String mimetype2 = "text/plain";
+        String filename2 = "manifest2";
         Path manifestPath2 = createTempFile("manifest", ".txt");
         writeStringToFile(manifestPath2.toFile(), bodyString2, UTF_8);
-        BinaryObject manifest2 = record.addManifest(manifestPath2.toUri(), mimetype2);
+        BinaryObject manifest2 = record.addManifest(manifestPath2.toUri(), filename2, mimetype2, null, null);
 
         assertNotNull(manifest2);
 

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/FedoraTransactionIT.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/FedoraTransactionIT.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.io.IOException;
 
@@ -32,8 +33,10 @@ import org.fcrepo.client.FcrepoOperationFailedException;
 import org.fcrepo.client.FcrepoResponse;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
 
 import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.persist.api.transfer.BinaryTransferService;
 import edu.unc.lib.dl.rdf.Cdr;
 import edu.unc.lib.dl.rdf.DcElements;
 import edu.unc.lib.dl.rdf.PcdmModels;
@@ -46,9 +49,13 @@ import edu.unc.lib.dl.rdf.PcdmModels;
 public class FedoraTransactionIT extends AbstractFedoraIT {
 
     private Model model;
+    @Mock
+    private BinaryTransferService binaryTransferService;
 
     @Before
     public void init() {
+        initMocks(this);
+        txManager.setBinaryTransferService(binaryTransferService);
         model = ModelFactory.createDefaultModel();
         Resource resc = model.createResource("");
         resc.addProperty(DcElements.title, "Folder Title");

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/TransactionalFcrepoClientIT.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/TransactionalFcrepoClientIT.java
@@ -20,6 +20,7 @@ import static org.apache.jena.rdf.model.ResourceFactory.createResource;
 import static org.fcrepo.client.FedoraTypes.LDP_NON_RDF_SOURCE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import java.io.InputStream;
 import java.net.URI;
@@ -41,6 +42,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.persist.api.transfer.BinaryTransferService;
 import edu.unc.lib.dl.test.TestHelper;
 import edu.unc.lib.dl.util.RDFModelUtil;
 
@@ -62,7 +64,9 @@ public class TransactionalFcrepoClientIT {
     public void setup() {
         TestHelper.setContentBase(BASE_PATH);
 
+        BinaryTransferService bts = mock(BinaryTransferService.class);
         txManager = new TransactionManager();
+        txManager.setBinaryTransferService(bts);
     }
 
     @Test

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/TransactionalFcrepoClientTest.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/TransactionalFcrepoClientTest.java
@@ -38,6 +38,8 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import edu.unc.lib.dl.persist.api.transfer.BinaryTransferService;
+
 /**
  *
  * @author harring
@@ -65,6 +67,8 @@ public class TransactionalFcrepoClientTest extends AbstractFedoraTest {
     private CloseableHttpResponse httpResponse;
     @Mock
     private Header header;
+    @Mock
+    private BinaryTransferService bts;
 
     @Before
     public void setup() throws Exception {
@@ -74,6 +78,7 @@ public class TransactionalFcrepoClientTest extends AbstractFedoraTest {
         txClient = (TransactionalFcrepoClient) builder.build();
         txManager= new TransactionManager();
         txManager.setClient(txClient);
+        txManager.setBinaryTransferService(bts);
         tx = new FedoraTransaction(uri, txManager);
 
         setField(txClient, "httpclient", httpClient);

--- a/fcrepo-clients/src/test/resources/spring-test/cdr-client-container.xml
+++ b/fcrepo-clients/src/test/resources/spring-test/cdr-client-container.xml
@@ -94,7 +94,12 @@
         <property name="fcrepoClient" ref="fcrepoClient" />
     </bean>
     
+    <bean id="binaryTransferService" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.persist.api.transfer.BinaryTransferService" />
+    </bean>
+    
     <bean id="txManager" class="edu.unc.lib.dl.fcrepo4.TransactionManager">
         <property name="client" ref="fcrepoClient" />
+        <property name="binaryTransferService" ref="binaryTransferService" />
     </bean>
 </beans>

--- a/migration-util/src/main/resources/spring/service-context.xml
+++ b/migration-util/src/main/resources/spring/service-context.xml
@@ -119,6 +119,7 @@
     
     <bean id="txManager" class="edu.unc.lib.dl.fcrepo4.TransactionManager">
         <property name="client" ref="fcrepoClient" />
+        <property name="binaryTransferService" ref="binaryTransferService" />
     </bean>
     
     <bean id="pathIndex" class="edu.unc.lib.dcr.migration.paths.PathIndex"

--- a/migration-util/src/test/java/edu/unc/lib/dcr/migration/RecalculateDigestsCommandIT.java
+++ b/migration-util/src/test/java/edu/unc/lib/dcr/migration/RecalculateDigestsCommandIT.java
@@ -174,7 +174,7 @@ public class RecalculateDigestsCommandIT {
 
         PID manifestPid = DatastreamPids.getDepositManifestPid(depRec.getPid(), "manifest0");
         BinaryTransferOutcome manifestOut = transferContent(manifestPid, "manifested");
-        depRec.addManifest(manifestOut.getDestinationUri(), "text/plain");
+        depRec.addManifest(manifestOut.getDestinationUri(), "manifest0", "text/plain", null, null);
 
         treeIndexer.indexAll(baseAddress);
 

--- a/migration-util/src/test/resources/spring-test/cdr-client-container.xml
+++ b/migration-util/src/test/resources/spring-test/cdr-client-container.xml
@@ -109,6 +109,7 @@
     
     <bean id="txManager" class="edu.unc.lib.dl.fcrepo4.TransactionManager">
         <property name="client" ref="fcrepoClient" />
+        <property name="binaryTransferService" ref="binaryTransferService" />
     </bean>
     
     <bean id="pathIndex" class="edu.unc.lib.dcr.migration.paths.PathIndex"

--- a/persistence/pom.xml
+++ b/persistence/pom.xml
@@ -115,8 +115,6 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>4.0.3</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>

--- a/persistence/pom.xml
+++ b/persistence/pom.xml
@@ -113,6 +113,12 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.0.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-broker</artifactId>
         </dependency>

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/storage/HashedFilesystemStorageLocation.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/storage/HashedFilesystemStorageLocation.java
@@ -107,8 +107,10 @@ public class HashedFilesystemStorageLocation implements StorageLocation {
 
     @Override
     public URI getNewStorageUri(PID pid) {
-        String path = getBaseStoragePath(pid);
-        path += "." + System.nanoTime();
+        String base = getBaseStoragePath(pid);
+        // Add timestamp to base path, combining wall time millisecond with relative nanotime
+        long nano = System.nanoTime() % 1000000;
+        String path = base + "." + System.currentTimeMillis() + Long.toString(nano);
         return URI.create(path).normalize();
     }
 

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/storage/HashedFilesystemStorageLocation.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/storage/HashedFilesystemStorageLocation.java
@@ -21,6 +21,8 @@ import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.HASHED_PATH_SIZE;
 import java.net.URI;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
+
 import edu.unc.lib.dl.fcrepo4.RepositoryPaths;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.persist.api.storage.StorageLocation;
@@ -109,8 +111,8 @@ public class HashedFilesystemStorageLocation implements StorageLocation {
     public URI getNewStorageUri(PID pid) {
         String base = getBaseStoragePath(pid);
         // Add timestamp to base path, combining wall time millisecond with relative nanotime
-        long nano = System.nanoTime() % 1000000;
-        String path = base + "." + System.currentTimeMillis() + Long.toString(nano);
+        String nano = StringUtils.right(Long.toString(System.nanoTime()), 6);
+        String path = base + "." + System.currentTimeMillis() + nano;
         return URI.create(path).normalize();
     }
 

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/storage/HashedFilesystemStorageLocation.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/storage/HashedFilesystemStorageLocation.java
@@ -19,6 +19,7 @@ import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.HASHED_PATH_DEPTH;
 import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.HASHED_PATH_SIZE;
 
 import java.net.URI;
+import java.util.List;
 
 import edu.unc.lib.dl.fcrepo4.RepositoryPaths;
 import edu.unc.lib.dl.fedora.PID;
@@ -115,6 +116,12 @@ public class HashedFilesystemStorageLocation implements StorageLocation {
     public URI getCurrentStorageUri(PID pid) {
         String path = getBaseStoragePath(pid);
         return FileSystemTransferHelpers.getMostRecentStorageUri(URI.create(path));
+    }
+
+    @Override
+    public List<URI> getAllStorageUris(PID pid) {
+        String path = getBaseStoragePath(pid);
+        return FileSystemTransferHelpers.getAllStorageUris(URI.create(path));
     }
 
     @Override

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/storage/HashedFilesystemStorageLocation.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/storage/HashedFilesystemStorageLocation.java
@@ -19,9 +19,11 @@ import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.HASHED_PATH_DEPTH;
 import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.HASHED_PATH_SIZE;
 
 import java.net.URI;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
-
-import org.apache.commons.lang3.StringUtils;
 
 import edu.unc.lib.dl.fcrepo4.RepositoryPaths;
 import edu.unc.lib.dl.fedora.PID;
@@ -39,6 +41,10 @@ import edu.unc.lib.dl.util.URIUtil;
  */
 public class HashedFilesystemStorageLocation implements StorageLocation {
     public static final String TYPE_NAME = "hashed_fs";
+
+    private static final DateTimeFormatter TIME_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
+                .withZone(ZoneId.from(ZoneOffset.UTC));
 
     private String id;
     private String name;
@@ -111,8 +117,9 @@ public class HashedFilesystemStorageLocation implements StorageLocation {
     public URI getNewStorageUri(PID pid) {
         String base = getBaseStoragePath(pid);
         // Add timestamp to base path, combining wall time millisecond with relative nanotime
-        String nano = StringUtils.right(Long.toString(System.nanoTime()), 6);
-        String path = base + "." + System.currentTimeMillis() + nano;
+
+        String timestamp = TIME_FORMATTER.format(Instant.now());
+        String path = base + "." + timestamp + System.nanoTime();
         return URI.create(path).normalize();
     }
 

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/BinaryTransferOutcomeImpl.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/BinaryTransferOutcomeImpl.java
@@ -17,6 +17,7 @@ package edu.unc.lib.dl.persist.services.transfer;
 
 import java.net.URI;
 
+import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferOutcome;
 
 /**
@@ -26,11 +27,15 @@ import edu.unc.lib.dl.persist.api.transfer.BinaryTransferOutcome;
  */
 public class BinaryTransferOutcomeImpl implements BinaryTransferOutcome {
 
+    private PID binPid;
     private URI destinationUri;
+    private String destinationId;
     private String sha1;
 
-    public BinaryTransferOutcomeImpl(URI destinationUri, String sha1) {
+    public BinaryTransferOutcomeImpl(PID binPid, URI destinationUri, String destinationId, String sha1) {
+        this.binPid = binPid;
         this.destinationUri = destinationUri;
+        this.destinationId = destinationId;
         this.sha1 = sha1;
     }
 
@@ -44,4 +49,17 @@ public class BinaryTransferOutcomeImpl implements BinaryTransferOutcome {
         return sha1;
     }
 
+    @Override
+    public PID getBinaryPid() {
+        return binPid;
+    }
+
+    @Override
+    public String getDestinationId() {
+        return destinationId;
+    }
+
+    public static enum BinaryTransferActionTaken {
+        Created, Replaced, VersionAdded;
+    }
 }

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/BinaryTransferOutcomeImpl.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/BinaryTransferOutcomeImpl.java
@@ -58,8 +58,4 @@ public class BinaryTransferOutcomeImpl implements BinaryTransferOutcome {
     public String getDestinationId() {
         return destinationId;
     }
-
-    public static enum BinaryTransferActionTaken {
-        Created, Replaced, VersionAdded;
-    }
 }

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/BinaryTransferServiceImpl.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/BinaryTransferServiceImpl.java
@@ -15,10 +15,21 @@
  */
 package edu.unc.lib.dl.persist.services.transfer;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.slf4j.Logger;
+
 import edu.unc.lib.dl.fcrepo4.RepositoryObject;
 import edu.unc.lib.dl.persist.api.ingest.IngestSourceManager;
 import edu.unc.lib.dl.persist.api.storage.StorageLocation;
 import edu.unc.lib.dl.persist.api.storage.StorageLocationManager;
+import edu.unc.lib.dl.persist.api.transfer.BinaryTransferOutcome;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferService;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferSession;
 import edu.unc.lib.dl.persist.api.transfer.MultiDestinationTransferSession;
@@ -30,10 +41,17 @@ import edu.unc.lib.dl.persist.api.transfer.MultiDestinationTransferSession;
  *
  */
 public class BinaryTransferServiceImpl implements BinaryTransferService {
+    private static final Logger log = getLogger(BinaryTransferServiceImpl.class);
 
     private IngestSourceManager sourceManager;
 
     private StorageLocationManager storageLocationManager;
+
+    private Map<String, Collection<TransferCacheEntry>> txTransferCache;
+
+    public BinaryTransferServiceImpl() {
+        txTransferCache = new ConcurrentHashMap<>();
+    }
 
     @Override
     public MultiDestinationTransferSession getSession() {
@@ -51,6 +69,39 @@ public class BinaryTransferServiceImpl implements BinaryTransferService {
         return getSession(loc);
     }
 
+    @Override
+    public void rollbackTransaction(URI txUri) {
+        String txId = txUri.toString();
+        Collection<TransferCacheEntry> cache = txTransferCache.get(txId);
+        if (cache == null) {
+            return;
+        }
+        new Thread(() -> {
+            try (MultiDestinationTransferSession mSession = getSession()) {
+                for (TransferCacheEntry entry : cache) {
+                    StorageLocation loc = storageLocationManager.getStorageLocationById(entry.newContentStorageId);
+                    try (BinaryTransferSession session = mSession.forDestination(loc)) {
+                        session.delete(entry.newContentUri);
+                    } catch (Exception e) {
+                        log.error("Rollback of transaction failed to cleanup new binary {}", entry.newContentUri, e);
+                    }
+                }
+            } finally {
+                txTransferCache.remove(txId);
+            }
+        }).start();
+    }
+
+    @Override
+    public void registerOutcome(URI txUri, BinaryTransferOutcome outcome) {
+        if (txUri == null) {
+            return;
+        }
+        String txId = txUri.toString();
+        txTransferCache.computeIfAbsent(txId, k -> new ConcurrentLinkedQueue<TransferCacheEntry>())
+                .add(new TransferCacheEntry(outcome));
+    }
+
     /**
      * @param sourceManager the sourceManager to set
      */
@@ -62,4 +113,13 @@ public class BinaryTransferServiceImpl implements BinaryTransferService {
         this.storageLocationManager = storageLocationManager;
     }
 
+    private static class TransferCacheEntry {
+        private URI newContentUri;
+        private String newContentStorageId;
+
+        private TransferCacheEntry(BinaryTransferOutcome outcome) {
+            this.newContentUri = outcome.getDestinationUri();
+            this.newContentStorageId = outcome.getDestinationId();
+        }
+    }
 }

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/BinaryTransferSessionImpl.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/BinaryTransferSessionImpl.java
@@ -33,6 +33,7 @@ import edu.unc.lib.dl.persist.api.storage.BinaryDetails;
 import edu.unc.lib.dl.persist.api.storage.StorageLocation;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferClient;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferOutcome;
+import edu.unc.lib.dl.persist.api.transfer.BinaryTransferService;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferSession;
 import edu.unc.lib.dl.persist.api.transfer.StreamTransferClient;
 
@@ -48,16 +49,19 @@ public class BinaryTransferSessionImpl implements BinaryTransferSession {
     private StorageLocation storageLocation;
     private Map<String, BinaryTransferClient> clientCache;
     private StreamTransferClient streamClient;
+    private BinaryTransferService binaryTransferService;
 
     /**
      * Constructor for session for a single destination
      *
      * @param storageLocation
      */
-    public BinaryTransferSessionImpl(IngestSourceManager sourceManager, StorageLocation storageLocation) {
+    public BinaryTransferSessionImpl(IngestSourceManager sourceManager, StorageLocation storageLocation,
+            BinaryTransferService binaryTransferService) {
         notNull(storageLocation, "Must provide a storage location");
         this.sourceManager = sourceManager;
         this.storageLocation = storageLocation;
+        this.binaryTransferService = binaryTransferService;
     }
 
     @Override
@@ -74,21 +78,24 @@ public class BinaryTransferSessionImpl implements BinaryTransferSession {
     public BinaryTransferOutcome transfer(PID binPid, URI sourceFileUri) {
         IngestSource source = sourceManager.getIngestSourceForUri(sourceFileUri);
         BinaryTransferClient client = getTransferClient(source);
-        return client.transfer(binPid, sourceFileUri);
+        return binaryTransferService.registerOutcome(
+                client.transfer(binPid, sourceFileUri));
     }
 
     @Override
     public BinaryTransferOutcome transferReplaceExisting(PID binPid, URI sourceFileUri) {
         IngestSource source = sourceManager.getIngestSourceForUri(sourceFileUri);
         BinaryTransferClient client = getTransferClient(source);
-        return client.transferReplaceExisting(binPid, sourceFileUri);
+        return binaryTransferService.registerOutcome(
+                client.transferReplaceExisting(binPid, sourceFileUri));
     }
 
     @Override
     public BinaryTransferOutcome transferVersion(PID binPid, URI sourceFileUri) {
         IngestSource source = sourceManager.getIngestSourceForUri(sourceFileUri);
         BinaryTransferClient client = getTransferClient(source);
-        return client.transferVersion(binPid, sourceFileUri);
+        return binaryTransferService.registerOutcome(
+                client.transferVersion(binPid, sourceFileUri));
     }
 
     private BinaryTransferClient getTransferClient(IngestSource source) {
@@ -117,17 +124,20 @@ public class BinaryTransferSessionImpl implements BinaryTransferSession {
 
     @Override
     public BinaryTransferOutcome transfer(PID binPid, InputStream sourceStream) {
-        return getStreamClient().transfer(binPid, sourceStream);
+        return binaryTransferService.registerOutcome(
+                getStreamClient().transfer(binPid, sourceStream));
     }
 
     @Override
     public BinaryTransferOutcome transferReplaceExisting(PID binPid, InputStream sourceStream) {
-        return getStreamClient().transferReplaceExisting(binPid, sourceStream);
+        return binaryTransferService.registerOutcome(
+                getStreamClient().transferReplaceExisting(binPid, sourceStream));
     }
 
     @Override
     public BinaryTransferOutcome transferVersion(PID binPid, InputStream sourceStream) {
-        return getStreamClient().transferVersion(binPid, sourceStream);
+        return binaryTransferService.registerOutcome(
+                getStreamClient().transferVersion(binPid, sourceStream));
     }
 
     private StreamTransferClient getStreamClient() {

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/FileSystemTransferHelpers.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/FileSystemTransferHelpers.java
@@ -151,13 +151,20 @@ public class FileSystemTransferHelpers {
         if (Files.notExists(dirPath)) {
             return false;
         }
-        String filename = filePath.getFileName().toString();
-        String namePrefix = StringUtils.substringBefore(filename, ".");
+        String namePrefix = getBaseBinaryPath(filePath.getFileName());
         try (Stream<Path> stream = Files.list(dirPath)) {
             return stream.filter(path -> !Files.isDirectory(path))
                     .anyMatch(path -> path.getFileName().toString().startsWith(namePrefix));
         } catch (IOException e) {
             throw new BinaryTransferException("Failed to check for storage URI " + filePath, e);
         }
+    }
+
+    /**
+     * @param filePath
+     * @return the base form of the provided path, as a string
+     */
+    public static String getBaseBinaryPath(Path filePath) {
+        return StringUtils.substringBeforeLast(filePath.toString(), ".");
     }
 }

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/FileSystemTransferHelpers.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/FileSystemTransferHelpers.java
@@ -20,13 +20,18 @@ import static org.apache.commons.codec.binary.Hex.encodeHexString;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Comparator;
 import java.util.Date;
+import java.util.NoSuchElementException;
+import java.util.stream.Stream;
 
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import edu.unc.lib.dl.exceptions.RepositoryException;
 import edu.unc.lib.dl.fedora.PID;
@@ -54,7 +59,10 @@ public class FileSystemTransferHelpers {
      * @return details of stored binary, or null if not found
      */
     public static BinaryDetails getStoredBinaryDetails(StorageLocation storageLoc, PID binPid) {
-        URI destUri = storageLoc.getStorageUri(binPid);
+        URI destUri = storageLoc.getCurrentStorageUri(binPid);
+        if (destUri == null) {
+            return null;
+        }
         return getBinaryDetails(destUri);
     }
 
@@ -82,6 +90,50 @@ public class FileSystemTransferHelpers {
             throw new BinaryTransferException("Failed to retrieve binary details for " + binUri, e);
         } catch (NoSuchAlgorithmException e) {
             throw new RepositoryException(e);
+        }
+    }
+
+    /**
+     * Get the most recent storage URI for files beginning with the provided base URI
+     *
+     * @param baseUri Base URI of the file, without version suffixes
+     * @return Most recent storage URI, or null if there is no existing URI
+     */
+    public static URI getMostRecentStorageUri(URI baseUri) {
+        Path basePath = Paths.get(baseUri);
+        Path dirPath = basePath.getParent();
+        String namePrefix = basePath.getFileName().toString();
+        try (Stream<Path> stream = Files.list(dirPath)) {
+            Path recentPath = stream
+                    .filter(path -> !Files.isDirectory(path))
+                    .filter(path -> path.getFileName().toString().startsWith(namePrefix))
+                    .max(Comparator.comparing(String::valueOf))
+                    .get();
+            return recentPath.toFile().toURI().normalize();
+        } catch (NoSuchFileException | NoSuchElementException e) {
+            return null;
+        } catch (IOException e) {
+            throw new BinaryTransferException("Failed to retrieve most recent URI for " + baseUri, e);
+        }
+    }
+
+    /**
+     * @param filePath Path of the file to check for existing versions of.
+     * @return True if any files exist in the parent directory of filePath which begin with
+     *    the same filename prefix. This includes filePath itself, if it exists.
+     */
+    public static boolean versionsExist(Path filePath) {
+        Path dirPath = filePath.getParent();
+        if (Files.notExists(dirPath)) {
+            return false;
+        }
+        String filename = filePath.getFileName().toString();
+        String namePrefix = StringUtils.substringBefore(filename, ".");
+        try (Stream<Path> stream = Files.list(dirPath)) {
+            return stream.filter(path -> !Files.isDirectory(path))
+                    .anyMatch(path -> path.getFileName().toString().startsWith(namePrefix));
+        } catch (IOException e) {
+            throw new BinaryTransferException("Failed to check for storage URI " + filePath, e);
         }
     }
 }

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/MultiDestinationTransferSessionImpl.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/transfer/MultiDestinationTransferSessionImpl.java
@@ -24,6 +24,7 @@ import edu.unc.lib.dl.fcrepo4.RepositoryObject;
 import edu.unc.lib.dl.persist.api.ingest.IngestSourceManager;
 import edu.unc.lib.dl.persist.api.storage.StorageLocation;
 import edu.unc.lib.dl.persist.api.storage.StorageLocationManager;
+import edu.unc.lib.dl.persist.api.transfer.BinaryTransferService;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferSession;
 import edu.unc.lib.dl.persist.api.transfer.MultiDestinationTransferSession;
 
@@ -38,6 +39,7 @@ public class MultiDestinationTransferSessionImpl implements MultiDestinationTran
     private StorageLocationManager storageLocationManager;
     private IngestSourceManager sourceManager;
     private Map<String, BinaryTransferSession> sessionMap;
+    private BinaryTransferService binaryTransferService;
 
     /**
      *
@@ -45,10 +47,11 @@ public class MultiDestinationTransferSessionImpl implements MultiDestinationTran
      * @param storageLocationManager
      */
     public MultiDestinationTransferSessionImpl(IngestSourceManager sourceManager,
-            StorageLocationManager storageLocationManager) {
+            StorageLocationManager storageLocationManager, BinaryTransferService binaryTransferService) {
         sessionMap = new HashMap<>();
         this.sourceManager = sourceManager;
         this.storageLocationManager = storageLocationManager;
+        this.binaryTransferService = binaryTransferService;
     }
 
     @Override
@@ -61,7 +64,7 @@ public class MultiDestinationTransferSessionImpl implements MultiDestinationTran
         notNull(dest, "Must provide a destination location");
         BinaryTransferSession session = sessionMap.get(dest.getId());
         if (session == null) {
-            session = new BinaryTransferSessionImpl(sourceManager, dest);
+            session = new BinaryTransferSessionImpl(sourceManager, dest, binaryTransferService);
             sessionMap.put(dest.getId(), session);
         }
         return session;

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/versioning/VersionedDatastreamService.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/versioning/VersionedDatastreamService.java
@@ -97,10 +97,10 @@ public class VersionedDatastreamService {
             }
             throw e;
         } finally {
-            dsLock.unlock();
             if (tx != null) {
                 tx.close();
             }
+            dsLock.unlock();
             // Only close the transfer session if it was created within this method call
             if (session != null && newVersion.getTransferSession() == null) {
                 session.close();

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/versioning/VersionedDatastreamService.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/versioning/VersionedDatastreamService.java
@@ -16,6 +16,7 @@
 package edu.unc.lib.dl.persist.services.versioning;
 
 import static edu.unc.lib.dl.model.DatastreamPids.getDatastreamHistoryPid;
+import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,13 +25,16 @@ import java.util.Date;
 import java.util.concurrent.locks.Lock;
 
 import org.apache.jena.rdf.model.Model;
+import org.slf4j.Logger;
 
 import edu.unc.lib.dl.exceptions.InvalidChecksumException;
 import edu.unc.lib.dl.fcrepo4.BinaryObject;
+import edu.unc.lib.dl.fcrepo4.FedoraTransaction;
 import edu.unc.lib.dl.fcrepo4.PIDs;
 import edu.unc.lib.dl.fcrepo4.RepositoryObject;
 import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
 import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
+import edu.unc.lib.dl.fcrepo4.TransactionManager;
 import edu.unc.lib.dl.fedora.NotFoundException;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.fedora.ServiceException;
@@ -47,9 +51,12 @@ import edu.unc.lib.dl.persist.api.transfer.BinaryTransferSession;
  * @author bbpennel
  */
 public class VersionedDatastreamService {
+    private static final Logger log = getLogger(VersionedDatastreamService.class);
+
     private RepositoryObjectLoader repoObjLoader;
     private RepositoryObjectFactory repoObjFactory;
     private BinaryTransferService transferService;
+    private TransactionManager transactionManager;
     private static final PidLockManager lockManager = PidLockManager.getDefaultPidLockManager();
 
     /**
@@ -66,12 +73,17 @@ public class VersionedDatastreamService {
         BinaryObject dsObj = getBinaryObject(dsPid);
 
         // Get a session for transferring the binary and its history
-        BinaryTransferSession session = getTransferSession(newVersion, dsObj);
+        BinaryTransferSession session = null;
+        FedoraTransaction tx = null;
         try {
+            session = getTransferSession(newVersion, dsObj);
+            tx = transactionManager.startTransaction();
             // if datastream is new, go ahead and create it
             if (dsObj == null) {
+                log.debug("Adding head version for datastream {}", dsPid);
                 return updateHeadVersion(newVersion, session);
             } else {
+                log.debug("Adding history and head version for datastream {}", dsPid);
                 // Datastream already exists
                 // Add the current head version to the history log
                 updateDatastreamHistory(session, dsObj);
@@ -79,10 +91,18 @@ public class VersionedDatastreamService {
                 // Replace the head version with the new content
                 return updateHeadVersion(newVersion, session);
             }
+        } catch (Exception e) {
+            if (tx != null) {
+                tx.cancelAndIgnore();
+            }
+            throw e;
         } finally {
             dsLock.unlock();
+            if (tx != null) {
+                tx.close();
+            }
             // Only close the transfer session if it was created within this method call
-            if (newVersion.getTransferSession() == null) {
+            if (session != null && newVersion.getTransferSession() == null) {
                 session.close();
             }
         }
@@ -208,6 +228,10 @@ public class VersionedDatastreamService {
 
     public void setBinaryTransferService(BinaryTransferService transferService) {
         this.transferService = transferService;
+    }
+
+    public void setTransactionManager(TransactionManager transactionManager) {
+        this.transactionManager = transactionManager;
     }
 
     /**

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsCompletelyJobIT.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsCompletelyJobIT.java
@@ -384,7 +384,7 @@ public class DestroyObjectsCompletelyJobIT {
     private FileObject addFileToWork(WorkObject work) throws Exception {
         String bodyString = "Content";
         String mimetype = "text/plain";
-        Path storagePath = Paths.get(locationManager.getStorageLocationById(LOC1_ID).getStorageUri(work.getPid()));
+        Path storagePath = Paths.get(locationManager.getStorageLocationById(LOC1_ID).getNewStorageUri(work.getPid()));
         Files.createDirectories(storagePath);
         File contentFile = Files.createTempFile(storagePath, "file", ".txt").toFile();
         String filename = contentFile.getName();

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsJobIT.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsJobIT.java
@@ -378,7 +378,7 @@ public class DestroyObjectsJobIT {
         folder.addMember(work);
         String bodyString = "Content";
         String mimetype = "text/plain";
-        Path storagePath = Paths.get(locationManager.getStorageLocationById(LOC1_ID).getStorageUri(work.getPid()));
+        Path storagePath = Paths.get(locationManager.getStorageLocationById(LOC1_ID).getNewStorageUri(work.getPid()));
         Files.createDirectories(storagePath);
         File contentFile = Files.createTempFile(storagePath, "file", ".txt").toFile();
         String sha1 = "4f9be057f0ea5d2ba72fd2c810e8d7b9aa98b469";

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/storage/HashedFilesystemStorageLocationTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/storage/HashedFilesystemStorageLocationTest.java
@@ -27,6 +27,8 @@ import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
@@ -172,6 +174,28 @@ public class HashedFilesystemStorageLocationTest {
         URI expectedUri = createNewStorageUri(pid);
 
         assertEquals(expectedUri, loc.getCurrentStorageUri(pid));
+    }
+
+    @Test
+    public void getAllStorageUrisExisting() throws Exception {
+        PID pid = PIDs.get(TEST_UUID);
+        List<URI> expected = Arrays.asList(
+                createNewStorageUri(pid),
+                createNewStorageUri(pid),
+                createNewStorageUri(pid),
+                createNewStorageUri(pid));
+
+        List<URI> uris = loc.getAllStorageUris(pid);
+        assertEquals(expected.size(), uris.size());
+        assertTrue(uris.containsAll(expected));
+    }
+
+    @Test
+    public void getAllStorageUrisNoneExisting() throws Exception {
+        PID pid = PIDs.get(TEST_UUID);
+
+        List<URI> uris = loc.getAllStorageUris(pid);
+        assertEquals(0, uris.size());
     }
 
     private URI createNewStorageUri(PID pid) throws IOException {

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/storage/HashedPosixStorageLocationTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/storage/HashedPosixStorageLocationTest.java
@@ -36,8 +36,11 @@ public class HashedPosixStorageLocationTest extends HashedFilesystemStorageLocat
 
     @Override
     @Before
-    public void setup() {
+    public void setup() throws Exception {
+        storagePath = tmpFolder.newFolder("storage").toPath();
+
         posixLoc = new HashedPosixStorageLocation();
+        posixLoc.setBase(storagePath.toString());
         loc = posixLoc;
     }
 

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/transfer/BinaryTransferSessionImplTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/transfer/BinaryTransferSessionImplTest.java
@@ -69,7 +69,7 @@ public class BinaryTransferSessionImplTest extends AbstractBinaryTransferTest {
         when(sourceManager.getIngestSourceForUri(any(URI.class))).thenReturn(ingestSource);
         when(ingestSource.getId()).thenReturn("source1");
 
-        when(storageLoc.getStorageUri(binPid)).thenReturn(binDestPath.toUri());
+        when(storageLoc.getNewStorageUri(binPid)).thenReturn(binDestPath.toUri());
         when(storageLoc.getId()).thenReturn("loc1");
     }
 
@@ -111,7 +111,7 @@ public class BinaryTransferSessionImplTest extends AbstractBinaryTransferTest {
 
         PID binPid2 = makeBinPid();
         Path binDestPath2 = storagePath.resolve(binPid2.getComponentId());
-        when(storageLoc.getStorageUri(binPid2)).thenReturn(binDestPath2.toUri());
+        when(storageLoc.getNewStorageUri(binPid2)).thenReturn(binDestPath2.toUri());
 
         Path sourceFile = createSourceFile();
         Path sourceFile2 = createSourceFile("another.txt", "stuff");
@@ -139,7 +139,7 @@ public class BinaryTransferSessionImplTest extends AbstractBinaryTransferTest {
 
         PID binPid2 = makeBinPid();
         Path binDestPath2 = storagePath.resolve(binPid2.getComponentId());
-        when(storageLoc.getStorageUri(binPid2)).thenReturn(binDestPath2.toUri());
+        when(storageLoc.getNewStorageUri(binPid2)).thenReturn(binDestPath2.toUri());
 
         // Create second ingest source, which is not read only
         IngestSource source2 = mock(IngestSource.class);

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/transfer/BinaryTransferSessionImplTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/transfer/BinaryTransferSessionImplTest.java
@@ -39,6 +39,7 @@ import edu.unc.lib.dl.persist.api.ingest.IngestSource;
 import edu.unc.lib.dl.persist.api.ingest.IngestSourceManager;
 import edu.unc.lib.dl.persist.api.storage.StorageLocation;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferOutcome;
+import edu.unc.lib.dl.persist.api.transfer.BinaryTransferService;
 
 /**
  * @author bbpennel
@@ -48,6 +49,7 @@ public class BinaryTransferSessionImplTest extends AbstractBinaryTransferTest {
 
     private BinaryTransferSessionImpl session;
 
+    private BinaryTransferService bts;
     @Mock
     private IngestSourceManager sourceManager;
     @Mock
@@ -71,6 +73,8 @@ public class BinaryTransferSessionImplTest extends AbstractBinaryTransferTest {
 
         when(storageLoc.getNewStorageUri(binPid)).thenReturn(binDestPath.toUri());
         when(storageLoc.getId()).thenReturn("loc1");
+
+        bts = new BinaryTransferServiceImpl();
     }
 
     @Test
@@ -78,7 +82,7 @@ public class BinaryTransferSessionImplTest extends AbstractBinaryTransferTest {
         when(ingestSource.getStorageType()).thenReturn(FILESYSTEM);
         when(storageLoc.getStorageType()).thenReturn(FILESYSTEM);
 
-        try (BinaryTransferSessionImpl session = new BinaryTransferSessionImpl(sourceManager, storageLoc)) {
+        try (BinaryTransferSessionImpl session = new BinaryTransferSessionImpl(sourceManager, storageLoc, bts)) {
             Path sourceFile = createSourceFile();
 
             session.transfer(binPid, sourceFile.toUri());
@@ -89,7 +93,7 @@ public class BinaryTransferSessionImplTest extends AbstractBinaryTransferTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void transferNoDestination() throws Exception {
-        session = new BinaryTransferSessionImpl(sourceManager, null);
+        session = new BinaryTransferSessionImpl(sourceManager, null, bts);
     }
 
     @Test(expected = NotImplementedException.class)
@@ -97,7 +101,7 @@ public class BinaryTransferSessionImplTest extends AbstractBinaryTransferTest {
         when(ingestSource.getStorageType()).thenReturn(FILESYSTEM);
         when(storageLoc.getStorageType()).thenReturn(null);
 
-        session = new BinaryTransferSessionImpl(sourceManager, storageLoc);
+        session = new BinaryTransferSessionImpl(sourceManager, storageLoc, bts);
 
         Path sourceFile = createSourceFile();
 
@@ -117,7 +121,7 @@ public class BinaryTransferSessionImplTest extends AbstractBinaryTransferTest {
         Path sourceFile2 = createSourceFile("another.txt", "stuff");
 
         // Initialize session with the destination
-        try (BinaryTransferSessionImpl session = new BinaryTransferSessionImpl(sourceManager, storageLoc)) {
+        try (BinaryTransferSessionImpl session = new BinaryTransferSessionImpl(sourceManager, storageLoc, bts)) {
             BinaryTransferOutcome outcome1 = session.transfer(binPid, sourceFile.toUri());
             BinaryTransferOutcome outcome2 = session.transfer(binPid2, sourceFile2.toUri());
 
@@ -150,7 +154,7 @@ public class BinaryTransferSessionImplTest extends AbstractBinaryTransferTest {
         // Make first ingest source read only, so it will be different from the second
         when(ingestSource.isReadOnly()).thenReturn(true);
 
-        try (BinaryTransferSessionImpl session = new BinaryTransferSessionImpl(sourceManager, storageLoc)) {
+        try (BinaryTransferSessionImpl session = new BinaryTransferSessionImpl(sourceManager, storageLoc, bts)) {
             BinaryTransferOutcome outcome1 = session.transfer(binPid, sourceFile.toUri());
             BinaryTransferOutcome outcome2 = session.transfer(binPid2, sourceFile2.toUri());
 
@@ -173,7 +177,7 @@ public class BinaryTransferSessionImplTest extends AbstractBinaryTransferTest {
         createFile(binDestPath, "some stuff");
         Path sourceFile = createSourceFile();
 
-        try (BinaryTransferSessionImpl session = new BinaryTransferSessionImpl(sourceManager, storageLoc)) {
+        try (BinaryTransferSessionImpl session = new BinaryTransferSessionImpl(sourceManager, storageLoc, bts)) {
             session.transferReplaceExisting(binPid, sourceFile.toUri());
 
             assertIsSourceFile(binDestPath);
@@ -187,7 +191,7 @@ public class BinaryTransferSessionImplTest extends AbstractBinaryTransferTest {
 
         Path sourceFile = createSourceFile();
 
-        try (BinaryTransferSessionImpl session = new BinaryTransferSessionImpl(sourceManager, storageLoc)) {
+        try (BinaryTransferSessionImpl session = new BinaryTransferSessionImpl(sourceManager, storageLoc, bts)) {
             session.transferVersion(binPid, sourceFile.toUri());
         }
     }
@@ -201,7 +205,7 @@ public class BinaryTransferSessionImplTest extends AbstractBinaryTransferTest {
         createFile(binDestPath, "some stuff");
         Path sourceFile = createSourceFile();
 
-        try (BinaryTransferSessionImpl session = new BinaryTransferSessionImpl(sourceManager, storageLoc)) {
+        try (BinaryTransferSessionImpl session = new BinaryTransferSessionImpl(sourceManager, storageLoc, bts)) {
             session.delete(sourceFile.toUri());
         }
         assertFalse("File must be deleted", Files.exists(sourceFile));

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/transfer/FSToPosixTransferClientTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/transfer/FSToPosixTransferClientTest.java
@@ -16,10 +16,8 @@
 package edu.unc.lib.dl.persist.services.transfer;
 
 import static edu.unc.lib.dl.model.DatastreamPids.getOriginalFilePid;
-import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.net.URI;
@@ -27,12 +25,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermission;
-import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mock;
 
 import edu.unc.lib.dl.fcrepo4.PIDs;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferOutcome;
@@ -42,9 +38,6 @@ import edu.unc.lib.dl.persist.services.storage.HashedPosixStorageLocation;
  * @author bbpennel
  */
 public class FSToPosixTransferClientTest extends FSToFSTransferClientTest {
-
-    @Mock
-    private HashedPosixStorageLocation storageLoc;
 
     private FSToPosixTransferClient posixClient;
 
@@ -56,21 +49,20 @@ public class FSToPosixTransferClientTest extends FSToFSTransferClientTest {
         sourcePath = tmpFolder.newFolder("source").toPath();
         storagePath = tmpFolder.newFolder("storage").toPath();
 
+        HashedPosixStorageLocation hashedLoc = new HashedPosixStorageLocation();
+        hashedLoc.setBase(storagePath.toString());
+        hashedLoc.setId("loc1");
+        storageLoc = hashedLoc;
+
         this.posixClient = new FSToPosixTransferClient(ingestSource, storageLoc);
         this.client = posixClient;
 
         binPid = getOriginalFilePid(PIDs.get(TEST_UUID));
-        binDestPath = storagePath.resolve(binPid.getComponentId());
-
-        when(storageLoc.getStorageUri(binPid)).thenReturn(binDestPath.toUri());
-        when(storageLoc.getPermissions()).thenReturn(null);
     }
 
     @Test
     public void transfer_NewFile_WithPermissions() throws Exception {
-        when(storageLoc.getPermissions()).thenReturn(new HashSet<>(asList(
-                PosixFilePermission.OWNER_READ,
-                PosixFilePermission.OWNER_WRITE)));
+        ((HashedPosixStorageLocation) storageLoc).setPermissions("0600");
 
         Path sourceFile = createSourceFile();
 

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/transfer/MultiDestinationTransferSessionImplTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/transfer/MultiDestinationTransferSessionImplTest.java
@@ -35,6 +35,7 @@ import edu.unc.lib.dl.persist.api.ingest.IngestSourceManager;
 import edu.unc.lib.dl.persist.api.storage.StorageLocation;
 import edu.unc.lib.dl.persist.api.storage.StorageLocationManager;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferOutcome;
+import edu.unc.lib.dl.persist.api.transfer.BinaryTransferService;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferSession;
 
 /**
@@ -56,6 +57,7 @@ public class MultiDestinationTransferSessionImplTest extends AbstractBinaryTrans
     private StorageLocation storageLoc2;
     @Mock
     private StorageLocationManager storageLocationManager;
+    private BinaryTransferService bts;
 
     private PID binPid;
     private Path binDestPath;
@@ -75,12 +77,14 @@ public class MultiDestinationTransferSessionImplTest extends AbstractBinaryTrans
         when(storageLoc.getStorageType()).thenReturn(FILESYSTEM);
         when(storageLoc.getNewStorageUri(binPid)).thenReturn(binDestPath.toUri());
         when(storageLoc.getId()).thenReturn("loc1");
+
+        bts = new BinaryTransferServiceImpl();
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void noDestination() throws Exception {
         try (MultiDestinationTransferSessionImpl session = new MultiDestinationTransferSessionImpl(
-                sourceManager, storageLocationManager)) {
+                sourceManager, storageLocationManager, bts)) {
             session.forDestination(null);
         }
     }
@@ -96,7 +100,7 @@ public class MultiDestinationTransferSessionImplTest extends AbstractBinaryTrans
         Path sourceFile2 = createSourceFile("another.txt", "stuff");
 
         try (MultiDestinationTransferSessionImpl session = new MultiDestinationTransferSessionImpl(
-                sourceManager, storageLocationManager)) {
+                sourceManager, storageLocationManager, bts)) {
             BinaryTransferSession destSession = session.forDestination(storageLoc);
             BinaryTransferOutcome result1 = destSession.transfer(binPid, sourceFile.toUri());
             BinaryTransferOutcome result2 = destSession.transfer(binPid2, sourceFile2.toUri());
@@ -124,7 +128,7 @@ public class MultiDestinationTransferSessionImplTest extends AbstractBinaryTrans
         Path sourceFile2 = createSourceFile("another.txt", "stuff");
 
         try (MultiDestinationTransferSessionImpl session = new MultiDestinationTransferSessionImpl(
-                sourceManager, storageLocationManager)) {
+                sourceManager, storageLocationManager, bts)) {
             BinaryTransferOutcome result1 = session
                     .forDestination(storageLoc).transfer(binPid, sourceFile.toUri());
             BinaryTransferOutcome result2 = session

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/transfer/MultiDestinationTransferSessionImplTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/transfer/MultiDestinationTransferSessionImplTest.java
@@ -73,7 +73,7 @@ public class MultiDestinationTransferSessionImplTest extends AbstractBinaryTrans
 
         when(ingestSource.getStorageType()).thenReturn(FILESYSTEM);
         when(storageLoc.getStorageType()).thenReturn(FILESYSTEM);
-        when(storageLoc.getStorageUri(binPid)).thenReturn(binDestPath.toUri());
+        when(storageLoc.getNewStorageUri(binPid)).thenReturn(binDestPath.toUri());
         when(storageLoc.getId()).thenReturn("loc1");
     }
 
@@ -90,7 +90,7 @@ public class MultiDestinationTransferSessionImplTest extends AbstractBinaryTrans
         PID binPid2 = makeBinPid();
         Path binDestPath2 = storagePath.resolve(binPid2.getComponentId());
         // Establish destination path for second binary in second location
-        when(storageLoc.getStorageUri(binPid2)).thenReturn(binDestPath2.toUri());
+        when(storageLoc.getNewStorageUri(binPid2)).thenReturn(binDestPath2.toUri());
 
         Path sourceFile = createSourceFile();
         Path sourceFile2 = createSourceFile("another.txt", "stuff");
@@ -118,7 +118,7 @@ public class MultiDestinationTransferSessionImplTest extends AbstractBinaryTrans
         PID binPid2 = makeBinPid();
         Path binDestPath2 = storagePath2.resolve(binPid2.getComponentId());
         // Establish destination path for second binary in second location
-        when(storageLoc2.getStorageUri(binPid2)).thenReturn(binDestPath2.toUri());
+        when(storageLoc2.getNewStorageUri(binPid2)).thenReturn(binDestPath2.toUri());
 
         Path sourceFile = createSourceFile();
         Path sourceFile2 = createSourceFile("another.txt", "stuff");

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/transfer/StreamToFSTransferClientTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/transfer/StreamToFSTransferClientTest.java
@@ -37,16 +37,12 @@ import java.nio.file.Paths;
 
 import org.apache.commons.io.FileUtils;
 import org.fusesource.hawtbuf.ByteArrayInputStream;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.mockito.Mock;
 
-import edu.unc.lib.dl.fcrepo4.FedoraTransaction;
 import edu.unc.lib.dl.fcrepo4.PIDs;
-import edu.unc.lib.dl.fcrepo4.TransactionManager;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.persist.api.storage.StorageLocation;
 import edu.unc.lib.dl.persist.api.transfer.BinaryAlreadyExistsException;
@@ -75,11 +71,6 @@ public class StreamToFSTransferClientTest {
 
     protected PID binPid;
 
-    @Mock
-    private TransactionManager txManager;
-    private FedoraTransaction fedoraTransaction;
-    private final static URI TX_URI = URI.create("http://example.com/tx");
-
     @Before
     public void setup() throws Exception {
         initMocks(this);
@@ -95,13 +86,6 @@ public class StreamToFSTransferClientTest {
         client = new StreamToFSTransferClient(storageLoc);
 
         binPid = getOriginalFilePid(PIDs.get(TEST_UUID));
-    }
-
-    @After
-    public void teardown() throws Exception {
-        if (fedoraTransaction != null) {
-            fedoraTransaction.close();
-        }
     }
 
     @Test
@@ -144,7 +128,6 @@ public class StreamToFSTransferClientTest {
 
     @Test
     public void transferReplaceExisting_ExistingFile() throws Exception {
-        fedoraTransaction = new FedoraTransaction(TX_URI, txManager);
         // Create existing file content
         createFile();
 

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/transfer/StreamToFSTransferClientTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/transfer/StreamToFSTransferClientTest.java
@@ -17,7 +17,9 @@ package edu.unc.lib.dl.persist.services.transfer;
 
 import static edu.unc.lib.dl.model.DatastreamPids.getOriginalFilePid;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
@@ -28,24 +30,29 @@ import static org.mockito.MockitoAnnotations.initMocks;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.apache.commons.io.FileUtils;
 import org.fusesource.hawtbuf.ByteArrayInputStream;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.Mock;
 
+import edu.unc.lib.dl.fcrepo4.FedoraTransaction;
 import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fcrepo4.TransactionManager;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.persist.api.storage.StorageLocation;
 import edu.unc.lib.dl.persist.api.transfer.BinaryAlreadyExistsException;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferException;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferOutcome;
+import edu.unc.lib.dl.persist.services.storage.HashedFilesystemStorageLocation;
 
 /**
  * @author bbpennel
@@ -64,11 +71,14 @@ public class StreamToFSTransferClientTest {
     public final TemporaryFolder tmpFolder = new TemporaryFolder();
     protected Path sourcePath;
     protected Path storagePath;
-    @Mock
-    private StorageLocation storageLoc;
+    protected StorageLocation storageLoc;
 
     protected PID binPid;
-    protected Path binDestPath;
+
+    @Mock
+    private TransactionManager txManager;
+    private FedoraTransaction fedoraTransaction;
+    private final static URI TX_URI = URI.create("http://example.com/tx");
 
     @Before
     public void setup() throws Exception {
@@ -77,12 +87,21 @@ public class StreamToFSTransferClientTest {
         sourcePath = tmpFolder.newFolder("source").toPath();
         storagePath = tmpFolder.newFolder("storage").toPath();
 
+        HashedFilesystemStorageLocation hashedLoc = new HashedFilesystemStorageLocation();
+        hashedLoc.setBase(storagePath.toString());
+        hashedLoc.setId("loc1");
+        storageLoc = hashedLoc;
+
         client = new StreamToFSTransferClient(storageLoc);
 
         binPid = getOriginalFilePid(PIDs.get(TEST_UUID));
-        binDestPath = storagePath.resolve(binPid.getComponentId());
+    }
 
-        when(storageLoc.getStorageUri(binPid)).thenReturn(binDestPath.toUri());
+    @After
+    public void teardown() throws Exception {
+        if (fedoraTransaction != null) {
+            fedoraTransaction.close();
+        }
     }
 
     @Test
@@ -91,14 +110,14 @@ public class StreamToFSTransferClientTest {
 
         BinaryTransferOutcome outcome = client.transfer(binPid, sourceStream);
 
-        assertContent(binDestPath, STREAM_CONTENT);
-        assertOutcome(outcome, binDestPath, STREAM_CONTENT_SHA1);
+        assertContent(outcome, STREAM_CONTENT);
+        assertOutcome(outcome, STREAM_CONTENT_SHA1);
     }
 
     @Test(expected = BinaryAlreadyExistsException.class)
     public void transfer_ExistingFile() throws Exception {
         // Create existing file content
-        createFile();
+        Path destPath = createFile();
 
         // Attempt to transfer new content
         InputStream sourceStream = toStream(STREAM_CONTENT);
@@ -107,7 +126,7 @@ public class StreamToFSTransferClientTest {
             client.transfer(binPid, sourceStream);
         } finally {
             // Verify that the file was not replaced
-            assertContent(binDestPath, ORIGINAL_CONTENT);
+            assertContent(destPath, ORIGINAL_CONTENT);
         }
     }
 
@@ -116,22 +135,25 @@ public class StreamToFSTransferClientTest {
         InputStream sourceStream = mock(InputStream.class);
         when(sourceStream.read(any(), anyInt(), anyInt())).thenThrow(new IOException());
 
-        client.transfer(binPid, sourceStream);
-
-        assertContent(binDestPath, STREAM_CONTENT);
+        try {
+            client.transfer(binPid, sourceStream);
+        } finally {
+            assertNull(storageLoc.getCurrentStorageUri(binPid));
+        }
     }
 
     @Test
     public void transferReplaceExisting_ExistingFile() throws Exception {
+        fedoraTransaction = new FedoraTransaction(TX_URI, txManager);
         // Create existing file content
         createFile();
 
         InputStream sourceStream = toStream(STREAM_CONTENT);
 
         BinaryTransferOutcome outcome = client.transferReplaceExisting(binPid, sourceStream);
-        // Verify that the file was replaced
-        assertContent(binDestPath, STREAM_CONTENT);
-        assertOutcome(outcome, binDestPath, STREAM_CONTENT_SHA1);
+        // Verify that the new file is present
+        assertContent(outcome, STREAM_CONTENT);
+        assertOutcome(outcome, STREAM_CONTENT_SHA1);
     }
 
     @Test(expected = BinaryTransferException.class)
@@ -140,22 +162,21 @@ public class StreamToFSTransferClientTest {
         when(sourceStream.read(any(), anyInt(), anyInt())).thenThrow(new IOException());
 
         // Create existing file content
-        createFile();
+        Path destPath = createFile();
 
         try {
             client.transferReplaceExisting(binPid, sourceStream);
         } finally {
             // Verify that the content was not replaced
-            assertContent(binDestPath, ORIGINAL_CONTENT);
+            assertContent(destPath, ORIGINAL_CONTENT);
         }
     }
 
     @Test
     public void rollbackOnTransferInterruption() throws Exception {
-        Files.createDirectories(binDestPath.getParent());
-        createFile();
-        File destFile = binDestPath.toFile();
-        File parentDir = binDestPath.getParent().toFile();
+        Path destPath = createFile();
+        File destFile = destPath.toFile();
+        File parentDir = destPath.getParent().toFile();
         parentDir.setReadOnly();
 
         InputStream sourceStream = toStream(ORIGINAL_CONTENT);
@@ -164,11 +185,32 @@ public class StreamToFSTransferClientTest {
             client.transferReplaceExisting(binPid, sourceStream);
         } catch (BinaryTransferException e) {
             assertTrue("Original file should be present", destFile.exists());
-            assertEquals(1, binDestPath.getParent().toFile().listFiles().length);
+            assertEquals(1, parentDir.listFiles().length);
         } finally {
-            binDestPath.getParent().toFile().setWritable(true);
+            parentDir.setWritable(true);
             destFile.delete();
         }
+    }
+
+    @Test
+    public void deleteExisting() throws Exception {
+        InputStream sourceStream = toStream(STREAM_CONTENT);
+
+        BinaryTransferOutcome outcome = client.transfer(binPid, sourceStream);
+        assertTrue(Files.exists(Paths.get(outcome.getDestinationUri())));
+
+        client.delete(outcome.getDestinationUri());
+        assertFalse(Files.exists(Paths.get(outcome.getDestinationUri())));
+    }
+
+    @Test(expected = BinaryTransferException.class)
+    public void deleteNonExistent() throws Exception {
+        URI destUri = storageLoc.getNewStorageUri(binPid);
+        client.delete(destUri);
+    }
+
+    protected void assertContent(BinaryTransferOutcome outcome, String content) throws Exception {
+        assertContent(Paths.get(outcome.getDestinationUri()), content);
     }
 
     protected void assertContent(Path path, String content) throws Exception {
@@ -180,13 +222,16 @@ public class StreamToFSTransferClientTest {
         return new ByteArrayInputStream(content.getBytes());
     }
 
-    private void createFile() throws Exception {
-        FileUtils.copyInputStreamToFile(toStream(ORIGINAL_CONTENT), binDestPath.toFile());
+    private Path createFile() throws Exception {
+        Path path = Paths.get(storageLoc.getNewStorageUri(binPid));
+        FileUtils.copyInputStreamToFile(toStream(ORIGINAL_CONTENT), path.toFile());
+        return path;
     }
 
-    protected void assertOutcome(BinaryTransferOutcome outcome, Path expectedDest, String expectedSha1) {
+    protected void assertOutcome(BinaryTransferOutcome outcome, String expectedSha1) {
         assertNotNull("Outcome was not returned", outcome);
-        assertEquals("Unexpected outcome destination", expectedDest, Paths.get(outcome.getDestinationUri()));
+        assertTrue("Destination file must be in the destination storage location",
+                Paths.get(outcome.getDestinationUri()).startsWith(storagePath));
         assertEquals("Unexpected outcome digest", expectedSha1, outcome.getSha1());
     }
 }

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/versioning/VersionedDatastreamServiceIT.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/versioning/VersionedDatastreamServiceIT.java
@@ -51,6 +51,7 @@ import edu.unc.lib.dl.fcrepo4.BinaryObject;
 import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
 import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
 import edu.unc.lib.dl.fcrepo4.RepositoryPIDMinter;
+import edu.unc.lib.dl.fcrepo4.TransactionManager;
 import edu.unc.lib.dl.fcrepo4.WorkObject;
 import edu.unc.lib.dl.fedora.ObjectTypeMismatchException;
 import edu.unc.lib.dl.fedora.PID;
@@ -93,6 +94,8 @@ public class VersionedDatastreamServiceIT {
     private RepositoryPIDMinter pidMinter;
     @Autowired
     private RepositoryObjectTreeIndexer treeIndexer;
+    @Autowired
+    private TransactionManager transactionManager;
 
     private IngestSourceManagerImpl sourceManager;
     private Path sourcePath;
@@ -108,6 +111,7 @@ public class VersionedDatastreamServiceIT {
         service.setBinaryTransferService(transferService);
         service.setRepositoryObjectFactory(repoObjFactory);
         service.setRepositoryObjectLoader(repoObjLoader);
+        service.setTransactionManager(transactionManager);
 
         File sourceMappingFile = new File(tmpFolder.getRoot(), "sourceMapping.json");
         FileUtils.writeStringToFile(sourceMappingFile, "[]", "UTF-8");

--- a/persistence/src/test/resources/spring-test/cdr-client-container.xml
+++ b/persistence/src/test/resources/spring-test/cdr-client-container.xml
@@ -58,11 +58,11 @@
     </bean>
 
     <bean id="cacheTimeToLive" class="java.lang.Long">
-        <constructor-arg value="5" />
+        <constructor-arg value="0" />
     </bean>
     
     <bean id="cacheMaxSize" class="java.lang.Long">
-        <constructor-arg value="5" />
+        <constructor-arg value="0" />
     </bean>
     
     <bean id="repositoryObjectLoader" class="edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader" init-method="init">

--- a/persistence/src/test/resources/spring-test/cdr-client-container.xml
+++ b/persistence/src/test/resources/spring-test/cdr-client-container.xml
@@ -94,6 +94,7 @@
     
     <bean id="transactionManager" class="edu.unc.lib.dl.fcrepo4.TransactionManager">
         <property name="client" ref="fcrepoClient" />
+        <property name="binaryTransferService" ref="binaryTransferService" />
     </bean>
     
     <bean id="jmsTemplate" class="org.mockito.Mockito" factory-method="mock">

--- a/persistence/src/test/resources/spring-test/destroy-completely-it-context.xml
+++ b/persistence/src/test/resources/spring-test/destroy-completely-it-context.xml
@@ -8,6 +8,7 @@
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
         <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
         <property name="binaryTransferService" ref="binaryTransferService" />
+        <property name="transactionManager" ref="transactionManager" />
     </bean>
     
     <bean id="updateDescriptionService" class="edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService" >

--- a/persistence/src/test/resources/spring-test/import-job-it.xml
+++ b/persistence/src/test/resources/spring-test/import-job-it.xml
@@ -17,6 +17,7 @@
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
         <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
         <property name="binaryTransferService" ref="binaryTransferService" />
+        <property name="transactionManager" ref="transactionManager" />
     </bean>
     
     <bean id="updateService" class="edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService" >

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
         <fcrepo.client.version>0.4.0</fcrepo.client.version>
         <mock.server.version>5.4.1</mock.server.version>
         <powermock.version>1.7.4</powermock.version>
+        <awaitility.version>4.0.3</awaitility.version>
         
         <jackson.version>2.11.2</jackson.version>
         <jackson.databind.version>2.11.2</jackson.databind.version>
@@ -695,6 +696,12 @@
                 <groupId>org.powermock</groupId>
                 <artifactId>powermock-api-mockito</artifactId>
                 <version>${powermock.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.awaitility</groupId>
+                <artifactId>awaitility</artifactId>
+                <version>${awaitility.version}</version>
                 <scope>test</scope>
             </dependency>
             

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/binaryCleanup/BinaryCleanupProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/binaryCleanup/BinaryCleanupProcessor.java
@@ -50,6 +50,7 @@ public class BinaryCleanupProcessor implements Processor {
     @Override
     public void process(Exchange exchange) throws Exception {
         Message aggrMsg = exchange.getIn();
+        // Keys of the map are PIDs of updated binaries, values of content URIs
         Map<String, String> messages = aggrMsg.getBody(Map.class);
         try (MultiDestinationTransferSession mSession = binaryTransferService.getSession()) {
             for (Entry<String, String> entry : messages.entrySet()) {

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/binaryCleanup/BinaryCleanupProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/binaryCleanup/BinaryCleanupProcessor.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.services.camel.binaryCleanup;
+
+import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.net.URI;
+import java.util.List;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.slf4j.Logger;
+
+import edu.unc.lib.dl.fcrepo4.BinaryObject;
+import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.persist.api.storage.StorageLocation;
+import edu.unc.lib.dl.persist.api.storage.StorageLocationManager;
+import edu.unc.lib.dl.persist.api.transfer.BinaryTransferService;
+import edu.unc.lib.dl.persist.api.transfer.BinaryTransferSession;
+
+/**
+ * Processor which cleans up old binaries leftover from transfers
+ *
+ * @author bbpennel
+ */
+public class BinaryCleanupProcessor implements Processor {
+    private final Logger log = getLogger(BinaryCleanupProcessor.class);
+
+    private StorageLocationManager storageLocationManager;
+    private BinaryTransferService binaryTransferService;
+    private RepositoryObjectLoader repositoryObjectLoaderNoCache;
+
+    @Override
+    public void process(Exchange exchange) throws Exception {
+        String fcrepoUri = (String) exchange.getIn().getHeader(FCREPO_URI);
+        PID dsPid = PIDs.get(fcrepoUri);
+        BinaryObject binObj = repositoryObjectLoaderNoCache.getBinaryObject(dsPid);
+        URI currentContentUri = binObj.getContentUri();
+        String currentContentString = currentContentUri.toString();
+        log.debug("Performing cleanup of out of date binaries for {}, retaining current: {}",
+                fcrepoUri, currentContentString);
+        StorageLocation storageLoc = storageLocationManager.getStorageLocation(binObj);
+        // Delete all content files which are older than the current content file
+        try (BinaryTransferSession session = binaryTransferService.getSession(storageLoc)) {
+            List<URI> uris = storageLoc.getAllStorageUris(dsPid);
+            if (!uris.contains(currentContentUri)) {
+                log.error("Expected binary {} to have head content file {}, but file was not found",
+                        dsPid, currentContentString);
+                return;
+            }
+            uris.stream()
+                .filter(storageUri -> storageUri.toString().compareTo(currentContentString) < 0)
+                .forEach(storageUri -> {
+                    log.debug("Cleaning up out of date binary URI {}", storageUri);
+                    session.delete(storageUri);
+                });
+        }
+    }
+
+    public void setStorageLocationManager(StorageLocationManager storageLocationManager) {
+        this.storageLocationManager = storageLocationManager;
+    }
+
+    public void setBinaryTransferService(BinaryTransferService binaryTransferService) {
+        this.binaryTransferService = binaryTransferService;
+    }
+
+    public void setRepositoryObjectLoaderNoCache(RepositoryObjectLoader repositoryObjectLoader) {
+        this.repositoryObjectLoaderNoCache = repositoryObjectLoader;
+    }
+}

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/binaryCleanup/BinaryCleanupRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/binaryCleanup/BinaryCleanupRouter.java
@@ -15,11 +15,11 @@
  */
 package edu.unc.lib.dl.services.camel.binaryCleanup;
 
-import static edu.unc.lib.dl.fcrepo4.FcrepoJmsConstants.RESOURCE_TYPE;
-import static edu.unc.lib.dl.rdf.Fcrepo4Repository.Binary;
+import static org.slf4j.LoggerFactory.getLogger;
 
-import org.apache.camel.PropertyInject;
+import org.apache.camel.LoggingLevel;
 import org.apache.camel.builder.RouteBuilder;
+import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -27,20 +27,16 @@ import org.springframework.beans.factory.annotation.Autowired;
  * @author bbpennel
  */
 public class BinaryCleanupRouter extends RouteBuilder {
-    @PropertyInject(value = "cdr.binaryCleanup.delay")
-    private Long cleanup_delay;
-
+    private final Logger log = getLogger(BinaryCleanupRouter.class);
     @Autowired
     private BinaryCleanupProcessor binaryCleanupProcessor;
 
     @Override
     public void configure() throws Exception {
-        // Queue which interprets fedora messages into enhancement requests
-        from("{{cdr.binaryCleanup.camel}}")
-            .routeId("CleanupOldBinaryCopies")
-            .startupOrder(120)
-            .filter(simple("${headers[" + RESOURCE_TYPE + "]} contains '" + Binary.getURI() + "'"))
-            .delay(cleanup_delay)
+        from("{{cdr.registration.successful.dest}}")
+            .routeId("CleanupOldBinaryBatch")
+            .log(LoggingLevel.DEBUG, log, "Cleaning up old binaries")
+            .startupOrder(119)
             .process(binaryCleanupProcessor);
     }
 }

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/binaryCleanup/BinaryCleanupRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/binaryCleanup/BinaryCleanupRouter.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.services.camel.binaryCleanup;
+
+import static edu.unc.lib.dl.fcrepo4.FcrepoJmsConstants.RESOURCE_TYPE;
+import static edu.unc.lib.dl.rdf.Fcrepo4Repository.Binary;
+
+import org.apache.camel.PropertyInject;
+import org.apache.camel.builder.RouteBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Router for tasks to cleanup old binary files
+ * @author bbpennel
+ */
+public class BinaryCleanupRouter extends RouteBuilder {
+    @PropertyInject(value = "cdr.binaryCleanup.delay")
+    private Long cleanup_delay;
+
+    @Autowired
+    private BinaryCleanupProcessor binaryCleanupProcessor;
+
+    @Override
+    public void configure() throws Exception {
+        // Queue which interprets fedora messages into enhancement requests
+        from("{{cdr.binaryCleanup.camel}}")
+            .routeId("CleanupOldBinaryCopies")
+            .startupOrder(120)
+            .filter(simple("${headers[" + RESOURCE_TYPE + "]} contains '" + Binary.getURI() + "'"))
+            .delay(cleanup_delay)
+            .process(binaryCleanupProcessor);
+    }
+}

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/longleaf/RegisterToLongleafProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/longleaf/RegisterToLongleafProcessor.java
@@ -228,6 +228,9 @@ public class RegisterToLongleafProcessor extends AbstractLongleafProcessor {
     }
 
     private void sendSuccessMessage(Map<String, String> successful, Exchange exchange) {
+        if (successful.size() == 0) {
+            return;
+        }
         ProducerTemplate template = exchange.getContext().createProducerTemplate();
         template.sendBody(registrationSuccessfulEndpoint, successful);
     }

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/longleaf/RegisterToLongleafProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/longleaf/RegisterToLongleafProcessor.java
@@ -228,13 +228,8 @@ public class RegisterToLongleafProcessor extends AbstractLongleafProcessor {
     }
 
     private void sendSuccessMessage(Map<String, String> successful, Exchange exchange) {
-        try {
         ProducerTemplate template = exchange.getContext().createProducerTemplate();
         template.sendBody(registrationSuccessfulEndpoint, successful);
-        } catch (Exception e) {
-            log.error("wtf", e);
-            throw e;
-        }
     }
 
     private DigestEntry findDigestEntry(String seekPath, Map<String, List<DigestEntry>> digestsMap) {

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/longleaf/RegisterToLongleafProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/longleaf/RegisterToLongleafProcessor.java
@@ -21,6 +21,7 @@ import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -51,6 +52,7 @@ import edu.unc.lib.dl.fedora.ServiceException;
 import edu.unc.lib.dl.metrics.HistogramFactory;
 import edu.unc.lib.dl.metrics.TimerFactory;
 import edu.unc.lib.dl.model.DatastreamType;
+import edu.unc.lib.dl.persist.services.transfer.FileSystemTransferHelpers;
 import io.dropwizard.metrics5.Histogram;
 import io.dropwizard.metrics5.Timer;
 
@@ -166,9 +168,13 @@ public class RegisterToLongleafProcessor extends AbstractLongleafProcessor {
             sb.append(digestGroup.getKey()).append(":\n");
 
             digestEntries.forEach(manifestEntry -> {
+                Path filePath = Paths.get(manifestEntry.storageUri);
+                String basePath = FileSystemTransferHelpers.getBaseBinaryPath(filePath);
                 sb.append(manifestEntry.digest)
                     .append(' ')
-                    .append(Paths.get(manifestEntry.storageUri).toString())
+                    .append(basePath)
+                    .append(' ')
+                    .append(filePath)
                     .append('\n');
                 cnt.increment();
             });

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/routing/FedoraIdFilters.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/routing/FedoraIdFilters.java
@@ -16,6 +16,7 @@
 package edu.unc.lib.dl.services.camel.routing;
 
 import static edu.unc.lib.dl.rdf.Fcrepo4Repository.Binary;
+import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.util.regex.Pattern;
@@ -68,7 +69,8 @@ public class FedoraIdFilters {
     public static boolean allowedForLongleaf(Exchange exchange) {
         Message in = exchange.getIn();
         String resourceType = (String) in.getHeader(FcrepoJmsConstants.RESOURCE_TYPE);
-        if (!resourceType.contains(Binary.getURI())) {
+        String fcrepoUri = (String) exchange.getIn().getHeader(FCREPO_URI);
+        if (!resourceType.contains(Binary.getURI()) || fcrepoUri.endsWith(RepositoryPathConstants.FCR_METADATA)) {
             return false;
         }
         String eventType = (String) in.getHeader(FcrepoJmsConstants.EVENT_TYPE);

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/routing/MetaServicesRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/routing/MetaServicesRouter.java
@@ -77,6 +77,7 @@ public class MetaServicesRouter extends RouteBuilder {
             .end()
             .filter().method(FedoraIdFilters.class, "allowedForLongleaf")
                 .wireTap("direct-vm:filter.longleaf")
+                .to("{{cdr.binaryCleanup.camel}}")
             .end().end() // ending the filter and the wiretap
             .filter().method(FedoraIdFilters.class, "allowedForEnhancements")
             .wireTap("direct:process.enhancement");

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/routing/MetaServicesRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/routing/MetaServicesRouter.java
@@ -77,7 +77,6 @@ public class MetaServicesRouter extends RouteBuilder {
             .end()
             .filter().method(FedoraIdFilters.class, "allowedForLongleaf")
                 .wireTap("direct-vm:filter.longleaf")
-                .to("{{cdr.binaryCleanup.camel}}")
             .end().end() // ending the filter and the wiretap
             .filter().method(FedoraIdFilters.class, "allowedForEnhancements")
             .wireTap("direct:process.enhancement");

--- a/services-camel/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel/src/main/webapp/WEB-INF/service-context.xml
@@ -84,6 +84,12 @@
         <property name="cacheMaxSize" value="${cache.contentPath.maxSize}" />
     </bean>
     
+    <bean id="repositoryObjectLoaderNoCache" class="edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader" init-method="init">
+        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
+        <property name="cacheTimeToLive" value="0" />
+        <property name="cacheMaxSize" value="0" />
+    </bean>
+    
     <bean id="repositoryObjectCacheLoader" class="edu.unc.lib.dl.fcrepo4.RepositoryObjectCacheLoader">
         <property name="client" ref="fcrepoClient" />
         <property name="repositoryObjectDriver" ref="repositoryObjectDriver" />
@@ -422,6 +428,12 @@
         <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
         <property name="operationsMessageSender" ref="operationsMessageSender" />
     </bean>
+    
+    <bean id="binaryCleanupProcessor" class="edu.unc.lib.dl.services.camel.binaryCleanup.BinaryCleanupProcessor">
+        <property name="storageLocationManager" ref="storageLocationManager" />
+        <property name="binaryTransferService" ref="binaryTransferService" />
+        <property name="repositoryObjectLoaderNoCache" ref="repositoryObjectLoaderNoCache" />
+    </bean>
 
     <!-- Camel contexts -->
 
@@ -446,6 +458,10 @@
         <camel:package>edu.unc.lib.dl.services.camel.images</camel:package>
         <camel:package>edu.unc.lib.dl.services.camel.fulltext</camel:package>
         <camel:package>edu.unc.lib.dl.services.camel.solr</camel:package>
+    </camel:camelContext>
+    
+    <camel:camelContext id="CdrBinaryCleanup">
+        <camel:package>edu.unc.lib.dl.services.camel.binaryCleanup</camel:package>
     </camel:camelContext>
     
     <!-- Initialize metaServicesRouter after the routes it depends on -->

--- a/services-camel/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel/src/main/webapp/WEB-INF/service-context.xml
@@ -280,6 +280,7 @@
     
     <bean id="transactionManager" class="edu.unc.lib.dl.fcrepo4.TransactionManager">
         <property name="client" ref="fcrepoClient" />
+        <property name="binaryTransferService" ref="binaryTransferService" />
     </bean>
     
     <!-- XML Import dependencies -->

--- a/services-camel/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel/src/main/webapp/WEB-INF/service-context.xml
@@ -403,9 +403,10 @@
     </bean>
     
     <bean id="registerLongleafProcessor" class="edu.unc.lib.dl.services.camel.longleaf.RegisterToLongleafProcessor">
-        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoaderNoCache" />
         <property name="fcrepoClient" ref="fcrepoClient" />
         <property name="longleafBaseCommand" value="${longleaf.baseCommand}" />
+        <property name="registrationSuccessfulEndpoint" value="${cdr.registration.successful.dest}" />
     </bean>
     
     <bean id="binaryDestroyedJmsTemplate" class="org.springframework.jms.core.JmsTemplate">
@@ -433,7 +434,6 @@
     <bean id="binaryCleanupProcessor" class="edu.unc.lib.dl.services.camel.binaryCleanup.BinaryCleanupProcessor">
         <property name="storageLocationManager" ref="storageLocationManager" />
         <property name="binaryTransferService" ref="binaryTransferService" />
-        <property name="repositoryObjectLoaderNoCache" ref="repositoryObjectLoaderNoCache" />
     </bean>
 
     <!-- Camel contexts -->

--- a/services-camel/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel/src/main/webapp/WEB-INF/service-context.xml
@@ -374,6 +374,7 @@
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
         <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
         <property name="binaryTransferService" ref="binaryTransferService" />
+        <property name="transactionManager" ref="transactionManager" />
     </bean>
 
     <bean id="updateDescriptionService" class="edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService">

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/binaryCleanup/BinaryCleanupRouterIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/binaryCleanup/BinaryCleanupRouterIT.java
@@ -1,0 +1,276 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.services.camel.binaryCleanup;
+
+import static edu.unc.lib.dl.fcrepo4.FcrepoJmsConstants.EVENT_TYPE;
+import static edu.unc.lib.dl.fcrepo4.FcrepoJmsConstants.IDENTIFIER;
+import static edu.unc.lib.dl.fcrepo4.FcrepoJmsConstants.RESOURCE_TYPE;
+import static edu.unc.lib.dl.fcrepo4.RepositoryPaths.getContentRootPid;
+import static org.fcrepo.camel.FcrepoHeaders.FCREPO_URI;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.io.File;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.NotifyBuilder;
+import org.apache.jena.rdf.model.Resource;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.ContextHierarchy;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import edu.unc.lib.dl.event.PremisLogger;
+import edu.unc.lib.dl.fcrepo4.AdminUnit;
+import edu.unc.lib.dl.fcrepo4.BinaryObject;
+import edu.unc.lib.dl.fcrepo4.CollectionObject;
+import edu.unc.lib.dl.fcrepo4.ContentRootObject;
+import edu.unc.lib.dl.fcrepo4.FcrepoJmsConstants;
+import edu.unc.lib.dl.fcrepo4.FedoraTransaction;
+import edu.unc.lib.dl.fcrepo4.FolderObject;
+import edu.unc.lib.dl.fcrepo4.RepositoryInitializer;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
+import edu.unc.lib.dl.fcrepo4.TransactionManager;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.model.DatastreamPids;
+import edu.unc.lib.dl.persist.api.storage.StorageLocation;
+import edu.unc.lib.dl.persist.api.storage.StorageLocationManager;
+import edu.unc.lib.dl.persist.services.storage.StorageLocationTestHelper;
+import edu.unc.lib.dl.rdf.Cdr;
+import edu.unc.lib.dl.rdf.Fcrepo4Repository;
+import edu.unc.lib.dl.rdf.Premis;
+import edu.unc.lib.dl.test.TestHelper;
+
+/**
+ * @author bbpennel
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextHierarchy({
+    @ContextConfiguration("/spring-test/test-fedora-container.xml"),
+    @ContextConfiguration("/spring-test/cdr-client-container.xml"),
+    @ContextConfiguration("/spring-test/jms-context.xml"),
+    @ContextConfiguration("/binary-cleanup-it-context.xml")
+})
+public class BinaryCleanupRouterIT {
+
+    @Autowired
+    private String baseAddress;
+    @Autowired
+    private RepositoryInitializer repositoryInitializer;
+    @Autowired
+    private RepositoryObjectFactory repoObjectFactory;
+    @javax.annotation.Resource(name = "repositoryObjectLoaderNoCache")
+    private RepositoryObjectLoader repoObjectLoader;
+    @Autowired
+    private StorageLocationManager storageLocationManager;
+    @Autowired
+    private TransactionManager txManager;
+
+    @Produce(uri = "{{cdr.binaryCleanup.camel}}")
+    private ProducerTemplate template;
+
+    @Autowired
+    private CamelContext cdrBinaryCleanup;
+
+    private AdminUnit adminUnit;
+
+    private CollectionObject collection;
+
+    @Before
+    public void init() {
+        initMocks(this);
+
+        TestHelper.setContentBase(baseAddress);
+
+        repositoryInitializer.initializeRepository();
+        PID contentRootPid = getContentRootPid();
+
+        ContentRootObject contentRoot = repoObjectLoader.getContentRootObject(contentRootPid);
+        adminUnit = repoObjectFactory.createAdminUnit(null);
+        collection = repoObjectFactory.createCollectionObject(null);
+        contentRoot.addMember(adminUnit);
+        adminUnit.addMember(collection);
+    }
+
+    @Test
+    public void nonBinaryObjectTest() throws Exception {
+        FolderObject folder = repoObjectFactory.createFolderObject(null);
+
+        NotifyBuilder notify = new NotifyBuilder(cdrBinaryCleanup)
+                .whenCompleted(1)
+                .create();
+
+        Map<String, Object> headers = createEvent(folder.getPid(), Cdr.Folder);
+        template.sendBodyAndHeaders("", headers);
+
+        assertTrue("Route not satisfied", notify.matches(5l, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void binaryOnlyCurrentVersionTest() throws Exception {
+        FolderObject folder = repoObjectFactory.createFolderObject(null);
+        PremisLogger premisLogger = folder.getPremisLog();
+        premisLogger.buildEvent(Premis.Ingestion)
+                    .addEventDetail("Ingested this thing")
+                    .writeAndClose();
+
+        PID mdEventsPid = DatastreamPids.getMdEventsPid(folder.getPid());
+        BinaryObject mdEventsObj = repoObjectLoader.getBinaryObject(mdEventsPid);
+        File headContentFile = new File(mdEventsObj.getContentUri());
+        assertTrue("Binary must exist prior to cleanup", headContentFile.exists());
+
+        Map<String, Object> headers = createEvent(mdEventsPid, Fcrepo4Repository.Binary);
+        template.sendBodyAndHeaders("", headers);
+
+        NotifyBuilder notify = new NotifyBuilder(cdrBinaryCleanup)
+                .whenCompleted(1)
+                .create();
+        assertTrue("Route not satisfied", notify.matches(5l, TimeUnit.SECONDS));
+
+        assertTrue("Binary must exist after cleanup", headContentFile.exists());
+    }
+
+    @Test
+    public void binaryMultipleOlderVersionsTest() throws Exception {
+        FolderObject folder = repoObjectFactory.createFolderObject(null);
+        PremisLogger premisLogger = folder.getPremisLog();
+        // Add events one by one, to produce multiple versions of log datastream
+        premisLogger.buildEvent(Premis.Ingestion)
+                    .addEventDetail("Ingested this thing")
+                    .write();
+
+        premisLogger.buildEvent(Premis.VirusCheck)
+                    .addEventDetail("Scanning it")
+                    .write();
+
+        premisLogger.buildEvent(Premis.FixityCheck)
+                    .addEventDetail("Checking it")
+                    .write();
+
+        PID mdEventsPid = DatastreamPids.getMdEventsPid(folder.getPid());
+        BinaryObject mdEventsObj = repoObjectLoader.getBinaryObject(mdEventsPid);
+        URI headContentUri = mdEventsObj.getContentUri();
+        File headContentFile = new File(headContentUri);
+        assertTrue("Binary must exist prior to cleanup", headContentFile.exists());
+
+        StorageLocation storageLoc = storageLocationManager.getStorageLocationById(StorageLocationTestHelper.LOC1_ID);
+        List<URI> startingUris = storageLoc.getAllStorageUris(mdEventsPid);
+        assertEquals(3, startingUris.size());
+
+        Map<String, Object> headers = createEvent(mdEventsPid, Fcrepo4Repository.Binary);
+        template.sendBodyAndHeaders("", headers);
+
+        NotifyBuilder notify1 = new NotifyBuilder(cdrBinaryCleanup)
+                .whenCompleted(1)
+                .create();
+        assertTrue("Route not satisfied", notify1.matches(5l, TimeUnit.SECONDS));
+
+        assertTrue("Head binary must exist after cleanup", headContentFile.exists());
+
+        List<URI> afterUris = storageLoc.getAllStorageUris(mdEventsPid);
+        assertEquals(1, afterUris.size());
+        assertTrue(afterUris.contains(headContentUri));
+    }
+
+    @Test
+    public void binaryNewerVersionInTxTest() throws Exception {
+        FolderObject folder = repoObjectFactory.createFolderObject(null);
+        PremisLogger premisLogger = folder.getPremisLog();
+        // Add events one by one, to produce multiple versions of log datastream
+        premisLogger.buildEvent(Premis.Ingestion)
+                    .addEventDetail("Ingested this thing")
+                    .write();
+
+        PID mdEventsPid = DatastreamPids.getMdEventsPid(folder.getPid());
+        BinaryObject mdEventsObj = repoObjectLoader.getBinaryObject(mdEventsPid);
+        URI headContentUri = mdEventsObj.getContentUri();
+        File headContentFile = new File(headContentUri);
+        assertTrue("Binary must exist prior to cleanup", headContentFile.exists());
+
+        StorageLocation storageLoc = storageLocationManager.getStorageLocationById(StorageLocationTestHelper.LOC1_ID);
+
+        FedoraTransaction tx = txManager.startTransaction();
+        try {
+            premisLogger.buildEvent(Premis.VirusCheck)
+                        .addEventDetail("Scanning it")
+                        .write();
+
+            List<URI> startingUris = storageLoc.getAllStorageUris(mdEventsPid);
+            assertEquals(2, startingUris.size());
+
+            Map<String, Object> headers = createEvent(mdEventsPid, Fcrepo4Repository.Binary);
+            template.sendBodyAndHeaders("", headers);
+
+            NotifyBuilder notify1 = new NotifyBuilder(cdrBinaryCleanup)
+                    .whenCompleted(1)
+                    .create();
+            assertTrue("Route not satisfied", notify1.matches(5l, TimeUnit.SECONDS));
+
+            // Both the head version and the uncommitted tx version should exist
+            List<URI> afterUris = storageLoc.getAllStorageUris(mdEventsPid);
+            assertEquals(2, afterUris.size());
+            assertTrue(afterUris.containsAll(startingUris));
+            assertTrue(afterUris.stream().allMatch(uri -> new File(uri).exists()));
+        } finally {
+            tx.close();
+        }
+
+        // Check that correct files are in place after ending the tx
+        BinaryObject afterMdEventsObj = repoObjectLoader.getBinaryObject(mdEventsPid);
+        URI afterContentUri = afterMdEventsObj.getContentUri();
+        assertNotEquals("Content URI of Event Log must have updated", afterContentUri, headContentUri);
+
+        NotifyBuilder notify2 = new NotifyBuilder(cdrBinaryCleanup)
+                .whenCompleted(1)
+                .create();
+
+        Map<String, Object> headers = createEvent(mdEventsPid, Fcrepo4Repository.Binary);
+        template.sendBodyAndHeaders("", headers);
+
+        assertTrue("Route not satisfied", notify2.matches(5l, TimeUnit.SECONDS));
+
+        // Both the head version and the uncommitted tx version should exist
+        List<URI> afterUris = storageLoc.getAllStorageUris(mdEventsPid);
+        assertEquals(1, afterUris.size());
+        assertTrue(afterUris.contains(afterContentUri));
+        assertTrue(afterUris.stream().allMatch(uri -> new File(uri).exists()));
+    }
+
+    private Map<String, Object> createEvent(PID pid, Resource... types) {
+        Map<String, Object> headers = new HashMap<>();
+        headers.put(IDENTIFIER, pid.getRepositoryPath());
+        headers.put(EVENT_TYPE, FcrepoJmsConstants.EVENT_MODIFY);
+        headers.put(FCREPO_URI, pid.getRepositoryPath());
+        headers.put(RESOURCE_TYPE, Arrays.stream(types).map(Resource::getURI).collect(Collectors.joining(",")));
+
+        return headers;
+    }
+}

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/destroyDerivatives/DestroyDerivativesRouterIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/destroyDerivatives/DestroyDerivativesRouterIT.java
@@ -95,7 +95,7 @@ public class DestroyDerivativesRouterIT {
     private String baseAddress;
     @Autowired
     private RepositoryObjectFactory repoObjectFactory;
-    @Autowired
+    @javax.annotation.Resource(name = "repositoryObjectLoader")
     private RepositoryObjectLoader repoObjLoader;
     @Autowired
     private TransactionManager txManager;

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/destroyDerivatives/DestroyDerivativesRouterIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/destroyDerivatives/DestroyDerivativesRouterIT.java
@@ -302,7 +302,7 @@ public class DestroyDerivativesRouterIT {
         collection.addMember(work);
 
         String bodyString = "Content";
-        Path storagePath = Paths.get(locationManager.getStorageLocationById(LOC1_ID).getStorageUri(work.getPid()));
+        Path storagePath = Paths.get(locationManager.getStorageLocationById(LOC1_ID).getNewStorageUri(work.getPid()));
         Files.createDirectories(storagePath);
         File contentFile = Files.createTempFile(storagePath, "file", ".txt").toFile();
         String sha1 = "4f9be057f0ea5d2ba72fd2c810e8d7b9aa98b469";

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/enhancements/EnhancementRouterIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/enhancements/EnhancementRouterIT.java
@@ -300,7 +300,7 @@ public class EnhancementRouterIT {
     public void testDepositManifestFileMetadata() throws Exception {
         DepositRecord recObj = repoObjectFactory.createDepositRecord(null);
         Path manifestPath = Files.createTempFile("manifest", ".txt");
-        BinaryObject manifestBin = recObj.addManifest(manifestPath.toUri(), "text/plain");
+        BinaryObject manifestBin = recObj.addManifest(manifestPath.toUri(), "manifest", "text/plain", null, null);
 
         String mdId = manifestBin.getPid().getRepositoryPath() + "/fcr:metadata";
         PID mdPid = PIDs.get(mdId);

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/importxml/ImportXMLIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/importxml/ImportXMLIT.java
@@ -88,7 +88,7 @@ public class ImportXMLIT {
 
     @Autowired
     private RepositoryObjectFactory repoObjectFactory;
-    @Autowired
+    @javax.annotation.Resource(name = "repositoryObjectLoader")
     private RepositoryObjectLoader repoObjectLoader;
 
     @Autowired

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/RegisterToLongleafProcessorIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/RegisterToLongleafProcessorIT.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
@@ -59,6 +60,7 @@ import edu.unc.lib.dl.persist.api.storage.StorageLocationManager;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferOutcome;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferService;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferSession;
+import edu.unc.lib.dl.persist.services.transfer.FileSystemTransferHelpers;
 import edu.unc.lib.dl.test.TestHelper;
 
 /**
@@ -234,13 +236,15 @@ public class RegisterToLongleafProcessorIT {
         int algIndex = output.indexOf(alg + ":");
         assertNotEquals("Expected digest algorithm " + alg + " not found in manifest", -1, algIndex);
 
-        String expectedPath = Paths.get(storageUri).toString();
+        Path storagePath = Paths.get(storageUri);
+        String expectedBase = FileSystemTransferHelpers.getBaseBinaryPath(storagePath);
+        String expectedPath = storagePath.toString();
         for (int i = algIndex + 1; i < output.size(); i++) {
             String line = output.get(i);
             if (line.matches("\\S+:")) {
                 break;
             }
-            if (line.matches(expectedDigest + " +" + expectedPath)) {
+            if (line.matches(expectedDigest + " +" + expectedBase + " +" + expectedPath)) {
                 return;
             }
         }

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/RegisterToLongleafProcessorIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/RegisterToLongleafProcessorIT.java
@@ -30,8 +30,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.apache.camel.CamelContext;
 import org.apache.camel.Exchange;
 import org.apache.camel.Message;
+import org.apache.camel.ProducerTemplate;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.fcrepo.client.FcrepoClient;
 import org.fusesource.hawtbuf.ByteArrayInputStream;
@@ -259,6 +261,10 @@ public class RegisterToLongleafProcessorIT {
     private Exchange createBatchExchange(RepositoryObject... objects) {
         Exchange exchange = mock(Exchange.class);
         Message msg = mock(Message.class);
+        CamelContext context = mock(CamelContext.class);
+        when(exchange.getContext()).thenReturn(context);
+        ProducerTemplate template = mock(ProducerTemplate.class);
+        when(context.createProducerTemplate()).thenReturn(template);
         when(exchange.getIn()).thenReturn(msg);
         when(msg.getBody(List.class)).thenReturn(Arrays.stream(objects)
                 .map(ro -> ro.getPid().getRepositoryPath())

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/RegisterToLongleafProcessorIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/RegisterToLongleafProcessorIT.java
@@ -89,7 +89,7 @@ public class RegisterToLongleafProcessorIT {
     private String baseAddress;
     @Autowired
     private RepositoryObjectFactory repoObjFactory;
-    @Autowired
+    @javax.annotation.Resource(name = "repositoryObjectLoader")
     private RepositoryObjectLoader repoObjLoader;
     @Autowired
     private RepositoryPIDMinter pidMinter;

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/routing/MetaServicesRouterTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/routing/MetaServicesRouterTest.java
@@ -85,7 +85,6 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
     public void testRouteStartContainer() throws Exception {
         getMockEndpoint("mock:direct-vm:index.start").expectedMessageCount(1);
         getMockEndpoint("mock:direct-vm:filter.longleaf").expectedMessageCount(0);
-        getMockEndpoint("mock:direct-vm:binaryCleanup").expectedMessageCount(0);
         getMockEndpoint("mock:direct:process.enhancement").expectedMessageCount(1);
 
         createContext(META_ROUTE);
@@ -101,7 +100,6 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
     public void testRouteStartTimemap() throws Exception {
         getMockEndpoint("mock:direct-vm:index.start").expectedMessageCount(0);
         getMockEndpoint("mock:direct-vm:filter.longleaf").expectedMessageCount(0);
-        getMockEndpoint("mock:direct-vm:binaryCleanup").expectedMessageCount(0);
         getMockEndpoint("mock:direct:process.enhancement").expectedMessageCount(0);
 
         createContext(META_ROUTE);
@@ -118,7 +116,6 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
     public void testRouteStartDatafs() throws Exception {
         getMockEndpoint("mock:direct-vm:index.start").expectedMessageCount(1);
         getMockEndpoint("mock:direct-vm:filter.longleaf").expectedMessageCount(0);
-        getMockEndpoint("mock:direct-vm:binaryCleanup").expectedMessageCount(0);
         getMockEndpoint("mock:direct:process.enhancement").expectedMessageCount(0);
 
         createContext(META_ROUTE);
@@ -135,7 +132,6 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
     public void testRouteStartDepositRecord() throws Exception {
         getMockEndpoint("mock:direct-vm:index.start").expectedMessageCount(1);
         getMockEndpoint("mock:direct-vm:filter.longleaf").expectedMessageCount(0);
-        getMockEndpoint("mock:direct-vm:binaryCleanup").expectedMessageCount(0);
         getMockEndpoint("mock:direct:process.enhancement").expectedMessageCount(0);
 
         createContext(META_ROUTE);
@@ -152,7 +148,6 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
     public void testRouteStartNotAPid() throws Exception {
         getMockEndpoint("mock:direct-vm:index.start").expectedMessageCount(1);
         getMockEndpoint("mock:direct-vm:filter.longleaf").expectedMessageCount(0);
-        getMockEndpoint("mock:direct-vm:binaryCleanup").expectedMessageCount(0);
         getMockEndpoint("mock:direct:process.enhancement").expectedMessageCount(0);
 
         createContext(META_ROUTE);
@@ -169,7 +164,6 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
     public void testRouteStartCollections() throws Exception {
         getMockEndpoint("mock:direct-vm:index.start").expectedMessageCount(1);
         getMockEndpoint("mock:direct-vm:filter.longleaf").expectedMessageCount(0);
-        getMockEndpoint("mock:direct-vm:binaryCleanup").expectedMessageCount(0);
         getMockEndpoint("mock:direct:process.enhancement").expectedMessageCount(0);
 
         createContext(META_ROUTE);
@@ -186,7 +180,6 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
     public void testRouteStartBinaryMetadata() throws Exception {
         getMockEndpoint("mock:direct-vm:index.start").expectedMessageCount(1);
         getMockEndpoint("mock:direct-vm:filter.longleaf").expectedMessageCount(0);
-        getMockEndpoint("mock:direct-vm:binaryCleanup").expectedMessageCount(0);
         getMockEndpoint("mock:direct:process.enhancement").expectedMessageCount(0);
 
         createContext(META_ROUTE);
@@ -207,7 +200,6 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
     public void testRouteStartOriginalBinary() throws Exception {
         getMockEndpoint("mock:direct-vm:index.start").expectedMessageCount(1);
         getMockEndpoint("mock:direct-vm:filter.longleaf").expectedMessageCount(1);
-        getMockEndpoint("mock:direct-vm:binaryCleanup").expectedMessageCount(1);
         getMockEndpoint("mock:direct:process.enhancement").expectedMessageCount(1);
 
         createContext(META_ROUTE);
@@ -224,7 +216,6 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
     public void testRouteStartPremisBinary() throws Exception {
         getMockEndpoint("mock:direct-vm:index.start").expectedMessageCount(1);
         getMockEndpoint("mock:direct-vm:filter.longleaf").expectedMessageCount(1);
-        getMockEndpoint("mock:direct-vm:binaryCleanup").expectedMessageCount(1);
         getMockEndpoint("mock:direct:process.enhancement").expectedMessageCount(0);
 
         createContext(META_ROUTE);

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solr/AbstractSolrProcessorIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solr/AbstractSolrProcessorIT.java
@@ -88,7 +88,7 @@ public abstract class AbstractSolrProcessorIT {
 
     @Autowired
     protected Model queryModel;
-    @Autowired
+    @javax.annotation.Resource(name = "repositoryObjectLoader")
     protected RepositoryObjectLoader repositoryObjectLoader;
     @Autowired
     protected RepositoryObjectFactory repositoryObjectFactory;

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solr/SolrIngestProcessorIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solr/SolrIngestProcessorIT.java
@@ -78,7 +78,7 @@ public class SolrIngestProcessorIT extends AbstractSolrProcessorIT {
     private DocumentIndexingPipeline solrFullUpdatePipeline;
     @Autowired
     private UpdateDescriptionService updateDescriptionService;
-    @Autowired
+    @javax.annotation.Resource(name = "repositoryObjectLoader")
     private RepositoryObjectLoader repositoryObjectLoader;
     @Autowired
     private DerivativeService derivativeService;

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/triplesReindexing/TriplesReindexingRouterIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/triplesReindexing/TriplesReindexingRouterIT.java
@@ -96,7 +96,7 @@ public class TriplesReindexingRouterIT {
     @Autowired
     private String fusekiPort;
 
-    @Autowired
+    @javax.annotation.Resource(name = "repositoryObjectLoader")
     private RepositoryObjectLoader repositoryObjectLoader;
     @Autowired
     private RepositoryObjectFactory repositoryObjectFactory;

--- a/services-camel/src/test/resources/binary-cleanup-it-config.properties
+++ b/services-camel/src/test/resources/binary-cleanup-it-config.properties
@@ -1,3 +1,1 @@
-cdr.binaryCleanup=activemq:queue:repository.binaryCleanup
-cdr.binaryCleanup.camel=activemq://activemq:queue:repository.binaryCleanup
-cdr.binaryCleanup.delay=1
+cdr.registration.successful.dest=activemq://activemq:queue:repository.binaryCleanup?transacted=true

--- a/services-camel/src/test/resources/binary-cleanup-it-config.properties
+++ b/services-camel/src/test/resources/binary-cleanup-it-config.properties
@@ -1,0 +1,3 @@
+cdr.binaryCleanup=activemq:queue:repository.binaryCleanup
+cdr.binaryCleanup.camel=activemq://activemq:queue:repository.binaryCleanup
+cdr.binaryCleanup.delay=1

--- a/services-camel/src/test/resources/binary-cleanup-it-context.xml
+++ b/services-camel/src/test/resources/binary-cleanup-it-context.xml
@@ -24,10 +24,12 @@
         <property name="location" value="classpath:binary-cleanup-it-config.properties"/>
     </bean>
     
+    <bean id="longleafAggregationStrategy" class="edu.unc.lib.dl.services.camel.longleaf.LongleafAggregationStrategy">
+    </bean>
+    
     <bean id="binaryCleanupProcessor" class="edu.unc.lib.dl.services.camel.binaryCleanup.BinaryCleanupProcessor">
         <property name="storageLocationManager" ref="storageLocationManager" />
         <property name="binaryTransferService" ref="binaryTransferService" />
-        <property name="repositoryObjectLoaderNoCache" ref="repositoryObjectLoaderNoCache" />
     </bean>
 
     <!-- Force the camel context to shutdown before activemq broker -->

--- a/services-camel/src/test/resources/binary-cleanup-it-context.xml
+++ b/services-camel/src/test/resources/binary-cleanup-it-context.xml
@@ -24,9 +24,6 @@
         <property name="location" value="classpath:binary-cleanup-it-config.properties"/>
     </bean>
     
-    <bean id="longleafAggregationStrategy" class="edu.unc.lib.dl.services.camel.longleaf.LongleafAggregationStrategy">
-    </bean>
-    
     <bean id="binaryCleanupProcessor" class="edu.unc.lib.dl.services.camel.binaryCleanup.BinaryCleanupProcessor">
         <property name="storageLocationManager" ref="storageLocationManager" />
         <property name="binaryTransferService" ref="binaryTransferService" />

--- a/services-camel/src/test/resources/binary-cleanup-it-context.xml
+++ b/services-camel/src/test/resources/binary-cleanup-it-context.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:c="http://www.springframework.org/schema/c"
+    xmlns:p="http://www.springframework.org/schema/p" xmlns:context="http://www.springframework.org/schema/context"
+    xmlns:util="http://www.springframework.org/schema/util"
+    xmlns:camel="http://camel.apache.org/schema/spring"
+    xmlns:amq="http://activemq.apache.org/schema/core"
+    xsi:schemaLocation="http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans-4.3.xsd
+        http://www.springframework.org/schema/util 
+        http://www.springframework.org/schema/util/spring-util.xsd
+        http://www.springframework.org/schema/context
+        http://www.springframework.org/schema/context/spring-context-4.3.xsd
+        http://activemq.apache.org/schema/core
+        http://activemq.apache.org/schema/core/activemq-core.xsd
+        http://camel.apache.org/schema/spring
+        http://camel.apache.org/schema/spring/camel-spring.xsd">
+        
+    <bean id="properties" class="org.apache.camel.component.properties.PropertiesComponent">
+        <property name="location" value="classpath:binary-cleanup-it-config.properties"/>
+    </bean>
+    
+    <bean id="bridgePropertyPlaceholder" class="org.apache.camel.spring.spi.BridgePropertyPlaceholderConfigurer">
+        <property name="location" value="classpath:binary-cleanup-it-config.properties"/>
+    </bean>
+    
+    <bean id="binaryCleanupProcessor" class="edu.unc.lib.dl.services.camel.binaryCleanup.BinaryCleanupProcessor">
+        <property name="storageLocationManager" ref="storageLocationManager" />
+        <property name="binaryTransferService" ref="binaryTransferService" />
+        <property name="repositoryObjectLoaderNoCache" ref="repositoryObjectLoaderNoCache" />
+    </bean>
+
+    <!-- Force the camel context to shutdown before activemq broker -->
+    <bean id="camelShutdownHook" class="org.apache.activemq.camel.CamelShutdownHook">
+        <constructor-arg ref="activemqBroker" />
+        <property name="camelContext" ref="cdrBinaryCleanup" />
+    </bean>
+    
+    <camel:camelContext id="cdrBinaryCleanup">
+        <camel:package>edu.unc.lib.dl.services.camel.binaryCleanup</camel:package>
+    </camel:camelContext>
+
+</beans>

--- a/services-camel/src/test/resources/config.properties
+++ b/services-camel/src/test/resources/config.properties
@@ -59,6 +59,9 @@ cdr.destroy.derivatives.stream.camel=direct-vm:index.start
 cdr.enhancement.stream=direct-vm:repository.enhancements
 cdr.enhancement.stream.camel=direct-vm:repository.enhancements
 
+cdr.binaryCleanup=direct-vm:binaryCleanup
+cdr.binaryCleanup.camel=direct-vm:binaryCleanup
+
 # The camel URI for handling reindexing events.
 triplestore.reindex.stream=activemq:queue:triplestore.reindex
 reindexing.stream=activemq:queue:reindexing

--- a/services-camel/src/test/resources/config.properties
+++ b/services-camel/src/test/resources/config.properties
@@ -59,9 +59,6 @@ cdr.destroy.derivatives.stream.camel=direct-vm:index.start
 cdr.enhancement.stream=direct-vm:repository.enhancements
 cdr.enhancement.stream.camel=direct-vm:repository.enhancements
 
-cdr.binaryCleanup=direct-vm:binaryCleanup
-cdr.binaryCleanup.camel=direct-vm:binaryCleanup
-
 # The camel URI for handling reindexing events.
 triplestore.reindex.stream=activemq:queue:triplestore.reindex
 reindexing.stream=activemq:queue:reindexing

--- a/services-camel/src/test/resources/register-longleaf-router-context.xml
+++ b/services-camel/src/test/resources/register-longleaf-router-context.xml
@@ -30,6 +30,7 @@
     <bean id="registerLongleafProcessor" class="edu.unc.lib.dl.services.camel.longleaf.RegisterToLongleafProcessor">
         <property name="fcrepoClient" ref="fcrepoClient" />
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="registrationSuccessfulEndpoint" value="mock:direct:registrationSuccessful" />
     </bean>
     
     <bean id="deregisterLongleafProcessor" class="org.mockito.Mockito" factory-method="mock">

--- a/services-camel/src/test/resources/spring-test/cdr-client-container.xml
+++ b/services-camel/src/test/resources/spring-test/cdr-client-container.xml
@@ -27,6 +27,7 @@
         <property name="pidMinter" ref="repositoryPIDMinter" />
         <property name="repoObjLoader" ref="repositoryObjectLoader" />
         <property name="repoObjFactory" ref="repositoryObjectFactory" />
+        <property name="binaryTransferService" ref="binaryTransferService" />
     </bean>
     
     <bean id="repositoryPIDMinter" class="edu.unc.lib.dl.fcrepo4.RepositoryPIDMinter"></bean>
@@ -59,6 +60,12 @@
         <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
         <property name="cacheTimeToLive" ref="cacheTimeToLive" />
         <property name="cacheMaxSize" ref="cacheMaxSize" />
+    </bean>
+    
+    <bean id="repositoryObjectLoaderNoCache" class="edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader" init-method="init">
+        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
+        <property name="cacheTimeToLive" value="0" />
+        <property name="cacheMaxSize" value="0" />
     </bean>
     
     <bean id="repositoryObjectDriver" class="edu.unc.lib.dl.fcrepo4.RepositoryObjectDriver">

--- a/services-camel/src/test/resources/spring-test/cdr-client-container.xml
+++ b/services-camel/src/test/resources/spring-test/cdr-client-container.xml
@@ -116,6 +116,7 @@
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
         <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
         <property name="binaryTransferService" ref="binaryTransferService" />
+        <property name="transactionManager" ref="txManager" />
     </bean>
     
     <bean id="operationsMessageSender" class="org.mockito.Mockito" factory-method="mock">

--- a/services-camel/src/test/resources/spring-test/cdr-client-container.xml
+++ b/services-camel/src/test/resources/spring-test/cdr-client-container.xml
@@ -89,6 +89,7 @@
     
     <bean id="txManager" class="edu.unc.lib.dl.fcrepo4.TransactionManager">
         <property name="client" ref="fcrepoClient" />
+        <property name="binaryTransferService" ref="binaryTransferService" />
     </bean>
     
     <bean id="aclService" class="org.mockito.Mockito" factory-method="mock">

--- a/services/src/main/webapp/WEB-INF/access-fedora-context.xml
+++ b/services/src/main/webapp/WEB-INF/access-fedora-context.xml
@@ -137,5 +137,6 @@
     
     <bean id="transactionManager" class="edu.unc.lib.dl.fcrepo4.TransactionManager">
         <property name="client" ref="fcrepoClient" />
+        <property name="binaryTransferService" ref="binaryTransferService" />
     </bean>
 </beans>

--- a/services/src/main/webapp/WEB-INF/service-context.xml
+++ b/services/src/main/webapp/WEB-INF/service-context.xml
@@ -316,6 +316,7 @@
       <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
       <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
       <property name="binaryTransferService" ref="binaryTransferService" />
+      <property name="transactionManager" ref="transactionManager" />
   </bean>
   
   <bean id="updateDescriptionService" class="edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService" >

--- a/services/src/test/resources/spring-test/cdr-client-container.xml
+++ b/services/src/test/resources/spring-test/cdr-client-container.xml
@@ -111,6 +111,7 @@
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
         <property name="repositoryObjectFactory" ref="repositoryObjectFactory" />
         <property name="binaryTransferService" ref="binaryTransferService" />
+        <property name="transactionManager" ref="transactionManager" />
     </bean>
 
     <bean id="updateDescriptionService" class="edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService" >

--- a/services/src/test/resources/spring-test/cdr-client-container.xml
+++ b/services/src/test/resources/spring-test/cdr-client-container.xml
@@ -100,6 +100,7 @@
     
     <bean id="transactionManager" class="edu.unc.lib.dl.fcrepo4.TransactionManager">
         <property name="client" ref="fcrepoClient" />
+        <property name="binaryTransferService" ref="binaryTransferService" />
     </bean>
     
     <bean id="aclService" class="org.mockito.Mockito" factory-method="mock">


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2880

* Binaries are now always transferred to a new file path, which is timestamped in millisecond + nano time
* Longleaf registration of binaries now records a separate physical and logical path for the file, so that new versions of a file (due to now being timestamped) can be considered the same logical by longleaf.
* Binary transfers that occur during a transaction (tx) are now tracked for the duration of the tx
* In the event of a Fedora Transaction rollback, binaries transferred in that tx will be immediately cleaned up
* Old versions of binaries are cleaned up after longleaf registration completes, to avoid gap where old file has been deleted before new file is registered
* Fixes issue where fcr:metadata objects were not being excluded from longleaf/binary cleanup routes
* Uses a non-caching RepositoryObjectLoader for longleaf registration/binary cleanup to ensure that the content URI is up to date
* Improvements to handling of nested fedora transactions
* VersionedDatastream updates now take place in a transaction, for safety reasons