### PR TITLE
Remove Loris from Admin UI

### DIFF
--- a/access-common/src/main/java/edu/unc/lib/dl/ui/controller/structure/StructureResultsController.java
+++ b/access-common/src/main/java/edu/unc/lib/dl/ui/controller/structure/StructureResultsController.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package edu.unc.lib.dl.ui.controller;
+package edu.unc.lib.dl.ui.controller.structure;
 
 import static edu.unc.lib.dl.acl.util.GroupsThreadStore.getAgentPrincipals;
 import static edu.unc.lib.dl.fcrepo4.RepositoryPaths.getContentRootPid;
@@ -33,6 +33,7 @@ import edu.unc.lib.dl.acl.util.GroupsThreadStore;
 import edu.unc.lib.dl.search.solr.model.BriefObjectMetadataBean;
 import edu.unc.lib.dl.search.solr.model.HierarchicalBrowseResultResponse;
 import edu.unc.lib.dl.search.solr.model.SimpleIdRequest;
+import edu.unc.lib.dl.ui.controller.AbstractStructureResultsController;
 import edu.unc.lib.dl.ui.exception.ResourceNotFoundException;
 import edu.unc.lib.dl.ui.util.SerializationUtil;
 

--- a/admin/src/main/webapp/WEB-INF/service-context.xml
+++ b/admin/src/main/webapp/WEB-INF/service-context.xml
@@ -79,11 +79,6 @@
     <bean id="httpClientConnectionManager" class="org.apache.http.impl.conn.PoolingHttpClientConnectionManager"
         destroy-method="shutdown">
     </bean>
-    
-    <bean id="lorisContentService" class="edu.unc.lib.dl.ui.service.LorisContentService">
-        <property name="lorisPath" value="${loris.base.url}"/>
-        <property name="httpClientConnectionManager" ref="httpClientConnectionManager" />
-    </bean>
 
     <bean class="edu.unc.lib.dl.ui.view.CDRViewResolver" p:suffix=".jsp">
         <property name="exposedContextBeanNames">

--- a/admin/src/main/webapp/WEB-INF/uiapp-servlet.xml
+++ b/admin/src/main/webapp/WEB-INF/uiapp-servlet.xml
@@ -20,7 +20,7 @@
 
     <!-- Import controllers -->
     <context:component-scan base-package="edu.unc.lib.dl.admin.controller" />
-    <context:component-scan base-package="edu.unc.lib.dl.ui.controller" />
+    <context:component-scan base-package="edu.unc.lib.dl.ui.controller.structure" />
     
     <mvc:annotation-driven/>
 </beans>


### PR DESCRIPTION
Move structure browse into its own package, only include it in the admin ui since the other controllers are not used. Remove loris beans from admin