### PR TITLE
WIP: BXC-3033/3045 - Flapping Deposit tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,21 +35,21 @@ jobs:
     - name: Build with Maven
       run: mvn -B -U clean install -DskipTests
     - name: Verify DCR modules
-      run: mvn verify -pl access,access-common,admin,deposit,fcrepo-clients,metadata,persistence,security,services,services-camel,solr-ingest,solr-search,sword-server,migration-util
-
-    - name: Set up nodejs
-      uses: actions/setup-node@v2
-      with:
-        node-version: '12'
-    - name: Cache npm modules
-      uses: actions/cache@v2
-      with:
-        path: ~/.npm
-        key: v1-npm-deps-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: v1-npm-deps-
-    - run: npm install
-    - run: npm install -g @vue/cli@4.5.7
-    - run: npm --prefix static/js/vue-cdr-access install
-    - run: npm --prefix static/js/admin/vue-permissions-editor install
-    - run: npm --prefix static/js/vue-cdr-access run test:unit
-    - run: npm --prefix static/js/admin/vue-permissions-editor run test:unit
+      run: mvn -Dtest=FixityCheckJobTest.java test -pl deposit
+    #
+    # - name: Set up nodejs
+    #   uses: actions/setup-node@v2
+    #   with:
+    #     node-version: '12'
+    # - name: Cache npm modules
+    #   uses: actions/cache@v2
+    #   with:
+    #     path: ~/.npm
+    #     key: v1-npm-deps-${{ hashFiles('**/package-lock.json') }}
+    #     restore-keys: v1-npm-deps-
+    # - run: npm install
+    # - run: npm install -g @vue/cli@4.5.7
+    # - run: npm --prefix static/js/vue-cdr-access install
+    # - run: npm --prefix static/js/admin/vue-permissions-editor install
+    # - run: npm --prefix static/js/vue-cdr-access run test:unit
+    # - run: npm --prefix static/js/admin/vue-permissions-editor run test:unit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,21 +35,21 @@ jobs:
     - name: Build with Maven
       run: mvn -B -U clean install -DskipTests
     - name: Verify DCR modules
-      run: mvn -Dtest=FixityCheckJobTest.java test -pl deposit
-    #
-    # - name: Set up nodejs
-    #   uses: actions/setup-node@v2
-    #   with:
-    #     node-version: '12'
-    # - name: Cache npm modules
-    #   uses: actions/cache@v2
-    #   with:
-    #     path: ~/.npm
-    #     key: v1-npm-deps-${{ hashFiles('**/package-lock.json') }}
-    #     restore-keys: v1-npm-deps-
-    # - run: npm install
-    # - run: npm install -g @vue/cli@4.5.7
-    # - run: npm --prefix static/js/vue-cdr-access install
-    # - run: npm --prefix static/js/admin/vue-permissions-editor install
-    # - run: npm --prefix static/js/vue-cdr-access run test:unit
-    # - run: npm --prefix static/js/admin/vue-permissions-editor run test:unit
+      run: mvn verify -pl access,access-common,admin,deposit,fcrepo-clients,metadata,persistence,security,services,services-camel,solr-ingest,solr-search,sword-server,migration-util
+
+    - name: Set up nodejs
+      uses: actions/setup-node@v2
+      with:
+        node-version: '12'
+    - name: Cache npm modules
+      uses: actions/cache@v2
+      with:
+        path: ~/.npm
+        key: v1-npm-deps-${{ hashFiles('**/package-lock.json') }}
+        restore-keys: v1-npm-deps-
+    - run: npm install
+    - run: npm install -g @vue/cli@4.5.7
+    - run: npm --prefix static/js/vue-cdr-access install
+    - run: npm --prefix static/js/admin/vue-permissions-editor install
+    - run: npm --prefix static/js/vue-cdr-access run test:unit
+    - run: npm --prefix static/js/admin/vue-permissions-editor run test:unit

--- a/deposit/src/main/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJob.java
@@ -118,6 +118,8 @@ public class TransferBinariesToStorageJob extends AbstractConcurrentDepositJob {
             }
 
             waitForCompletion();
+        } finally {
+            awaitRegistrarShutdown();
         }
     }
 

