### PR TITLE
BXC-3015 - Inherit collection numbers and finding aid URLs

### DIFF
--- a/access-common/src/main/java/edu/unc/lib/dl/ui/service/FindingAidUrlService.java
+++ b/access-common/src/main/java/edu/unc/lib/dl/ui/service/FindingAidUrlService.java
@@ -97,7 +97,7 @@ public class FindingAidUrlService {
             log.error("Failed to get finding aid link for {}", collectionId, e);
             return null;
         } finally {
-            log.error("Retrieved finding aid URL in {}ms", (System.nanoTime() - start) / 1e6);
+            log.debug("Retrieved finding aid URL in {}ms", (System.nanoTime() - start) / 1e6);
         }
     }
 

--- a/access-common/src/main/java/edu/unc/lib/dl/ui/service/FindingAidUrlService.java
+++ b/access-common/src/main/java/edu/unc/lib/dl/ui/service/FindingAidUrlService.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.ui.service;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpStatus;
+import org.apache.http.StatusLine;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.slf4j.Logger;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+
+import edu.unc.lib.dl.util.URIUtil;
+
+/**
+ * Service for getting finding aid URLs
+ *
+ * @author bbpennel
+ */
+public class FindingAidUrlService {
+    private static final Logger log = getLogger(FindingAidUrlService.class);
+
+    private LoadingCache<String, Optional<String>> collIdTolinkCache;
+
+    private long maxCacheSize;
+    private long expireCacheSeconds;
+    private int checkTimeoutSeconds = 5;
+    private String findingAidBaseUrl;
+    private CloseableHttpClient httpClient;
+
+    public void init() {
+        collIdTolinkCache = CacheBuilder.newBuilder()
+                .maximumSize(maxCacheSize)
+                .expireAfterWrite(expireCacheSeconds, TimeUnit.SECONDS)
+                .build(new CacheLoader<String, Optional<String>>() {
+                    @Override
+                    public Optional<String> load(String key) throws Exception {
+                        String baseCollId = key.replace("-z", "");
+                        String url = URIUtil.join(findingAidBaseUrl, baseCollId) + "/";
+                        HttpHead req = new HttpHead(url);
+                        try (CloseableHttpResponse resp = httpClient.execute(req)) {
+                            StatusLine statusLine = resp.getStatusLine();
+                            int status = statusLine.getStatusCode();
+                            if (status < HttpStatus.SC_BAD_REQUEST) {
+                                return Optional.of(url);
+                            } else if (status == HttpStatus.SC_NOT_FOUND) {
+                                log.debug("Finding aid not found for collection {} at {}", key, url);
+                                return Optional.empty();
+                            } else {
+                                log.error("Failed to check on finding aid URL {}: {} {}",
+                                        url, statusLine.getStatusCode(), statusLine.getReasonPhrase());
+                                return Optional.empty();
+                            }
+                        }
+                    }
+                });
+    }
+
+    /**
+     * @param collectionId Collection number (not the PID)
+     * @return the finding aid URL for the given collection ID, as a string, or null if none found.
+     */
+    public String getFindingAidUrl(String collectionId) {
+        if (StringUtils.isEmpty(collectionId)) {
+            return null;
+        }
+        long start = System.nanoTime();
+        try {
+            return collIdTolinkCache.get(collectionId).orElse(null);
+        } catch (ExecutionException e) {
+            log.error("Failed to get finding aid link for {}", collectionId, e);
+            return null;
+        } finally {
+            log.error("Retrieved finding aid URL in {}ms", (System.nanoTime() - start) / 1e6);
+        }
+    }
+
+    public void setMaxCacheSize(long maxCacheSize) {
+        this.maxCacheSize = maxCacheSize;
+    }
+
+    public void setExpireCacheSeconds(long expireCacheSeconds) {
+        this.expireCacheSeconds = expireCacheSeconds;
+    }
+
+    public void setCheckTimeoutSeconds(int checkTimeoutSeconds) {
+        this.checkTimeoutSeconds = checkTimeoutSeconds;
+    }
+
+    public void setFindingAidBaseUrl(String findingAidBaseUrl) {
+        this.findingAidBaseUrl = findingAidBaseUrl;
+    }
+
+    public void setHttpClientConnectionManager(HttpClientConnectionManager httpClientConnectionManager) {
+        RequestConfig config = RequestConfig.custom()
+                .setConnectTimeout(checkTimeoutSeconds * 1000)
+                .setSocketTimeout(checkTimeoutSeconds * 1000)
+                .build();
+        httpClient = HttpClients.custom()
+                .setConnectionManager(httpClientConnectionManager)
+                .setDefaultRequestConfig(config)
+                .build();
+    }
+
+    public void setHttpClient(CloseableHttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+}

--- a/access-common/src/test/java/edu/unc/lib/dl/ui/service/FindingAidUrlServiceTest.java
+++ b/access-common/src/test/java/edu/unc/lib/dl/ui/service/FindingAidUrlServiceTest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.ui.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import org.apache.http.HttpStatus;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+/**
+ * @author bbpennel
+ */
+public class FindingAidUrlServiceTest {
+
+    private FindingAidUrlService service;
+
+    private static final String BASE_URL = "http://example.com/";
+
+    @Mock
+    private CloseableHttpClient httpClient;
+    @Mock
+    private CloseableHttpResponse httpResp;
+    @Mock
+    private StatusLine statusLine;
+
+    @Before
+    public void setup() throws Exception {
+        initMocks(this);
+        service = new FindingAidUrlService();
+        service.setHttpClient(httpClient);
+        service.setFindingAidBaseUrl(BASE_URL);
+        service.setExpireCacheSeconds(5);
+        service.setMaxCacheSize(16);
+        service.init();
+
+        when(httpClient.execute(any(HttpHead.class))).thenReturn(httpResp);
+        when(httpResp.getStatusLine()).thenReturn(statusLine);
+    }
+
+    @Test
+    public void nullCollectionIdTest() {
+        assertNull(service.getFindingAidUrl(null));
+    }
+
+    @Test
+    public void existingCollectionIdTest() {
+        when(statusLine.getStatusCode()).thenReturn(HttpStatus.SC_OK);
+
+        String collId = "55555";
+        assertEquals(BASE_URL + collId + "/", service.getFindingAidUrl(collId));
+    }
+
+    @Test
+    public void notFoundCollectionIdTest() {
+        when(statusLine.getStatusCode()).thenReturn(HttpStatus.SC_NOT_FOUND);
+
+        String collId = "40404";
+        assertNull(service.getFindingAidUrl(collId));
+    }
+
+    @Test
+    public void failureCollectionIdTest() {
+        when(statusLine.getStatusCode()).thenReturn(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+
+        String collId = "50000";
+        assertNull(service.getFindingAidUrl(collId));
+    }
+}

--- a/access/src/main/java/edu/unc/lib/dl/ui/controller/FullRecordController.java
+++ b/access/src/main/java/edu/unc/lib/dl/ui/controller/FullRecordController.java
@@ -65,6 +65,7 @@ import edu.unc.lib.dl.search.solr.service.NeighborQueryService;
 import edu.unc.lib.dl.search.solr.util.SearchFieldKeys;
 import edu.unc.lib.dl.ui.exception.InvalidRecordRequestException;
 import edu.unc.lib.dl.ui.exception.RenderViewException;
+import edu.unc.lib.dl.ui.service.FindingAidUrlService;
 import edu.unc.lib.dl.ui.util.ModsUtil;
 import edu.unc.lib.dl.ui.view.XSLViewResolver;
 
@@ -87,6 +88,8 @@ public class FullRecordController extends AbstractSolrSearchController {
     private NeighborQueryService neighborService;
     @Autowired
     private GetCollectionIdService collectionIdService;
+    @Autowired
+    private FindingAidUrlService findingAidUrlService;
 
     @Autowired(required = true)
     private XSLViewResolver xslViewResolver;
@@ -219,8 +222,12 @@ public class FullRecordController extends AbstractSolrSearchController {
 
         if (resourceType.equals(searchSettings.resourceTypeFolder) ||
                 resourceType.equals(searchSettings.resourceTypeFile) ||
-                resourceType.equals(searchSettings.resourceTypeAggregate)) {
-            model.addAttribute("collectionId", collectionIdService.getCollectionId(briefObject));
+                resourceType.equals(searchSettings.resourceTypeAggregate) ||
+                resourceType.equals(searchSettings.resourceTypeCollection)) {
+            String collectionId = collectionIdService.getCollectionId(briefObject);
+            String faUrl = findingAidUrlService.getFindingAidUrl(collectionId);
+            model.addAttribute("collectionId", collectionId);
+            model.addAttribute("findingAidUrl", faUrl);
         }
 
         if (briefObject.getResourceType().equals(searchSettings.resourceTypeFile) ||

--- a/access/src/main/java/edu/unc/lib/dl/ui/controller/FullRecordController.java
+++ b/access/src/main/java/edu/unc/lib/dl/ui/controller/FullRecordController.java
@@ -60,6 +60,7 @@ import edu.unc.lib.dl.search.solr.model.FacetFieldObject;
 import edu.unc.lib.dl.search.solr.model.SearchResultResponse;
 import edu.unc.lib.dl.search.solr.model.SimpleIdRequest;
 import edu.unc.lib.dl.search.solr.service.ChildrenCountService;
+import edu.unc.lib.dl.search.solr.service.GetCollectionIdService;
 import edu.unc.lib.dl.search.solr.service.NeighborQueryService;
 import edu.unc.lib.dl.search.solr.util.SearchFieldKeys;
 import edu.unc.lib.dl.ui.exception.InvalidRecordRequestException;
@@ -84,6 +85,8 @@ public class FullRecordController extends AbstractSolrSearchController {
     private ChildrenCountService childrenCountService;
     @Autowired
     private NeighborQueryService neighborService;
+    @Autowired
+    private GetCollectionIdService collectionIdService;
 
     @Autowired(required = true)
     private XSLViewResolver xslViewResolver;
@@ -217,14 +220,7 @@ public class FullRecordController extends AbstractSolrSearchController {
         if (resourceType.equals(searchSettings.resourceTypeFolder) ||
                 resourceType.equals(searchSettings.resourceTypeFile) ||
                 resourceType.equals(searchSettings.resourceTypeAggregate)) {
-            String parentCollection = briefObject.getParentCollection();
-            SimpleIdRequest parentIdRequest = new SimpleIdRequest(parentCollection, principals);
-            BriefObjectMetadataBean parentBriefObject = queryLayer.getObjectById(parentIdRequest);
-            if (parentBriefObject == null) {
-                throw new InvalidRecordRequestException();
-            }
-
-            model.addAttribute("parentBriefObject", parentBriefObject);
+            model.addAttribute("collectionId", collectionIdService.getCollectionId(briefObject));
         }
 
         if (briefObject.getResourceType().equals(searchSettings.resourceTypeFile) ||

--- a/access/src/main/webapp/WEB-INF/jsp/fullRecord/aggregateRecord.jsp
+++ b/access/src/main/webapp/WEB-INF/jsp/fullRecord/aggregateRecord.jsp
@@ -24,155 +24,153 @@
 <%@ taglib prefix="s" uri="http://www.springframework.org/tags" %>
 
 <c:choose>
-	<c:when test="${not empty briefObject.countMap}">
-		<c:set var="childCount" value="${briefObject.countMap.child}"/>
-	</c:when>
-	<c:otherwise>
-		<c:set var="childCount" value="0"/>
-	</c:otherwise>
+    <c:when test="${not empty briefObject.countMap}">
+        <c:set var="childCount" value="${briefObject.countMap.child}"/>
+    </c:when>
+    <c:otherwise>
+        <c:set var="childCount" value="0"/>
+    </c:otherwise>
 </c:choose>
 
 <c:set var="dataFileUrl">${cdr:getOriginalFileUrl(briefObject)}</c:set>
 
 <div class="full_record_top">
-			<div class="collinfo_metadata browse-header aggregate-record">
-				<c:import url="fullRecord/navigationBar.jsp" />
-				<div class="columns">
-					<div class="column is-8">
-						<h2 class="item-title ${isDeleted}"><c:out value="${briefObject.title}" /></h2>
-					</div>
-					<div class="column is-narrow-desktop action-btn item-actions">
-						<c:if test="${permsHelper.hasEditAccess(accessGroupSet, briefObject)}">
-							<s:eval var="editDescriptionUrl" expression=
-								"T(edu.unc.lib.dl.util.URIUtil).join(adminBaseUrl, 'describe', briefObject.id)" />
-							<div class="actionlink right"><a class="button" href="${editDescriptionUrl}"><i class="fa fa-edit"></i> Edit</a></div>
-						</c:if>
+            <div class="collinfo_metadata browse-header aggregate-record">
+                <c:import url="fullRecord/navigationBar.jsp" />
+                <div class="columns">
+                    <div class="column is-8">
+                        <h2 class="item-title ${isDeleted}"><c:out value="${briefObject.title}" /></h2>
+                    </div>
+                    <div class="column is-narrow-desktop action-btn item-actions">
+                        <c:if test="${permsHelper.hasEditAccess(accessGroupSet, briefObject)}">
+                            <s:eval var="editDescriptionUrl" expression=
+                                "T(edu.unc.lib.dl.util.URIUtil).join(adminBaseUrl, 'describe', briefObject.id)" />
+                            <div class="actionlink right"><a class="button" href="${editDescriptionUrl}"><i class="fa fa-edit"></i> Edit</a></div>
+                        </c:if>
 
-						<c:choose>
-							<c:when test="${permsHelper.hasOriginalAccess(requestScope.accessGroupSet, briefObject)}">
-								<div class="actionlink right download">
-									<a class="button" href="${dataFileUrl}?dl=true"><i class="fa fa-download"></i> Download</a>
-								</div>
-							</c:when>
-							<c:when test="${not empty embargoDate && not empty dataFileUrl}">
-								<div class="noaction right">
-									Available after <fmt:formatDate value="${embargoDate}" pattern="d MMMM, yyyy"/>
-								</div>
-							</c:when>
-						</c:choose>
-					</div>
-				</div>
-				<div class="columns columns-resize aggregate-info">
-					<div class="column is-narrow-tablet ${isDeleted}">
-						<c:set var="thumbnailObject" value="${briefObject}" scope="request" />
-						<c:import url="common/thumbnail.jsp">
-							<c:param name="target" value="file" />
-							<c:param name="size" value="large" />
-						</c:import>
-					</div>
-					<div class="column is-10">
-						<ul>
-							<c:if test="${not empty briefObject.dateAdded}">
-								<li><span class="has-text-weight-bold">${searchSettings.searchFieldLabels['DATE_ADDED']}:</span> <fmt:formatDate pattern="yyyy-MM-dd" value="${briefObject.dateAdded}" /></li>
-							</c:if>
-							<c:if test="${not empty briefObject.parentCollection && briefObject.ancestorPathFacet.highestTier > 0}">
-								<li>
-									<c:url var="parentUrl" scope="page" value="record/${briefObject.parentCollection}" />
-									<span class="has-text-weight-bold">Collection:</span>
-									<a href="<c:out value='${parentUrl}' />"><c:out value="${briefObject.parentCollectionName}"/></a>
-								</li>
-							</c:if>
-							<c:if test="${not empty parentBriefObject.collectionId}">
-								<li>
-									<span class="has-text-weight-bold">Collection Number: </span>
-									<c:out value="${parentBriefObject.collectionId}"></c:out>
-								</li>
-							</c:if>
-							<li><span class="has-text-weight-bold">Finding Aid: </span>
-								<c:choose>
-									<c:when test="${not empty briefObject.findingAidLink}">
-										<c:forEach var="findingAid" items="${briefObject.findingAidLink}" varStatus="findingAidStatus">
-											<a href="<c:out value="${findingAid}"/>"><c:out value="${findingAid}"/></a><c:if test="${!findingAidStatus.last }">, </c:if>
-										</c:forEach>
-									</c:when>
-									<c:otherwise>Doesn’t have a finding aid</c:otherwise>
-								</c:choose>
-							</li>
-							<c:if test="${not empty briefObject.creator}">
-								<li>
-									<span class="has-text-weight-bold">Creator<c:if test="${fn:length(briefObject.creator) > 1}">s</c:if>:</span>
-									<c:forEach var="creatorObject" items="${briefObject.creator}" varStatus="creatorStatus">
-										<c:out value="${creatorObject}"/><c:if test="${!creatorStatus.last}">; </c:if>
-									</c:forEach>
-								</li>
-							</c:if>
+                        <c:choose>
+                            <c:when test="${permsHelper.hasOriginalAccess(requestScope.accessGroupSet, briefObject)}">
+                                <div class="actionlink right download">
+                                    <a class="button" href="${dataFileUrl}?dl=true"><i class="fa fa-download"></i> Download</a>
+                                </div>
+                            </c:when>
+                            <c:when test="${not empty embargoDate && not empty dataFileUrl}">
+                                <div class="noaction right">
+                                    Available after <fmt:formatDate value="${embargoDate}" pattern="d MMMM, yyyy"/>
+                                </div>
+                            </c:when>
+                        </c:choose>
+                    </div>
+                </div>
+                <div class="columns columns-resize aggregate-info">
+                    <div class="column is-narrow-tablet ${isDeleted}">
+                        <c:set var="thumbnailObject" value="${briefObject}" scope="request" />
+                        <c:import url="common/thumbnail.jsp">
+                            <c:param name="target" value="file" />
+                            <c:param name="size" value="large" />
+                        </c:import>
+                    </div>
+                    <div class="column is-10">
+                        <ul>
+                            <c:if test="${not empty briefObject.dateAdded}">
+                                <li><span class="has-text-weight-bold">${searchSettings.searchFieldLabels['DATE_ADDED']}:</span> <fmt:formatDate pattern="yyyy-MM-dd" value="${briefObject.dateAdded}" /></li>
+                            </c:if>
+                            <c:if test="${not empty briefObject.parentCollection && briefObject.ancestorPathFacet.highestTier > 0}">
+                                <li>
+                                    <c:url var="parentUrl" scope="page" value="record/${briefObject.parentCollection}" />
+                                    <span class="has-text-weight-bold">Collection:</span>
+                                    <a href="<c:out value='${parentUrl}' />"><c:out value="${briefObject.parentCollectionName}"/></a>
+                                </li>
+                            </c:if>
+                            <c:if test="${not empty collectionId}">
+                                <li>
+                                    <span class="has-text-weight-bold">Collection Number: </span>
+                                    <c:out value="${collectionId}"></c:out>
+                                </li>
+                            </c:if>
+                            <li><span class="has-text-weight-bold">Finding Aid: </span>
+                                <c:choose>
+                                    <c:when test="${not empty findingAidUrl}">
+                                        <a href="<c:out value="${findingAidUrl}"/>"><c:out value="${findingAidUrl}"/></a>
+                                    </c:when>
+                                    <c:otherwise>Doesn’t have a finding aid</c:otherwise>
+                                </c:choose>
+                            </li>
+                            <c:if test="${not empty briefObject.creator}">
+                                <li>
+                                    <span class="has-text-weight-bold">Creator<c:if test="${fn:length(briefObject.creator) > 1}">s</c:if>:</span>
+                                    <c:forEach var="creatorObject" items="${briefObject.creator}" varStatus="creatorStatus">
+                                        <c:out value="${creatorObject}"/><c:if test="${!creatorStatus.last}">; </c:if>
+                                    </c:forEach>
+                                </li>
+                            </c:if>
 
-							<c:choose>
-								<c:when test="${not empty briefObject.contentTypeFacet[0].displayValue}">
-									<li><span class="has-text-weight-bold">File Type:</span> <c:out value="${briefObject.contentTypeFacet[0].displayValue}" /></li>
-									<c:if test="${briefObject.filesizeSort != -1}"> <li><span class="has-text-weight-bold">${searchSettings.searchFieldLabels['FILESIZE']}:</span> <c:out value="${cdr:formatFilesize(briefObject.filesizeSort, 1)}"/></li></c:if>
-								</c:when>
-								<c:otherwise>
-									<li><span class="has-text-weight-bold">Contains:</span> ${childCount} item<c:if test="${childCount != 1}">s</c:if></li>
-								</c:otherwise>
-							</c:choose>
+                            <c:choose>
+                                <c:when test="${not empty briefObject.contentTypeFacet[0].displayValue}">
+                                    <li><span class="has-text-weight-bold">File Type:</span> <c:out value="${briefObject.contentTypeFacet[0].displayValue}" /></li>
+                                    <c:if test="${briefObject.filesizeSort != -1}"> <li><span class="has-text-weight-bold">${searchSettings.searchFieldLabels['FILESIZE']}:</span> <c:out value="${cdr:formatFilesize(briefObject.filesizeSort, 1)}"/></li></c:if>
+                                </c:when>
+                                <c:otherwise>
+                                    <li><span class="has-text-weight-bold">Contains:</span> ${childCount} item<c:if test="${childCount != 1}">s</c:if></li>
+                                </c:otherwise>
+                            </c:choose>
 
-							<c:if test="${not empty briefObject.dateCreated}"><li><span class="has-text-weight-bold">${searchSettings.searchFieldLabels['DATE_CREATED']}:</span> <fmt:formatDate pattern="yyyy-MM-dd" value="${briefObject.dateCreated}" /></li></c:if>
-							<c:if test="${not empty embargoDate}"><li><span class="has-text-weight-bold">Embargoed Until:</span> <fmt:formatDate pattern="yyyy-MM-dd" value="${embargoDate}" /></li></c:if>
-						</ul>
-					</div>
-				</div>
-			</div>
+                            <c:if test="${not empty briefObject.dateCreated}"><li><span class="has-text-weight-bold">${searchSettings.searchFieldLabels['DATE_CREATED']}:</span> <fmt:formatDate pattern="yyyy-MM-dd" value="${briefObject.dateCreated}" /></li></c:if>
+                            <c:if test="${not empty embargoDate}"><li><span class="has-text-weight-bold">Embargoed Until:</span> <fmt:formatDate pattern="yyyy-MM-dd" value="${embargoDate}" /></li></c:if>
+                        </ul>
+                    </div>
+                </div>
+            </div>
 
-			<div class="clear">
-				<c:choose>
-					<c:when test="${permsHelper.hasImagePreviewAccess(requestScope.accessGroupSet, briefObject)}">
-						<div class="clear_space"></div>
-						<link rel="stylesheet" href="/static/plugins/leaflet/leaflet.css">
-						<link rel="stylesheet" href="/static/plugins/Leaflet-fullscreen/dist/leaflet.fullscreen.css">
-						<div id="jp2_viewer" class="jp2_imageviewer_window" data-url="${jp2Id}"></div>
-					</c:when>
-					<c:when test="${permsHelper.hasOriginalAccess(requestScope.accessGroupSet, briefObject)}">
-						<c:choose>
-							<c:when test="${briefObject.contentTypeFacet[0].displayValue == 'mp3'}">
-								<div class="clear_space"></div>
-								<audio class="audio_player inline_viewer" src="${dataFileUrl}">
-								</audio>
-							</c:when>
-						</c:choose>
-					</c:when>
-				</c:choose>
-			</div>
+            <div class="clear">
+                <c:choose>
+                    <c:when test="${permsHelper.hasImagePreviewAccess(requestScope.accessGroupSet, briefObject)}">
+                        <div class="clear_space"></div>
+                        <link rel="stylesheet" href="/static/plugins/leaflet/leaflet.css">
+                        <link rel="stylesheet" href="/static/plugins/Leaflet-fullscreen/dist/leaflet.fullscreen.css">
+                        <div id="jp2_viewer" class="jp2_imageviewer_window" data-url="${jp2Id}"></div>
+                    </c:when>
+                    <c:when test="${permsHelper.hasOriginalAccess(requestScope.accessGroupSet, briefObject)}">
+                        <c:choose>
+                            <c:when test="${briefObject.contentTypeFacet[0].displayValue == 'mp3'}">
+                                <div class="clear_space"></div>
+                                <audio class="audio_player inline_viewer" src="${dataFileUrl}">
+                                </audio>
+                            </c:when>
+                        </c:choose>
+                    </c:when>
+                </c:choose>
+            </div>
 </div>
 
 <%-- Reenable once child counts are working --%>
 <c:if test="${childCount > 0}">
-	<link rel="stylesheet" href="/static/plugins/DataTables/datatables.min.css">
-	<link rel="stylesheet" href="/static/plugins/DataTables/Responsive-2.2.2/css/responsive.dataTables.css">
+    <link rel="stylesheet" href="/static/plugins/DataTables/datatables.min.css">
+    <link rel="stylesheet" href="/static/plugins/DataTables/Responsive-2.2.2/css/responsive.dataTables.css">
 
-	<div class="child-records">
-		<h3>List of Items in This Work (${childCount})</h3>
-		<table id="child-files" class="responsive" data-pid="${briefObject.id}">
-			<thead>
-			<tr>
-				<th><span class="sr-only">Thumbnail for file</span></th>
-				<th>Title</th>
-				<th>File Type</th>
-				<th>File Size</th>
-				<th><span class="sr-only">View file</span></th>
-				<th><span class="sr-only">Download file</span></th>
-				<c:if test="${permsHelper.hasEditAccess(accessGroupSet, briefObject)}">
-					<th><span class="sr-only">Edit MODS</span></th>
-				</c:if>
-			</tr>
-			</thead>
-			<tbody>
-			</tbody>
-		</table>
-	</div>
+    <div class="child-records">
+        <h3>List of Items in This Work (${childCount})</h3>
+        <table id="child-files" class="responsive" data-pid="${briefObject.id}">
+            <thead>
+            <tr>
+                <th><span class="sr-only">Thumbnail for file</span></th>
+                <th>Title</th>
+                <th>File Type</th>
+                <th>File Size</th>
+                <th><span class="sr-only">View file</span></th>
+                <th><span class="sr-only">Download file</span></th>
+                <c:if test="${permsHelper.hasEditAccess(accessGroupSet, briefObject)}">
+                    <th><span class="sr-only">Edit MODS</span></th>
+                </c:if>
+            </tr>
+            </thead>
+            <tbody>
+            </tbody>
+        </table>
+    </div>
 </c:if>
 <c:if test="${permsHelper.hasDescriptionAccess(accessGroupSet, briefObject)}">
-	<h2 class="full-metadata">Detailed Metadata</h2>
-	<div id="mods_data_display" data-pid="${briefObject.id}"></div>
+    <h2 class="full-metadata">Detailed Metadata</h2>
+    <div id="mods_data_display" data-pid="${briefObject.id}"></div>
 </c:if>
 <c:import url="fullRecord/neighborList.jsp" />

--- a/access/src/main/webapp/WEB-INF/jsp/fullRecord/collectionRecord.jsp
+++ b/access/src/main/webapp/WEB-INF/jsp/fullRecord/collectionRecord.jsp
@@ -56,20 +56,17 @@
             <c:if test="${not empty briefObject.dateAdded}">
                 <p><strong>${searchSettings.searchFieldLabels['DATE_ADDED']}:</strong> <fmt:formatDate pattern="yyyy-MM-dd" value="${briefObject.dateAdded}" /></p>
             </c:if>
+            <c:if test="${not empty briefObject.collectionId}">
+                <p><strong>Collection Number: </strong><c:out value="${briefObject.collectionId}"></c:out></p>
+            </c:if>
             <p><strong>Finding Aid: </strong>
                 <c:choose>
-                    <c:when test="${not empty briefObject.findingAidLink}">
-                        <c:forEach var="findingAid" items="${briefObject.findingAidLink}" varStatus="findingAidStatus">
-                            <a href="<c:out value="${findingAid}"/>"><c:out value="${findingAid}"/></a><c:if test="${!findingAidStatus.last }">, </c:if>
-                        </c:forEach>
+                    <c:when test="${not empty findingAidUrl}">
+                        <a href="<c:out value="${findingAidUrl}"/>"><c:out value="${findingAidUrl}"/></a>
                     </c:when>
                     <c:otherwise>Doesn’t have a finding aid</c:otherwise>
                 </c:choose>
             </p>
-            <c:if test="${not empty briefObject.collectionId}">
-                <p><strong>Collection Number: </strong><c:out value="${briefObject.collectionId}"></c:out></p>
-            </c:if>
-
             <c:if test="${not empty briefObject.abstractText}">
                 <c:set var="truncatedAbstract" value="${cdr:truncateText(briefObject.abstractText, 350)}"/>
                 <c:choose>

--- a/access/src/main/webapp/WEB-INF/jsp/fullRecord/fileRecord.jsp
+++ b/access/src/main/webapp/WEB-INF/jsp/fullRecord/fileRecord.jsp
@@ -75,18 +75,16 @@
                             <a href="<c:out value='${parentUrl}' />"><c:out value="${briefObject.parentCollectionName}"/></a>
                         </li>
                     </c:if>
-                    <c:if test="${not empty parentBriefObject.collectionId}">
+                    <c:if test="${not empty collectionId}">
                         <li>
                             <span class="has-text-weight-bold">Collection Number: </span>
-                            <c:out value="${parentBriefObject.collectionId}"></c:out>
+                            <c:out value="${collectionId}"></c:out>
                         </li>
                     </c:if>
                     <li><span class="has-text-weight-bold">Finding Aid: </span>
                         <c:choose>
-                            <c:when test="${not empty briefObject.findingAidLink}">
-                                <c:forEach var="findingAid" items="${briefObject.findingAidLink}" varStatus="findingAidStatus">
-                                    <a href="<c:out value="${findingAid}"/>"><c:out value="${findingAid}"/></a><c:if test="${!findingAidStatus.last }">, </c:if>
-                                </c:forEach>
+                            <c:when test="${not empty findingAidUrl}">
+                                <a href="<c:out value="${findingAidUrl}"/>"><c:out value="${findingAidUrl}"/></a>
                             </c:when>
                             <c:otherwise>Doesn’t have a finding aid</c:otherwise>
                         </c:choose>

--- a/access/src/main/webapp/WEB-INF/jsp/fullRecord/folderRecord.jsp
+++ b/access/src/main/webapp/WEB-INF/jsp/fullRecord/folderRecord.jsp
@@ -60,10 +60,8 @@
             </c:if>
             <p><strong>Finding Aid: </strong>
                 <c:choose>
-                    <c:when test="${not empty collectionId}">
-                        <c:forEach var="findingAid" items="${briefObject.findingAidLink}" varStatus="findingAidStatus">
-                            <a href="<c:out value="${findingAid}"/>"><c:out value="${findingAid}"/></a><c:if test="${!findingAidStatus.last }">, </c:if>
-                        </c:forEach>
+                    <c:when test="${not empty findingAidUrl}">
+                        <a href="<c:out value="${findingAidUrl}"/>"><c:out value="${findingAidUrl}"/></a>
                     </c:when>
                     <c:otherwise>Doesn’t have a finding aid</c:otherwise>
                 </c:choose>

--- a/access/src/main/webapp/WEB-INF/jsp/fullRecord/folderRecord.jsp
+++ b/access/src/main/webapp/WEB-INF/jsp/fullRecord/folderRecord.jsp
@@ -55,12 +55,12 @@
                 <p><strong>${searchSettings.searchFieldLabels['DATE_ADDED']}:</strong> <fmt:formatDate pattern="yyyy-MM-dd" value="${briefObject.dateAdded}" /></p>
             </c:if>
             <p><strong>Collection:</strong> <a href="<c:out value="record/${briefObject.parentCollection}"/>"><c:out value="${briefObject.parentCollectionName}"/></a></p>
-            <c:if test="${not empty parentBriefObject.collectionId}">
-                <p><strong>Collection Number: </strong><c:out value="${parentBriefObject.collectionId}"></c:out></p>
+            <c:if test="${not empty collectionId}">
+                <p><strong>Collection Number: </strong><c:out value="${collectionId}"></c:out></p>
             </c:if>
             <p><strong>Finding Aid: </strong>
                 <c:choose>
-                    <c:when test="${not empty briefObject.findingAidLink}">
+                    <c:when test="${not empty collectionId}">
                         <c:forEach var="findingAid" items="${briefObject.findingAidLink}" varStatus="findingAidStatus">
                             <a href="<c:out value="${findingAid}"/>"><c:out value="${findingAid}"/></a><c:if test="${!findingAidStatus.last }">, </c:if>
                         </c:forEach>

--- a/access/src/main/webapp/WEB-INF/service-context.xml
+++ b/access/src/main/webapp/WEB-INF/service-context.xml
@@ -88,6 +88,7 @@
         <property name="findingAidBaseUrl" value="${findingaids.base.url}" />
         <property name="maxCacheSize" value="${findingaids.maxCacheSize:1024}" />
         <property name="expireCacheSeconds" value="${findingaids.expireCacheSeconds:300}" />
+        <property name="checkTimeoutSeconds" value="${findingaids.checkTimeoutSeconds:5}" />
     </bean>
 
     <!-- Import controllers -->

--- a/access/src/main/webapp/WEB-INF/service-context.xml
+++ b/access/src/main/webapp/WEB-INF/service-context.xml
@@ -81,6 +81,14 @@
         <property name="lorisPath" value="${loris.base.url}"/>
         <property name="httpClientConnectionManager" ref="httpClientConnectionManager" />
     </bean>
+    
+    <bean id="findingAidUrlService" class="edu.unc.lib.dl.ui.service.FindingAidUrlService"
+            init-method="init">
+        <property name="httpClientConnectionManager" ref="httpClientConnectionManager" />
+        <property name="findingAidBaseUrl" value="${findingaids.base.url}" />
+        <property name="maxCacheSize" value="${findingaids.maxCacheSize:1024}" />
+        <property name="expireCacheSeconds" value="${findingaids.expireCacheSeconds:300}" />
+    </bean>
 
     <!-- Import controllers -->
     <bean

--- a/access/src/main/webapp/WEB-INF/solr-search-context.xml
+++ b/access/src/main/webapp/WEB-INF/solr-search-context.xml
@@ -112,6 +112,12 @@
         <property name="facetFieldUtil" ref="facetFieldUtil" />
     </bean>
     
+    <bean id="getCollectionIdService" class="edu.unc.lib.dl.search.solr.service.GetCollectionIdService"
+        init-method="initializeSolrServer">
+        <property name="searchSettings" ref="searchSettings" />
+        <property name="solrSettings" ref="solrSettings" />
+    </bean>
+    
     <bean id="queryLayer" class="edu.unc.lib.dl.ui.service.SolrQueryLayerService"
         init-method="initializeSolrServer">
         <property name="solrSettings" ref="solrSettings" />

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/ContentPathFactory.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fedora/ContentPathFactory.java
@@ -55,8 +55,6 @@ public class ContentPathFactory {
     private static final Logger log = getLogger(ContentPathFactory.class);
 
     private static int MAX_NESTING = 256;
-    public static final int COLLECTION_DEPTH = 2;
-    public static final int UNIT_DEPTH = 1;
 
     private LoadingCache<PID, PID> childToParentCache;
     private long cacheTimeToLive;

--- a/metadata/src/main/java/edu/unc/lib/dl/util/ContentPathConstants.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/util/ContentPathConstants.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.util;
+
+/**
+ * Constants related to Content paths
+ *
+ * @author bbpennel
+ */
+public class ContentPathConstants {
+    private ContentPathConstants() {
+    }
+
+    // Content path depth where collection objects are located
+    public static final int COLLECTION_DEPTH = 2;
+
+    // Content path depth where unit objects are located
+    public static final int UNIT_DEPTH = 1;
+}

--- a/services-camel/src/test/resources/config/access/conf/schema.xml
+++ b/services-camel/src/test/resources/config/access/conf/schema.xml
@@ -228,8 +228,7 @@
     <field name="otherTitle" type="string" indexed="false" stored="true" multiValued="true"/>
     <!-- Abstract for this item, for display purposes only -->
     <field name="abstract" type="string" indexed="false" stored="true"/>
-    <!-- Finding aid for this item, for display purposes only -->
-    <field name="findingAidLink" type="string" indexed="false" stored="true" multiValued="true"/>
+    <!-- Collection number -->
     <field name="collectionId" type="string" indexed="true" stored="true"/>
     <!-- Other keywords, for use in copy indexes -->
     <field name="keyword" type="string" indexed="false" stored="true" multiValued="true"/>

--- a/services/src/test/resources/config/access/conf/schema.xml
+++ b/services/src/test/resources/config/access/conf/schema.xml
@@ -228,8 +228,7 @@
     <field name="otherTitle" type="string" indexed="false" stored="true" multiValued="true"/>
     <!-- Abstract for this item, for display purposes only -->
     <field name="abstract" type="string" indexed="false" stored="true"/>
-    <!-- Finding aid for this item, for display purposes only -->
-    <field name="findingAidLink" type="string" indexed="false" stored="true" multiValued="true"/>
+    <!-- Collection number -->
     <field name="collectionId" type="string" indexed="true" stored="true"/>
     <!-- Other keywords, for use in copy indexes -->
     <field name="keyword" type="string" indexed="false" stored="true" multiValued="true"/>

--- a/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetCollectionSupplementalInformationFilter.java
+++ b/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetCollectionSupplementalInformationFilter.java
@@ -31,6 +31,7 @@ import edu.unc.lib.dl.data.ingest.solr.exception.IndexingException;
 import edu.unc.lib.dl.data.ingest.solr.indexing.DocumentIndexingPackage;
 import edu.unc.lib.dl.fedora.ContentPathFactory;
 import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.util.ContentPathConstants;
 
 /**
  *
@@ -52,8 +53,8 @@ public class SetCollectionSupplementalInformationFilter implements IndexDocument
         String parentCollection = dip.getDocument().getParentCollection();
         if (parentCollection == null) {
             List<PID> pids = pathFactory.getAncestorPids(dip.getPid());
-            if (pids.size() > ContentPathFactory.COLLECTION_DEPTH) {
-                parentCollection = pids.get(ContentPathFactory.COLLECTION_DEPTH).getId();
+            if (pids.size() > ContentPathConstants.COLLECTION_DEPTH) {
+                parentCollection = pids.get(ContentPathConstants.COLLECTION_DEPTH).getId();
             } else {
                 return;
             }

--- a/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetDescriptiveMetadataFilter.java
+++ b/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetDescriptiveMetadataFilter.java
@@ -78,7 +78,6 @@ public class SetDescriptiveMetadataFilter implements IndexDocumentFilter {
             this.extractNamesAndAffiliations(mods, idb, true);
             this.extractAbstract(mods, idb);
             this.extractCollectionId(mods, idb);
-            this.extractFindingAidLink(mods, idb);
             this.extractLanguages(mods, idb);
             this.extractSubjects(mods, idb);
             this.extractDateCreated(mods, idb);
@@ -280,34 +279,6 @@ public class SetDescriptiveMetadataFilter implements IndexDocumentFilter {
         }
 
         idb.setCollectionId(collectionId);
-    }
-
-    private void extractFindingAidLink(Element mods, IndexDocumentBean idb) {
-        List<Element> findingAidLinkEls = mods.getChildren("relatedItem", JDOMNamespaceUtil.MODS_V3_NS);
-        List<String> findingAids = new ArrayList<>();
-
-        if (!findingAidLinkEls.isEmpty()) {
-            for (Element findingAidObj: findingAidLinkEls) {
-                for (Element aid: findingAidObj.getChildren()) {
-                    if (aid.getName().equals("location")) {
-                        List<Element> urls = aid.getChildren();
-                        for (Element urlType : urls) {
-                            String displayLabel = urlType.getAttributeValue("displayLabel");
-
-                            if (displayLabel != null && displayLabel.toLowerCase().equals("link to finding aid")) {
-                                findingAids.add(urlType.getValue());
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        if (findingAids.size() > 0) {
-            idb.setFindingAidLink(findingAids);
-        } else {
-            idb.setFindingAidLink(null);
-        }
     }
 
     private void extractSubjects(Element mods, IndexDocumentBean idb) {

--- a/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetPathFilter.java
+++ b/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetPathFilter.java
@@ -30,6 +30,7 @@ import edu.unc.lib.dl.fcrepo4.FileObject;
 import edu.unc.lib.dl.fedora.ContentPathFactory;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.search.solr.model.IndexDocumentBean;
+import edu.unc.lib.dl.util.ContentPathConstants;
 
 /**
  * Indexing filter which extracts and stores hierarchical path information for
@@ -76,12 +77,12 @@ public class SetPathFilter implements IndexDocumentFilter {
         }
         idb.setAncestorIds(ancestorIds);
 
-        if (pids.size() > ContentPathFactory.COLLECTION_DEPTH) {
-            idb.setParentCollection(pids.get(ContentPathFactory.COLLECTION_DEPTH).getId());
+        if (pids.size() > ContentPathConstants.COLLECTION_DEPTH) {
+            idb.setParentCollection(pids.get(ContentPathConstants.COLLECTION_DEPTH).getId());
         }
 
-        if (pids.size() > ContentPathFactory.UNIT_DEPTH) {
-            idb.setParentUnit(pids.get(ContentPathFactory.UNIT_DEPTH).getId());
+        if (pids.size() > ContentPathConstants.UNIT_DEPTH) {
+            idb.setParentUnit(pids.get(ContentPathConstants.UNIT_DEPTH).getId());
         }
 
         ContentObject contentObject = dip.getContentObject();

--- a/solr-ingest/src/test/java/edu/unc/lib/dl/data/ingest/solr/filter/SetDescriptiveMetadataFilterTest.java
+++ b/solr-ingest/src/test/java/edu/unc/lib/dl/data/ingest/solr/filter/SetDescriptiveMetadataFilterTest.java
@@ -34,7 +34,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import edu.unc.lib.dl.rdf.Ebucore;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.jdom2.Document;
@@ -51,6 +50,7 @@ import edu.unc.lib.dl.data.ingest.solr.indexing.DocumentIndexingPackageDataLoade
 import edu.unc.lib.dl.fcrepo4.ContentObject;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.rdf.DcElements;
+import edu.unc.lib.dl.rdf.Ebucore;
 import edu.unc.lib.dl.search.solr.model.IndexDocumentBean;
 import edu.unc.lib.dl.util.VocabularyHelperManager;
 
@@ -135,8 +135,6 @@ public class SetDescriptiveMetadataFilterTest {
         assertEquals("Abstract text", idb.getAbstractText());
 
         assertEquals("40148", idb.getCollectionId());
-
-        assertTrue(idb.getFindingAidLink().contains("https://finding-aids.lib.unc.edu/1234"));
 
         assertTrue(idb.getSubject().contains("Test resource"));
 

--- a/solr-ingest/src/test/resources/config/access/conf/schema.xml
+++ b/solr-ingest/src/test/resources/config/access/conf/schema.xml
@@ -228,8 +228,7 @@
     <field name="otherTitle" type="string" indexed="false" stored="true" multiValued="true"/>
     <!-- Abstract for this item, for display purposes only -->
     <field name="abstract" type="string" indexed="false" stored="true"/>
-    <!-- Finding aid for this item, for display purposes only -->
-    <field name="findingAidLink" type="string" indexed="false" stored="true" multiValued="true"/>
+    <!-- Collection number -->
     <field name="collectionId" type="string" indexed="true" stored="true"/>
     <!-- Other keywords, for use in copy indexes -->
     <field name="keyword" type="string" indexed="false" stored="true" multiValued="true"/>

--- a/solr-search/src/main/java/edu/unc/lib/dl/search/solr/service/GetCollectionIdService.java
+++ b/solr-search/src/main/java/edu/unc/lib/dl/search/solr/service/GetCollectionIdService.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.search.solr.service;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.slf4j.Logger;
+
+import edu.unc.lib.dl.search.solr.model.BriefObjectMetadata;
+import edu.unc.lib.dl.search.solr.util.SearchFieldKeys;
+import edu.unc.lib.dl.search.solr.util.SolrSettings;
+import edu.unc.lib.dl.util.ContentPathConstants;
+
+/**
+ * Service for retrieving the collection ID for objects
+ *
+ * @author bbpennel
+ */
+public class GetCollectionIdService extends AbstractQueryService {
+    private static final Logger log = getLogger(GetCollectionIdService.class);
+
+    private final static List<String> RESULT_FIELDS = Collections.singletonList(
+            SearchFieldKeys.COLLECTION_ID.name());
+
+    /**
+     *
+     * @param mdObj Metadata record of object to retriev
+     * @return
+     */
+    public String getCollectionId(BriefObjectMetadata mdObj) {
+        if (mdObj.getCollectionId() != null) {
+            return mdObj.getCollectionId();
+        }
+
+        List<String> ancestors = mdObj.getAncestorPath();
+        int index = ancestors.size();
+
+        String idFieldName = solrSettings.getFieldName(SearchFieldKeys.ID.name());
+        String collectionIdName = solrSettings.getFieldName(SearchFieldKeys.COLLECTION_ID.name());
+
+        String currentVal = mdObj.getCollectionId();
+        while (index >= ContentPathConstants.COLLECTION_DEPTH) {
+            if (currentVal != null) {
+                return currentVal;
+            }
+
+
+            String nextId = StringUtils.substringBefore(ancestors.get(index), ",");
+
+            QueryResponse queryResponse = null;
+            StringBuilder query = new StringBuilder();
+            query.append(solrSettings.getFieldName(SearchFieldKeys.ID.name())).append(':')
+                    .append(SolrSettings.sanitize(nextId));
+
+            SolrQuery solrQuery = new SolrQuery(query.toString());
+            addResultFields(RESULT_FIELDS, solrQuery);
+            solrQuery.setRows(1);
+
+            log.debug("getObjectById query: " + solrQuery.toString());
+            try {
+                queryResponse = executeQuery(solrQuery);
+
+                currentVal = (String) queryResponse.getResults().get(0).getFieldValue(collectionIdName);
+            } catch (SolrServerException e) {
+                log.error("Error retrieving Solr object request", e);
+                return null;
+            }
+
+            --index;
+        }
+        return null;
+//        do {
+//            if (currentVal != null) {
+//                return currentVal;
+//            }
+//            if (index <= ContentPathConstants.COLLECTION_DEPTH) {
+//                return null;
+//            }
+//
+//            --index;
+//
+//        } while (true);
+    }
+}

--- a/solr-search/src/main/java/edu/unc/lib/dl/search/solr/service/GetCollectionIdService.java
+++ b/solr-search/src/main/java/edu/unc/lib/dl/search/solr/service/GetCollectionIdService.java
@@ -56,8 +56,8 @@ public class GetCollectionIdService extends AbstractQueryService {
         try {
             return findFirstCollectionId(mdObj);
         } finally {
-            log.warn("Finished retrieving collection id for {} with {} ancestors in {}ns",
-                    mdObj.getId(), mdObj.getAncestorPath().size(), (System.nanoTime() - start));
+            log.debug("Finished retrieving collection id for {} with {} ancestors in {}ns",
+                    mdObj.getId(), mdObj.getAncestorPath().size(), (System.nanoTime() - start) / 1e6);
         }
     }
 

--- a/solr-search/src/test/java/edu/unc/lib/dl/search/solr/service/GetCollectionIdServiceIT.java
+++ b/solr-search/src/test/java/edu/unc/lib/dl/search/solr/service/GetCollectionIdServiceIT.java
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.search.solr.service;
+
+import static edu.unc.lib.dl.test.TestHelpers.setField;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.search.solr.model.BriefObjectMetadata;
+import edu.unc.lib.dl.search.solr.model.SimpleIdRequest;
+import edu.unc.lib.dl.search.solr.test.BaseEmbeddedSolrTest;
+import edu.unc.lib.dl.search.solr.test.TestCorpus;
+import edu.unc.lib.dl.search.solr.util.AccessRestrictionUtil;
+
+/**
+ * @author bbpennel
+ */
+public class GetCollectionIdServiceIT extends BaseEmbeddedSolrTest {
+    private TestCorpus testCorpus;
+    private GetCollectionIdService collIdService;
+    private SolrSearchService solrSearchService;
+    @Mock
+    private AccessRestrictionUtil restrictionUtil;
+
+    public GetCollectionIdServiceIT() {
+        testCorpus = new TestCorpus();
+    }
+
+    @Before
+    public void init() throws Exception {
+        initMocks(this);
+
+        index(testCorpus.populate());
+
+        solrSearchService = new SolrSearchService();
+        solrSearchService.setSolrSettings(solrSettings);
+        solrSearchService.setAccessRestrictionUtil(restrictionUtil);
+        setField(solrSearchService, "solrClient", server);
+
+        collIdService = new GetCollectionIdService();
+        collIdService.setSolrSettings(solrSettings);
+        setField(collIdService, "solrClient", server);
+    }
+
+    @Test
+    public void collectionIdFromAncestorTest() throws Exception {
+        BriefObjectMetadata mdObj = getObject(testCorpus.work1Pid);
+
+        String collId = collIdService.getCollectionId(mdObj);
+        assertEquals(TestCorpus.TEST_COLL_ID, collId);
+    }
+
+    @Test
+    public void collectionIdFromSelfTest() throws Exception {
+        BriefObjectMetadata mdObj = getObject(testCorpus.coll1Pid);
+
+        String collId = collIdService.getCollectionId(mdObj);
+        assertEquals(TestCorpus.TEST_COLL_ID, collId);
+    }
+
+    @Test
+    public void noCollectionIdTest() throws Exception {
+        BriefObjectMetadata mdObj = getObject(testCorpus.work3Pid);
+
+        String collId = collIdService.getCollectionId(mdObj);
+        assertNull(collId);
+    }
+
+    @Test
+    public void noCollectionIdUnitTest() throws Exception {
+        BriefObjectMetadata mdObj = getObject(testCorpus.unitPid);
+
+        String collId = collIdService.getCollectionId(mdObj);
+        assertNull(collId);
+    }
+
+    private BriefObjectMetadata getObject(PID pid) {
+        return solrSearchService.getObjectById(
+                new SimpleIdRequest(pid.getId(), null));
+    }
+}

--- a/solr-search/src/test/java/edu/unc/lib/dl/search/solr/test/TestCorpus.java
+++ b/solr-search/src/test/java/edu/unc/lib/dl/search/solr/test/TestCorpus.java
@@ -73,6 +73,8 @@ public class TestCorpus {
     public PID privateWorkPid;
     public PID privateWorkFile1Pid;
 
+    public static final String TEST_COLL_ID = "10478";
+
     public TestCorpus() {
         // Initialize all pids
         Field[] fields = getClass().getFields();
@@ -104,6 +106,7 @@ public class TestCorpus {
         newDoc = makeContainerDocument(coll1Pid, "Collection 1", ResourceType.Collection,
                 rootPid, unitPid);
         addAclProperties(newDoc, PUBLIC_PRINC, "unitOwner", "manager");
+        newDoc.addField("collectionId", TEST_COLL_ID);
         docs.add(newDoc);
 
         newDoc = makeContainerDocument(folder1Pid, "Folder 1", ResourceType.Folder,

--- a/solr-search/src/test/resources/logback-test.xml
+++ b/solr-search/src/test/resources/logback-test.xml
@@ -6,7 +6,8 @@
       <pattern>%relative %-5level [%thread] %logger{20} - %msg%n</pattern>
     </encoder>
   </appender>
-  <root level="WARN">
+  <logger name="edu.unc.lib" level="WARN"/>
+  <root level="ERROR">
     <appender-ref ref="CONSOLE"/>
   </root>
 </configuration>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3015

* Collection numbers are looked up via solr from any ancestor (except the unit or root)
* Finding aid URLs are constructed from the collection number
    * Checks to make sure the finding aid is available before returning link
    * Outcome for whether the finding aid exists will be cached for some time, per collection number
    * "-z" suffixes are trimmed off of collection numbers for the finding aid URL, but retained for displaying the collection number
    * Finding aid url no longer indexed
* Moves constants for where object types appear in terms of hierarchy depth to their own class
