### PR TITLE
BXC-2874/2934 - Flapping ContentObjectTransformerTest

### DIFF
--- a/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformer.java
+++ b/migration-util/src/main/java/edu/unc/lib/dcr/migration/content/ContentObjectTransformer.java
@@ -319,11 +319,6 @@ public class ContentObjectTransformer extends RecursiveAction {
 
         // transform PREMIS and copy to deposit directory
         transformPremis(originalPid, newPid);
-
-        // set staff access if a unit or collection
-        if (Cdr.AdminUnit.equals(resourceType) || Cdr.Collection.equals(resourceType)) {
-            ACLTransformationHelpers.transformStaffRoles(bxc3Resc, containerBag);
-        }
     }
 
     private void populateFileObject(Resource bxc3Resc, Model depositModel) {

--- a/migration-util/src/test/java/edu/unc/lib/dcr/migration/content/ACLTransformationHelpersTest.java
+++ b/migration-util/src/test/java/edu/unc/lib/dcr/migration/content/ACLTransformationHelpersTest.java
@@ -227,38 +227,6 @@ public class ACLTransformationHelpersTest {
     }
 
     @Test
-    public void transformPatronAccess_CollectionInUnit_UnitWithEmbargoAndRoles() throws Exception {
-        PID depositPid = PIDs.get(DEPOSIT_RECORD_BASE, UUID.randomUUID().toString());
-
-        // First try to transform the unit
-        Resource unitBxc3Resc = buildBoxc3Resource(parentPid, ContentModel.COLLECTION);
-
-        addRoleForPublic(unitBxc3Resc, Bxc3UserRole.accessCopiesPatron);
-        addRoleForAuthenticated(unitBxc3Resc, Bxc3UserRole.patron);
-        addEmbargo(unitBxc3Resc, EMBARGO_END_DATE);
-
-        Resource unitBxc5Resc = buildBoxc5Resource(parentPid, Cdr.AdminUnit);
-
-        ACLTransformationHelpers.transformPatronAccess(unitBxc3Resc, unitBxc5Resc, depositPid);
-
-        // Unit must not have any patron ACLs set
-        assertNoRolesAssignedforEveryone(unitBxc5Resc);
-        assertNoRolesAssignedforAuthenticated(unitBxc5Resc);
-        assertFalse(unitBxc5Resc.hasProperty(CdrAcl.embargoUntil));
-
-        // now transform the child collection, which adds no additional acls
-        Resource bxc3Resc = buildBoxc3Resource(pid, ContentModel.COLLECTION);
-        Resource bxc5Resc = buildBoxc5Resource(pid, Cdr.Collection);
-
-        ACLTransformationHelpers.transformPatronAccess(bxc3Resc, bxc5Resc, parentPid);
-
-        // Collection should have inherited all of the ACLs from the unit
-        assertEveryoneHasRole(CdrAcl.canViewAccessCopies, bxc5Resc);
-        assertAuthenticatedHasRole(CdrAcl.canViewOriginals, bxc5Resc);
-        assertHasEmbargo(EMBARGO_END_DATE, bxc5Resc);
-    }
-
-    @Test
     public void transformPatronAccess_CollectionInUnit_BothWithEmbargoAndRoles() throws Exception {
         PID depositPid = PIDs.get(DEPOSIT_RECORD_BASE, UUID.randomUUID().toString());
 
@@ -288,9 +256,9 @@ public class ACLTransformationHelpersTest {
 
         ACLTransformationHelpers.transformPatronAccess(bxc3Resc, bxc5Resc, parentPid);
 
-        // Collection ACLs, when present, should win
+        // Only collection ACLs should be present
         assertEveryoneHasRole(CdrAcl.canViewAccessCopies, bxc5Resc);
-        assertAuthenticatedHasRole(CdrAcl.canViewAccessCopies, bxc5Resc);
+        assertNoRolesAssignedforAuthenticated(bxc5Resc);
         assertHasEmbargo("2045-01-01T00:00:00.000Z", bxc5Resc);
     }
 
@@ -400,128 +368,5 @@ public class ACLTransformationHelpersTest {
         assertTrue("Resource " + bxc5Resc.getURI() + " did not have expected embargo with end date " + embargoEndDate,
                 bxc5Resc.hasLiteral(CdrAcl.embargoUntil,
                         ResourceFactory.createTypedLiteral(embargoEndDate, XSDDatatype.XSDdateTime).getValue()));
-    }
-
-    @Test
-    public void transformStaffRoles_AllRoles() throws Exception {
-        Resource bxc3Resc = buildBoxc3Resource(pid, ContentModel.CONTAINER);
-        addStaffRole(bxc3Resc, Bxc3UserRole.observer, "obs_grp");
-        addStaffRole(bxc3Resc, Bxc3UserRole.ingester, "ingest_grp");
-        addStaffRole(bxc3Resc, Bxc3UserRole.metadataEditor, "describe_grp");
-        addStaffRole(bxc3Resc, Bxc3UserRole.processor, "proc_grp");
-        addStaffRole(bxc3Resc, Bxc3UserRole.curator, "curator_grp");
-
-        Resource bxc5Resc = buildBoxc5Resource(pid, Cdr.Folder);
-
-        ACLTransformationHelpers.transformStaffRoles(bxc3Resc, bxc5Resc);
-
-        assertHasStaffRole(CdrAcl.canAccess, "obs_grp", bxc5Resc);
-        assertHasStaffRole(CdrAcl.canIngest, "ingest_grp", bxc5Resc);
-        assertHasStaffRole(CdrAcl.canDescribe, "describe_grp", bxc5Resc);
-        assertHasStaffRole(CdrAcl.canProcess, "proc_grp", bxc5Resc);
-        assertHasStaffRole(CdrAcl.canManage, "curator_grp", bxc5Resc);
-    }
-
-    @Test
-    public void transformStaffRoles_NoRoles() throws Exception {
-        Resource bxc3Resc = buildBoxc3Resource(pid, ContentModel.CONTAINER);
-
-        Resource bxc5Resc = buildBoxc5Resource(pid, Cdr.Folder);
-
-        ACLTransformationHelpers.transformStaffRoles(bxc3Resc, bxc5Resc);
-
-        assertDoesNotHaveStaffRole(CdrAcl.canAccess, bxc5Resc);
-        assertDoesNotHaveStaffRole(CdrAcl.canIngest, bxc5Resc);
-        assertDoesNotHaveStaffRole(CdrAcl.canDescribe, bxc5Resc);
-        assertDoesNotHaveStaffRole(CdrAcl.canProcess, bxc5Resc);
-        assertDoesNotHaveStaffRole(CdrAcl.canManage, bxc5Resc);
-    }
-
-    @Test
-    public void transformStaffRoles_MultipleOfRole() throws Exception {
-        Resource bxc3Resc = buildBoxc3Resource(pid, ContentModel.CONTAINER);
-        addStaffRole(bxc3Resc, Bxc3UserRole.processor, "proc_grp1");
-        addStaffRole(bxc3Resc, Bxc3UserRole.processor, "proc_grp2");
-
-        Resource bxc5Resc = buildBoxc5Resource(pid, Cdr.Folder);
-
-        ACLTransformationHelpers.transformStaffRoles(bxc3Resc, bxc5Resc);
-
-        assertHasStaffRole(CdrAcl.canProcess, "proc_grp1", bxc5Resc);
-        assertHasStaffRole(CdrAcl.canProcess, "proc_grp2", bxc5Resc);
-    }
-
-    @Test
-    public void transformStaffRoles_EmptyPrincipal_Ignore() throws Exception {
-        Resource bxc3Resc = buildBoxc3Resource(pid, ContentModel.CONTAINER);
-        addStaffRole(bxc3Resc, Bxc3UserRole.processor, "");
-        addStaffRole(bxc3Resc, Bxc3UserRole.processor, "curator_grp");
-
-        Resource bxc5Resc = buildBoxc5Resource(pid, Cdr.Folder);
-
-        ACLTransformationHelpers.transformStaffRoles(bxc3Resc, bxc5Resc);
-
-        assertDoesNotHaveStaffAssignment(CdrAcl.canProcess, "", bxc5Resc);
-        assertHasStaffRole(CdrAcl.canProcess, "curator_grp", bxc5Resc);
-    }
-
-    @Test
-    public void transformStaffRoles_PatronPrincipal_Ignore() throws Exception {
-        Resource bxc3Resc = buildBoxc3Resource(pid, ContentModel.CONTAINER);
-        addStaffRole(bxc3Resc, Bxc3UserRole.processor, ACLTransformationHelpers.BXC3_PUBLIC_GROUP);
-        addStaffRole(bxc3Resc, Bxc3UserRole.processor, "processor_grp");
-        addStaffRole(bxc3Resc, Bxc3UserRole.curator, ACLTransformationHelpers.BXC3_AUTHENTICATED_GROUP);
-
-        Resource bxc5Resc = buildBoxc5Resource(pid, Cdr.Folder);
-
-        ACLTransformationHelpers.transformStaffRoles(bxc3Resc, bxc5Resc);
-
-        assertHasStaffRole(CdrAcl.canProcess, "processor_grp", bxc5Resc);
-        assertDoesNotHaveStaffAssignment(CdrAcl.canProcess, ACLTransformationHelpers.BXC3_PUBLIC_GROUP, bxc5Resc);
-        assertDoesNotHaveStaffAssignment(CdrAcl.canProcess, AccessPrincipalConstants.PUBLIC_PRINC, bxc5Resc);
-        assertDoesNotHaveStaffRole(CdrAcl.canAccess, bxc5Resc);
-        assertDoesNotHaveStaffRole(CdrAcl.canIngest, bxc5Resc);
-        assertDoesNotHaveStaffRole(CdrAcl.canDescribe, bxc5Resc);
-        assertDoesNotHaveStaffRole(CdrAcl.canManage, bxc5Resc);
-    }
-
-    @Test
-    public void transformStaffRoles_MultipleRolesSamePrincipal() throws Exception {
-        Resource bxc3Resc = buildBoxc3Resource(pid, ContentModel.CONTAINER);
-        addStaffRole(bxc3Resc, Bxc3UserRole.observer, "curator_grp");
-        addStaffRole(bxc3Resc, Bxc3UserRole.processor, "curator_grp");
-        addStaffRole(bxc3Resc, Bxc3UserRole.curator, "curator_grp");
-        addStaffRole(bxc3Resc, Bxc3UserRole.ingester, "curator_grp");
-
-        Resource bxc5Resc = buildBoxc5Resource(pid, Cdr.Folder);
-
-        ACLTransformationHelpers.transformStaffRoles(bxc3Resc, bxc5Resc);
-
-        // Only the fittest permission survives
-        assertHasStaffRole(CdrAcl.canManage, "curator_grp", bxc5Resc);
-        assertDoesNotHaveStaffRole(CdrAcl.canAccess, bxc5Resc);
-        assertDoesNotHaveStaffRole(CdrAcl.canIngest, bxc5Resc);
-        assertDoesNotHaveStaffRole(CdrAcl.canDescribe, bxc5Resc);
-        assertDoesNotHaveStaffRole(CdrAcl.canProcess, bxc5Resc);
-    }
-
-    private void addStaffRole(Resource bxc3Resc, Bxc3UserRole role, Object obj) {
-        bxc3Resc.addLiteral(role.getProperty(), obj);
-    }
-
-    private void assertHasStaffRole(Property role, String principal, Resource bxc5Resc) {
-        assertTrue("Expected " + bxc5Resc.getURI() + " to have role " + role.getLocalName()
-            + " with principal " + principal,
-            bxc5Resc.hasLiteral(role, principal));
-    }
-
-    private void assertDoesNotHaveStaffRole(Property role, Resource bxc5Resc) {
-        assertFalse("Expected " + bxc5Resc + " to not have role " + role.getLocalName(),
-                bxc5Resc.hasProperty(role));
-    }
-
-    private void assertDoesNotHaveStaffAssignment(Property role, String principal, Resource bxc5Resc) {
-        assertFalse("Expected " + bxc5Resc + " to not have assignment " + role.getLocalName() + " " + principal,
-                bxc5Resc.hasLiteral(role, principal));
     }
 }


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2874
https://jira.lib.unc.edu/browse/BXC-2934

* Removes Content migration functionality which copied ACLs from units to their children collections, since the migration is complete and this never ended up being used anyways. This was causing tests to flap because the unit and collection could be processed concurrently, so the unit info was not available for the collection transformation.
* Removes migration code which transformed staff roles, since this was not used either