--- a/deposit/src/main/java/edu/unc/lib/deposit/work/AbstractConcurrentDepositJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/work/AbstractConcurrentDepositJob.java
@@ -49,7 +49,7 @@ public abstract class AbstractConcurrentDepositJob extends AbstractDepositJob {
     protected Queue<Future<?>> futuresQueue = new LinkedBlockingQueue<>();
     protected BlockingQueue<Object> resultsQueue = new LinkedBlockingQueue<>();
 
-    private long MAX_REGISTRAR_SHUTDOWN_MS = 1000 * 5;
+    private long MAX_REGISTRAR_SHUTDOWN_MS = 1000 * 10;
     private int flushRate = 5000;
     // Should be higher than the number of workers
     private int maxQueuedJobs = 10;

--- a/deposit/src/main/java/edu/unc/lib/deposit/work/AbstractConcurrentDepositJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/work/AbstractConcurrentDepositJob.java
@@ -15,6 +15,8 @@
  */
 package edu.unc.lib.deposit.work;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 import java.util.Iterator;
 import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
@@ -25,6 +27,8 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.slf4j.Logger;
+
 import edu.unc.lib.dl.exceptions.RepositoryException;
 
 /**
@@ -34,14 +38,18 @@ import edu.unc.lib.dl.exceptions.RepositoryException;
  */
 public abstract class AbstractConcurrentDepositJob extends AbstractDepositJob {
 
+    private static final Logger log = getLogger(AbstractConcurrentDepositJob.class);
+
     protected AtomicBoolean isInterrupted = new AtomicBoolean(false);
     protected AtomicBoolean doneWork = new AtomicBoolean(false);
     protected Object flushingLock = new Object();
+    private Thread flushThread;
 
     protected ExecutorService executorService;
     protected Queue<Future<?>> futuresQueue = new LinkedBlockingQueue<>();
     protected BlockingQueue<Object> resultsQueue = new LinkedBlockingQueue<>();
 
+    private long MAX_REGISTRAR_SHUTDOWN_MS = 1000 * 5;
     private int flushRate = 5000;
     // Should be higher than the number of workers
     private int maxQueuedJobs = 10;
@@ -85,6 +93,16 @@ public abstract class AbstractConcurrentDepositJob extends AbstractDepositJob {
             } else {
                 throw new RuntimeException(e.getCause());
             }
+        }
+    }
+
+    @Override
+    protected void interruptJobIfStopped() throws JobInterruptedException {
+        try {
+            super.interruptJobIfStopped();
+        } catch (JobInterruptedException e) {
+            isInterrupted.set(true);
+            throw e;
         }
     }
 
