### PR TITLE
BXC-3065 - Collection filter indexing and dynamic field fixes

### DIFF
--- a/services-camel/src/test/resources/datastreams/modsWithRla.xml
+++ b/services-camel/src/test/resources/datastreams/modsWithRla.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mods xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <titleInfo>
+    <title>RLA Item</title>
+  </titleInfo>
+    <subject displayLabel="RLA Site Code" xlink:href="https://example.com/rla/stuff">
+    <geographic>BoXC 5</geographic>
+  </subject>
+  <subject displayLabel="RLA Site Name">
+    <geographic>Boxc Ferry</geographic>
+  </subject>
+  <identifier displayLabel="Digital Image Number" type="local">DBoxc</identifier>
+  <identifier displayLabel="RLA Filename" type="local">DBoxc.jpg</identifier>
+  <identifier displayLabel="RLA Catalog Number" type="local">12345</identifier>
+</mods>

--- a/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetCollectionSupplementalInformationFilter.java
+++ b/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetCollectionSupplementalInformationFilter.java
@@ -50,17 +50,19 @@ public class SetCollectionSupplementalInformationFilter implements IndexDocument
     }
     @Override
     public void filter(DocumentIndexingPackage dip) throws IndexingException {
-        String parentCollection = dip.getDocument().getParentCollection();
-        if (parentCollection == null) {
+        String collection = dip.getDocument().getParentCollection();
+        if (collection == null) {
             List<PID> pids = pathFactory.getAncestorPids(dip.getPid());
             if (pids.size() > ContentPathConstants.COLLECTION_DEPTH) {
-                parentCollection = pids.get(ContentPathConstants.COLLECTION_DEPTH).getId();
+                collection = pids.get(ContentPathConstants.COLLECTION_DEPTH).getId();
+            } else if (pids.size() == ContentPathConstants.COLLECTION_DEPTH) {
+                collection = dip.getPid().getId();
             } else {
                 return;
             }
         }
 
-        IndexDocumentFilter collectionFilter = collectionFilters.get(parentCollection);
+        IndexDocumentFilter collectionFilter = collectionFilters.get(collection);
         if (collectionFilter == null) {
             return;
         }

--- a/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/collection/RLASupplementalFilter.java
+++ b/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/collection/RLASupplementalFilter.java
@@ -42,15 +42,15 @@ public class RLASupplementalFilter extends CollectionSupplementalInformationFilt
 
     private static final String CATALOG_ID = "rla_catalog_number";
     private static final String CATALOG_LABEL = "RLA Catalog Number";
-    private static final String CATALOG_FIELD = "rla_catalog_number_d";
+    public static final String CATALOG_FIELD = "rla_catalog_number_d";
 
     private static final String SITE_CODE_ID = "rla_site_code";
     private static final String SITE_CODE_LABEL = "RLA Site Code";
-    private static final String SITE_CODE_FIELD = "rla_site_code_d";
+    public static final String SITE_CODE_FIELD = "rla_site_code_d";
 
     private static final String CONTEXT_1_ID = "rla_context_1";
     private static final String CONTEXT_1_LABEL = "Context";
-    private static final String CONTEXT_1_FIELD = "rla_context_1_d";
+    public static final String CONTEXT_1_FIELD = "rla_context_1_d";
 
     @Override
     public void filter(DocumentIndexingPackage dip) throws IndexingException {

--- a/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/indexing/SolrUpdateDriver.java
+++ b/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/indexing/SolrUpdateDriver.java
@@ -112,6 +112,18 @@ public class SolrUpdateDriver {
                 // Allowing values and explicitly nulled fields through
                 updateField(sid, fieldName, value);
             }
+            // Index dynamic fields if present
+            Map<String, Object> dynamics = idb.getDynamicFields();
+            if (dynamics != null) {
+                for (Entry<String, Object> field : dynamics.entrySet()) {
+                    String fieldName = field.getKey();
+                    Object value = field.getValue();
+
+                    // Allowing values and explicitly nulled fields through
+                    updateField(sid, fieldName, value);
+                }
+
+            }
 
             // Set timestamp to now, auto population not working with atomic update #SOLR-8966
             updateField(sid, UPDATE_TIMESTAMP, new Date());

--- a/solr-search/src/main/java/edu/unc/lib/dl/search/solr/model/BriefObjectMetadata.java
+++ b/solr-search/src/main/java/edu/unc/lib/dl/search/solr/model/BriefObjectMetadata.java
@@ -107,6 +107,8 @@ public interface BriefObjectMetadata {
 
     public List<String> getIdentifier();
 
+    public String getIdentifierSort();
+
     public String getLabel();
 
     public String getTitle();

--- a/solr-search/src/main/java/edu/unc/lib/dl/search/solr/model/GroupedMetadataBean.java
+++ b/solr-search/src/main/java/edu/unc/lib/dl/search/solr/model/GroupedMetadataBean.java
@@ -355,4 +355,9 @@ public class GroupedMetadataBean implements BriefObjectMetadata {
     public String getAncestorIds() {
         return representative.getAncestorIds();
     }
+
+    @Override
+    public String getIdentifierSort() {
+        return representative.getIdentifierSort();
+    }
 }


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3065
* Index dynamic fields during update operations, is provided.
* Collection indexing filter applies to collection objects now too, not just their children
* Exposed identifierSort field via BriefObjectMetadata interface.
* Add tests of collection/rla indexing workflow