@@ -133,11 +151,12 @@ public abstract class AbstractConcurrentDepositJob extends AbstractDepositJob {
      * @throws InterruptedException
      */
     protected void startResultRegistrar() {
-        Thread flushThread = new Thread(() -> {
+        flushThread = new Thread(() -> {
             try {
-                while (!isInterrupted.get()) {
+                while (true) {
                     registerResults();
-                    if (doneWork.get() && resultsQueue.isEmpty()) {
+                    if ((doneWork.get() || isInterrupted.get()) && resultsQueue.isEmpty()) {
+                        log.debug("Shutting down registrar for {}", jobUUID);
                         return;
                     }
                     TimeUnit.MILLISECONDS.sleep(flushRate);
@@ -159,6 +178,15 @@ public abstract class AbstractConcurrentDepositJob extends AbstractDepositJob {
             }
         });
         flushThread.start();
+    }
+
+    protected void awaitRegistrarShutdown() {
+        try {
+            flushThread.join(MAX_REGISTRAR_SHUTDOWN_MS);
+        } catch (InterruptedException e) {
+            isInterrupted.set(true);
+            throw new JobInterruptedException("Interrupted while waiting for registrar", e);
+        }
     }
 
     private void registerResults() {

--- a/deposit/src/main/java/edu/unc/lib/deposit/work/JobPausedException.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/work/JobPausedException.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.deposit.work;
+
+/**
+ * Thrown if a deposit job is paused
+ *
+ * @author bbpennel
+ */
+public class JobPausedException extends JobInterruptedException {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * @param message
+     */
+    public JobPausedException(String message) {
+        super(message);
+    }
+
+}

--- a/deposit/src/test/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/transfer/TransferBinariesToStorageJobTest.java
@@ -455,9 +455,6 @@ public class TransferBinariesToStorageJobTest extends AbstractNormalizationJobTe
             // expected
         }
 
-        // Wait to allow unflushed registrations to go through
-        Thread.sleep(FLUSH_RATE * 2);
-
         // Restore the contents
         FileUtils.writeStringToFile(flappingPath.toFile(), FILE_CONTENT2, "UTF-8");
 

--- a/deposit/src/test/java/edu/unc/lib/deposit/validate/FixityCheckJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/validate/FixityCheckJobTest.java
@@ -74,6 +74,8 @@ import edu.unc.lib.dl.util.RedisWorkerConstants.DepositState;
 public class FixityCheckJobTest extends AbstractDepositJobTest {
     private static final Logger log = getLogger(FixityCheckJobTest.class);
 
+    private final static int FLUSH_RATE = 100;
+
     private static final String CONTENT1 = "Something to digest";
     private static final String CONTENT1_MD5 = "7afbf05666feeebe7fbbf1c9071584e6";
     private static final String CONTENT1_SHA1 = "23d51c61a578a8cb00c5eec6b29c12b7da15c8de";
@@ -111,7 +113,7 @@ public class FixityCheckJobTest extends AbstractDepositJobTest {
         setField(job, "depositsDirectory", depositsDirectory);
         setField(job, "jobStatusFactory", jobStatusFactory);
         job.setExecutorService(executorService);
-        job.setFlushRate(100);
+        job.setFlushRate(FLUSH_RATE);
         job.setMaxQueuedJobs(2);
         job.init();
     }
@@ -326,6 +328,8 @@ public class FixityCheckJobTest extends AbstractDepositJobTest {
             // expected
         }
 
+        Thread.sleep(FLUSH_RATE * 2);
+
         // Write the file back into place
         FileUtils.write(flappingPath.toFile(), CONTENT2, UTF_8);
 
@@ -371,6 +375,8 @@ public class FixityCheckJobTest extends AbstractDepositJobTest {
         } catch (JobInterruptedException e) {
             // expected
         }
+
+        Thread.sleep(FLUSH_RATE * 2);
 
         // Resume the job
         when(depositStatusFactory.getState(depositUUID))

--- a/deposit/src/test/java/edu/unc/lib/deposit/validate/VirusScanJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/validate/VirusScanJobTest.java
@@ -88,21 +88,7 @@ public class VirusScanJobTest extends AbstractDepositJobTest {
     @Before
     public void init() throws Exception {
 
-        job = new VirusScanJob();
-        job.setJobUUID(jobUUID);
-        job.setDepositUUID(depositUUID);
-        job.setDepositDirectory(depositDir);
-        setField(job, "pidMinter", pidMinter);
-        job.setClamScan(clamScan);
-        job.setPremisLoggerFactory(premisLoggerFactory);
-        setField(job, "depositModelManager", depositModelManager);
-        setField(job, "depositsDirectory", depositsDirectory);
-        setField(job, "depositStatusFactory", depositStatusFactory);
-        setField(job, "jobStatusFactory", jobStatusFactory);
-        depositJobId = depositUUID + ":" + this.getClass().getName();
-        setField(job, "depositJobId", depositJobId);
-        job.setExecutorService(executorService);
-        job.init();
+        initializeJob();
 
         when(depositStatusFactory.getState(anyString()))
                 .thenReturn(DepositState.running);
@@ -125,6 +111,24 @@ public class VirusScanJobTest extends AbstractDepositJobTest {
         FileUtils.copyDirectory(examplesFile, depositDir);
 
         when(premisEventBuilder.addOutcome(anyBoolean())).thenReturn(premisEventBuilder);
+    }
+
+    private void initializeJob() {
+        job = new VirusScanJob();
+        job.setJobUUID(jobUUID);
+        job.setDepositUUID(depositUUID);
+        job.setDepositDirectory(depositDir);
+        setField(job, "pidMinter", pidMinter);
+        job.setClamScan(clamScan);
+        job.setPremisLoggerFactory(premisLoggerFactory);
+        setField(job, "depositModelManager", depositModelManager);
+        setField(job, "depositsDirectory", depositsDirectory);
+        setField(job, "depositStatusFactory", depositStatusFactory);
+        setField(job, "jobStatusFactory", jobStatusFactory);
+        depositJobId = depositUUID + ":" + this.getClass().getName();
+        setField(job, "depositJobId", depositJobId);
+        job.setExecutorService(executorService);
+        job.init();
     }
 
     @AfterClass
@@ -317,6 +321,7 @@ public class VirusScanJobTest extends AbstractDepositJobTest {
         when(depositStatusFactory.getState(depositUUID))
                 .thenReturn(DepositState.running);
 
+        initializeJob();
         job.run();
 
         verify(jobStatusFactory, times(2)).setTotalCompletion(eq(jobUUID), eq(2));


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3033
https://jira.lib.unc.edu/browse/BXC-3045

* Adds helper method to await the registrar thread finishing, which is called by concurrent deposit jobs before exiting the run method whether or not the job was interrupted. This means that the registrar flushing thread will be done before tests continue on to do a second run.
* Deposit interruptions due to pausing quit more gently, so that the changes to the deposit model are more likely to get saved, to prevent duplicate work
    * Registrar thread will attempt to flush one last time in the case of interruption
* Adds some missing resets and job reinitializations which could cause counts to sometimes be off
* Addresses bonus TransferBinariesToStorageJobTest.depositLotsOfFiles flapping test
