### PR TITLE
BXC-2459 - IP Address Patron Groups

### DIFF
--- a/access/src/main/webapp/WEB-INF/service-context.xml
+++ b/access/src/main/webapp/WEB-INF/service-context.xml
@@ -127,6 +127,15 @@
         </property>
     </bean>
     
+    <bean name="patronPrincipalProvider" class="edu.unc.lib.dl.acl.util.PatronPrincipalProvider"
+            init-method="init">
+        <property name="patronGroupConfigPath" value="${acl.patronPrincipalConfig.path}" />
+    </bean>
+    
+    <bean name="storeUserAccessControlFilter" class="edu.unc.lib.dl.acl.filter.StoreUserAccessControlFilter">
+        <property name="patronPrincipalProvider" ref="patronPrincipalProvider" />
+    </bean>
+    
     <bean name="storeAccessLevelFilter" class="edu.unc.lib.dl.ui.access.StoreAccessLevelFilter">
         <property name="queryLayer" ref="queryLayer" />
         <property name="requireViewAdmin" value="false" />

--- a/access/src/main/webapp/WEB-INF/web.xml
+++ b/access/src/main/webapp/WEB-INF/web.xml
@@ -105,11 +105,11 @@
     </filter-mapping>
     
     <filter>
-        <filter-name>StoreUserAccessControlFilter</filter-name>
-        <filter-class>edu.unc.lib.dl.acl.filter.StoreUserAccessControlFilter</filter-class>
+        <filter-name>storeUserAccessControlFilter</filter-name>
+        <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
     </filter>
     <filter-mapping>
-        <filter-name>StoreUserAccessControlFilter</filter-name>
+        <filter-name>storeUserAccessControlFilter</filter-name>
         <url-pattern>/*</url-pattern>
     </filter-mapping>
     

--- a/admin/src/main/webapp/WEB-INF/service-context.xml
+++ b/admin/src/main/webapp/WEB-INF/service-context.xml
@@ -96,6 +96,15 @@
         <property name="redirectHttp10Compatible" value="false" />
     </bean>
     
+    <bean name="patronPrincipalProvider" class="edu.unc.lib.dl.acl.util.PatronPrincipalProvider"
+            init-method="init">
+        <property name="patronGroupConfigPath" value="${acl.patronPrincipalConfig.path}" />
+    </bean>
+    
+    <bean name="storeUserAccessControlFilter" class="edu.unc.lib.dl.acl.filter.StoreUserAccessControlFilter">
+        <property name="patronPrincipalProvider" ref="patronPrincipalProvider" />
+    </bean>
+    
     <bean name="storeAccessLevelFilter" class="edu.unc.lib.dl.ui.access.StoreAccessLevelFilter">
         <property name="queryLayer" ref="queryLayer" />
         <property name="requireViewAdmin" value="true" />

--- a/admin/src/main/webapp/WEB-INF/web.xml
+++ b/admin/src/main/webapp/WEB-INF/web.xml
@@ -113,11 +113,11 @@
     </filter-mapping>
     
     <filter>
-        <filter-name>StoreUserAccessControlFilter</filter-name>
-        <filter-class>edu.unc.lib.dl.acl.filter.StoreUserAccessControlFilter</filter-class>
+        <filter-name>storeUserAccessControlFilter</filter-name>
+        <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
     </filter>
     <filter-mapping>
-        <filter-name>StoreUserAccessControlFilter</filter-name>
+        <filter-name>storeUserAccessControlFilter</filter-name>
         <url-pattern>/*</url-pattern>
     </filter-mapping>
     

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/acl/fcrepo4/GlobalPermissionEvaluator.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/acl/fcrepo4/GlobalPermissionEvaluator.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import edu.unc.lib.dl.acl.util.Permission;
+import edu.unc.lib.dl.acl.util.PrincipalClassifier;
 import edu.unc.lib.dl.acl.util.UserRole;
 
 /**
@@ -59,6 +60,10 @@ public class GlobalPermissionEvaluator {
                         .map(p -> new SimpleEntry<>(p, (String) e.getKey())))
                 // Transform into map of principal to permissions
                 .collect(Collectors.toMap(SimpleEntry::getKey, p -> {
+                    if (PrincipalClassifier.isPatronPrincipal(p.getKey())) {
+                        throw new IllegalArgumentException(
+                                "Cannot grant global role to patron principal " + p.getKey());
+                    }
                     String roleString = p.getValue().substring(GLOBAL_PROP_PREFIX.length());
                     UserRole role = UserRole.valueOf(roleString);
                     // Role must be valid and not a patron

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/acl/fcrepo4/InheritedAclFactory.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/acl/fcrepo4/InheritedAclFactory.java
@@ -76,7 +76,7 @@ public class InheritedAclFactory implements AclFactory {
         List<PID> path = getPidPath(target);
 
         Map<String, Set<String>> inheritedPrincRoles = new HashMap<>();
-        Set<String> specialPatronPrincs = null;
+        Set<String> customPatronPrincs = null;
 
         // Iterate through each step in the path except for the root content node
         int depth = 0;
@@ -98,12 +98,12 @@ public class InheritedAclFactory implements AclFactory {
                 }
 
                 if (depth == COLLECTION_PATH_DEPTH) {
-                    specialPatronPrincs = getSpecialPatronPrincs(objectPrincipalRoles);
+                    customPatronPrincs = getCustomPatronPrincs(objectPrincipalRoles);
                 }
 
                 // Apply any further patron restrictions to inherited patron principals
                 adjustPatronPrincipalRoles(pathPid, inheritedPrincRoles,
-                        inheritedPatronPrincipals, objectPrincipalRoles, specialPatronPrincs);
+                        inheritedPatronPrincipals, objectPrincipalRoles, customPatronPrincs);
             }
         }
 
@@ -118,7 +118,7 @@ public class InheritedAclFactory implements AclFactory {
         return inheritedPrincRoles;
     }
 
-    private Set<String> getSpecialPatronPrincs(Map<String, Set<String>> objectPrincipalRoles) {
+    private Set<String> getCustomPatronPrincs(Map<String, Set<String>> objectPrincipalRoles) {
         Set<String> princs = new HashSet<>(objectPrincipalRoles.keySet());
         princs.remove(AccessPrincipalConstants.PUBLIC_PRINC);
         princs.remove(AccessPrincipalConstants.AUTHENTICATED_PRINC);
@@ -179,7 +179,7 @@ public class InheritedAclFactory implements AclFactory {
             Map<String, Set<String>> inheritedPrincRoles,
             Set<String> inheritedPatronPrincipals,
             Map<String, Set<String>> objectPrincipalRoles,
-            Set<String> specialPatronPrincs) {
+            Set<String> customPatronPrincs) {
 
         // Discard any non-patron assignments at this depth
         Set<String> objPatronPrincipals = getPatronPrincipals(objectPrincipalRoles.keySet());
@@ -191,12 +191,12 @@ public class InheritedAclFactory implements AclFactory {
             return;
         }
 
-        // if both regular patron groups explicitly None, strip away inherited special groups unless directly added
-        if (specialPatronPrincs.size() > 0) {
+        // if both regular patron groups explicitly None, strip away inherited custom groups unless directly added
+        if (customPatronPrincs.size() > 0) {
             boolean publicNone = isAssignedNone(AccessPrincipalConstants.PUBLIC_PRINC, objectPrincipalRoles);
             boolean authNone = isAssignedNone(AccessPrincipalConstants.AUTHENTICATED_PRINC, objectPrincipalRoles);
             if (publicNone && authNone) {
-                specialPatronPrincs.stream()
+                customPatronPrincs.stream()
                         .filter(princ -> !objectPrincipalRoles.containsKey(princ))
                         .forEach(inheritedPrincRoles::remove);
             }

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/acl/fcrepo4/InheritedAclFactory.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/acl/fcrepo4/InheritedAclFactory.java
@@ -76,6 +76,7 @@ public class InheritedAclFactory implements AclFactory {
         List<PID> path = getPidPath(target);
 
         Map<String, Set<String>> inheritedPrincRoles = new HashMap<>();
+        Set<String> specialPatronPrincs = null;
 
         // Iterate through each step in the path except for the root content node
         int depth = 0;
@@ -96,9 +97,13 @@ public class InheritedAclFactory implements AclFactory {
                     return removeNoneRoles(inheritedPrincRoles);
                 }
 
+                if (depth == COLLECTION_PATH_DEPTH) {
+                    specialPatronPrincs = getSpecialPatronPrincs(objectPrincipalRoles);
+                }
+
                 // Apply any further patron restrictions to inherited patron principals
                 adjustPatronPrincipalRoles(pathPid, inheritedPrincRoles,
-                        inheritedPatronPrincipals, objectPrincipalRoles);
+                        inheritedPatronPrincipals, objectPrincipalRoles, specialPatronPrincs);
             }
         }
 
@@ -111,6 +116,13 @@ public class InheritedAclFactory implements AclFactory {
         }
 
         return inheritedPrincRoles;
+    }
+
+    private Set<String> getSpecialPatronPrincs(Map<String, Set<String>> objectPrincipalRoles) {
+        Set<String> princs = new HashSet<>(objectPrincipalRoles.keySet());
+        princs.remove(AccessPrincipalConstants.PUBLIC_PRINC);
+        princs.remove(AccessPrincipalConstants.AUTHENTICATED_PRINC);
+        return princs;
     }
 
     @Override
@@ -166,7 +178,8 @@ public class InheritedAclFactory implements AclFactory {
     private void adjustPatronPrincipalRoles(PID pid,
             Map<String, Set<String>> inheritedPrincRoles,
             Set<String> inheritedPatronPrincipals,
-            Map<String, Set<String>> objectPrincipalRoles) {
+            Map<String, Set<String>> objectPrincipalRoles,
+            Set<String> specialPatronPrincs) {
 
         // Discard any non-patron assignments at this depth
         Set<String> objPatronPrincipals = getPatronPrincipals(objectPrincipalRoles.keySet());
@@ -176,6 +189,17 @@ public class InheritedAclFactory implements AclFactory {
         // No new patron assignments for principal we are following, skip
         if (objPatronPrincipals.isEmpty()) {
             return;
+        }
+
+        // if both regular patron groups explicitly None, strip away inherited special groups unless directly added
+        if (specialPatronPrincs.size() > 0) {
+            boolean publicNone = isAssignedNone(AccessPrincipalConstants.PUBLIC_PRINC, objectPrincipalRoles);
+            boolean authNone = isAssignedNone(AccessPrincipalConstants.AUTHENTICATED_PRINC, objectPrincipalRoles);
+            if (publicNone && authNone) {
+                specialPatronPrincs.stream()
+                        .filter(princ -> !objectPrincipalRoles.containsKey(princ))
+                        .forEach(inheritedPrincRoles::remove);
+            }
         }
 
         // If any incoming patron roles are stricter than inherited roles, then override
@@ -203,6 +227,14 @@ public class InheritedAclFactory implements AclFactory {
                 inheritedPrincRoles.put(patronPrincipal, objRoles);
             }
         }
+    }
+
+    private boolean isAssignedNone(String principal, Map<String, Set<String>> principalRoles) {
+        Set<String> roles = principalRoles.get(principal);
+        if (roles == null) {
+            return false;
+        }
+        return roles.contains(UserRole.none.getPropertyString());
     }
 
     private Map<String, Set<String>> removeNoneRoles(Map<String, Set<String>> princRoles) {

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/acl/fcrepo4/InheritedPermissionEvaluator.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/acl/fcrepo4/InheritedPermissionEvaluator.java
@@ -134,7 +134,7 @@ public class InheritedPermissionEvaluator {
         // Determine which roles would grant the sought after permission
         Set<String> rolesWithPermission = getRolesWithPermission(permission);
         Set<String> activePatronPrincipals = null;
-        Set<String> specialPatronGroups = null;
+        Set<String> customPatronGroups = null;
 
         // Ignore embargoes if the agent is requesting metadata
         boolean ignoreEmbargoes = Permission.viewMetadata.equals(permission);
@@ -159,11 +159,11 @@ public class InheritedPermissionEvaluator {
                     return false;
                 }
 
-                specialPatronGroups = getSpecialPatronGroups(activePatronPrincipals);
+                customPatronGroups = getCustomPatronGroups(activePatronPrincipals);
             }
 
             // Remove any active patron principals that do not grant the permission
-            revokePatronPermissions(princRoles, activePatronPrincipals, rolesWithPermission, specialPatronGroups);
+            revokePatronPermissions(princRoles, activePatronPrincipals, rolesWithPermission, customPatronGroups);
 
             if (activePatronPrincipals.isEmpty()) {
                 return false;
@@ -172,7 +172,7 @@ public class InheritedPermissionEvaluator {
         return true;
     }
 
-    private Set<String> getSpecialPatronGroups(Set<String> patronPrincipals) {
+    private Set<String> getCustomPatronGroups(Set<String> patronPrincipals) {
         Set<String> princs = new HashSet<>(patronPrincipals);
         princs.remove(AccessPrincipalConstants.PUBLIC_PRINC);
         princs.remove(AccessPrincipalConstants.AUTHENTICATED_PRINC);
@@ -186,17 +186,17 @@ public class InheritedPermissionEvaluator {
      * @param princRoles
      * @param activePrincipals
      * @param rolesWithPermission
-     * @param specialPatronPrincs
+     * @param customPatronPrincs
      */
     private void revokePatronPermissions(Map<String, Set<String>> princRoles, Set<String> activePrincipals,
-            Set<String> rolesWithPermission, Set<String> specialPatronPrincs) {
+            Set<String> rolesWithPermission, Set<String> customPatronPrincs) {
 
-        // If both regular patron groups explicitly None, deactivate special groups unless directly added
-        if (specialPatronPrincs.size() > 0) {
+        // If both regular patron groups explicitly None, deactivate custom groups unless directly added
+        if (customPatronPrincs.size() > 0) {
             boolean publicNone = isAssignedNone(AccessPrincipalConstants.PUBLIC_PRINC, princRoles);
             boolean authNone = isAssignedNone(AccessPrincipalConstants.AUTHENTICATED_PRINC, princRoles);
             if (publicNone && authNone) {
-                specialPatronPrincs.stream()
+                customPatronPrincs.stream()
                         .filter(princ -> !princRoles.containsKey(princ))
                         .forEach(activePrincipals::remove);
             }

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/acl/fcrepo4/InheritedPermissionEvaluator.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/acl/fcrepo4/InheritedPermissionEvaluator.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import edu.unc.lib.dl.acl.util.AccessPrincipalConstants;
 import edu.unc.lib.dl.acl.util.Permission;
 import edu.unc.lib.dl.acl.util.UserRole;
 import edu.unc.lib.dl.exceptions.OrphanedObjectException;
@@ -133,6 +134,7 @@ public class InheritedPermissionEvaluator {
         // Determine which roles would grant the sought after permission
         Set<String> rolesWithPermission = getRolesWithPermission(permission);
         Set<String> activePatronPrincipals = null;
+        Set<String> specialPatronGroups = null;
 
         // Ignore embargoes if the agent is requesting metadata
         boolean ignoreEmbargoes = Permission.viewMetadata.equals(permission);
@@ -156,16 +158,25 @@ public class InheritedPermissionEvaluator {
                 if (activePatronPrincipals.isEmpty()) {
                     return false;
                 }
+
+                specialPatronGroups = getSpecialPatronGroups(activePatronPrincipals);
             }
 
             // Remove any active patron principals that do not grant the permission
-            revokePatronPermissions(princRoles, activePatronPrincipals, rolesWithPermission);
+            revokePatronPermissions(princRoles, activePatronPrincipals, rolesWithPermission, specialPatronGroups);
 
             if (activePatronPrincipals.isEmpty()) {
                 return false;
             }
         }
         return true;
+    }
+
+    private Set<String> getSpecialPatronGroups(Set<String> patronPrincipals) {
+        Set<String> princs = new HashSet<>(patronPrincipals);
+        princs.remove(AccessPrincipalConstants.PUBLIC_PRINC);
+        princs.remove(AccessPrincipalConstants.AUTHENTICATED_PRINC);
+        return princs;
     }
 
     /**
@@ -175,9 +186,22 @@ public class InheritedPermissionEvaluator {
      * @param princRoles
      * @param activePrincipals
      * @param rolesWithPermission
+     * @param specialPatronPrincs
      */
     private void revokePatronPermissions(Map<String, Set<String>> princRoles, Set<String> activePrincipals,
-            Set<String> rolesWithPermission) {
+            Set<String> rolesWithPermission, Set<String> specialPatronPrincs) {
+
+        // If both regular patron groups explicitly None, deactivate special groups unless directly added
+        if (specialPatronPrincs.size() > 0) {
+            boolean publicNone = isAssignedNone(AccessPrincipalConstants.PUBLIC_PRINC, princRoles);
+            boolean authNone = isAssignedNone(AccessPrincipalConstants.AUTHENTICATED_PRINC, princRoles);
+            if (publicNone && authNone) {
+                specialPatronPrincs.stream()
+                        .filter(princ -> !princRoles.containsKey(princ))
+                        .forEach(activePrincipals::remove);
+            }
+        }
+
         Iterator<String> activeIt = activePrincipals.iterator();
         while (activeIt.hasNext()) {
             String princ = activeIt.next();
@@ -192,6 +216,14 @@ public class InheritedPermissionEvaluator {
                 activeIt.remove();
             }
         }
+    }
+
+    private boolean isAssignedNone(String principal, Map<String, Set<String>> principalRoles) {
+        Set<String> roles = principalRoles.get(principal);
+        if (roles == null) {
+            return false;
+        }
+        return roles.contains(UserRole.none.getPropertyString());
     }
 
     /**

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/acl/fcrepo4/GlobalPermissionEvaluatorTest.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/acl/fcrepo4/GlobalPermissionEvaluatorTest.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 
+import edu.unc.lib.dl.acl.util.AccessPrincipalConstants;
 import edu.unc.lib.dl.acl.util.Permission;
 import edu.unc.lib.dl.acl.util.UserRole;
 
@@ -82,6 +83,13 @@ public class GlobalPermissionEvaluatorTest {
         evaluator = new GlobalPermissionEvaluator(configProperties);
 
         assertFalse(evaluator.hasGlobalPermission(principals, Permission.destroy));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void illegalPatronPrincipalTest() {
+        addGlobalAssignment(UserRole.canAccess, AccessPrincipalConstants.AUTHENTICATED_PRINC);
+
+        new GlobalPermissionEvaluator(configProperties);
     }
 
     @Test

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -50,6 +50,10 @@
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>edu.unc.lib.cdr</groupId>

--- a/security/src/main/java/edu/unc/lib/dl/acl/filter/StoreUserAccessControlFilter.java
+++ b/security/src/main/java/edu/unc/lib/dl/acl/filter/StoreUserAccessControlFilter.java
@@ -15,8 +15,6 @@
  */
 package edu.unc.lib.dl.acl.filter;
 
-import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.AUTHENTICATED_PRINC;
-import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.PUBLIC_PRINC;
 import static edu.unc.lib.dl.acl.util.RemoteUserUtil.getRemoteUser;
 import static edu.unc.lib.dl.httpclient.HttpClientUtil.FORWARDED_MAIL_HEADER;
 
@@ -35,6 +33,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import edu.unc.lib.dl.acl.util.AccessGroupSet;
 import edu.unc.lib.dl.acl.util.AgentPrincipals;
 import edu.unc.lib.dl.acl.util.GroupsThreadStore;
+import edu.unc.lib.dl.acl.util.PatronPrincipalProvider;
 import edu.unc.lib.dl.httpclient.HttpClientUtil;
 
 /**
@@ -50,6 +49,8 @@ public class StoreUserAccessControlFilter extends OncePerRequestFilter implement
     protected static String FORWARDING_ROLE = "group-forwarding";
 
     private boolean retainGroupsThreadStore;
+
+    private PatronPrincipalProvider patronPrincipalProvider;
 
     @Override
     public void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain) throws IOException,
@@ -129,10 +130,8 @@ public class StoreUserAccessControlFilter extends OncePerRequestFilter implement
             accessGroups = new AccessGroupSet(shibGroups);
         }
 
-        accessGroups.addAccessGroup(PUBLIC_PRINC);
-        if (userName != null && userName.length() > 0) {
-            accessGroups.addAccessGroup(AUTHENTICATED_PRINC);
-        }
+        // Add all patron principals to group set
+        accessGroups.addAll(patronPrincipalProvider.getPrincipals(request));
 
         return accessGroups;
     }
@@ -155,5 +154,9 @@ public class StoreUserAccessControlFilter extends OncePerRequestFilter implement
      */
     public void setRetainGroupsThreadStore(boolean retainGroupsThreadStore) {
         this.retainGroupsThreadStore = retainGroupsThreadStore;
+    }
+
+    public void setPatronPrincipalProvider(PatronPrincipalProvider patronPrincipalProvider) {
+        this.patronPrincipalProvider = patronPrincipalProvider;
     }
 }

--- a/security/src/main/java/edu/unc/lib/dl/acl/util/AccessGroupSet.java
+++ b/security/src/main/java/edu/unc/lib/dl/acl/util/AccessGroupSet.java
@@ -35,7 +35,7 @@ public class AccessGroupSet extends HashSet<String> {
         addAccessGroups(groups.split(";"));
     }
 
-    public AccessGroupSet(String[] groups) {
+    public AccessGroupSet(String... groups) {
         super();
         addAccessGroups(groups);
     }

--- a/security/src/main/java/edu/unc/lib/dl/acl/util/AccessPrincipalConstants.java
+++ b/security/src/main/java/edu/unc/lib/dl/acl/util/AccessPrincipalConstants.java
@@ -30,6 +30,7 @@ public class AccessPrincipalConstants {
     public final static String USER_NAMESPACE = "unc:onyen:";
     // Namespace prefix for special patron groups
     public final static String PATRON_NAMESPACE = "unc:patron:";
+    public final static String IP_PRINC_NAMESPACE = PATRON_NAMESPACE + "ipp:";
     public final static String ADMIN_ACCESS_PRINC = "admin_access";
 
     public final static Pattern PATRON_PRINC_PATTERN =

--- a/security/src/main/java/edu/unc/lib/dl/acl/util/AccessPrincipalConstants.java
+++ b/security/src/main/java/edu/unc/lib/dl/acl/util/AccessPrincipalConstants.java
@@ -15,17 +15,28 @@
  */
 package edu.unc.lib.dl.acl.util;
 
+import java.util.regex.Pattern;
+
 /**
  * Constants related to access principals
  *
  * @author bbpennel
  *
  */
-public abstract class AccessPrincipalConstants {
+public class AccessPrincipalConstants {
 
     public final static String PUBLIC_PRINC = "everyone";
     public final static String AUTHENTICATED_PRINC = "authenticated";
     public final static String USER_NAMESPACE = "unc:onyen:";
+    // Namespace prefix for special patron groups
+    public final static String PATRON_NAMESPACE = "unc:patron:";
     public final static String ADMIN_ACCESS_PRINC = "admin_access";
 
+    public final static Pattern PATRON_PRINC_PATTERN =
+            Pattern.compile("(" + PUBLIC_PRINC
+                    + "|" + AUTHENTICATED_PRINC
+                    + "|" + PATRON_NAMESPACE + ".+)");
+
+    private AccessPrincipalConstants() {
+    }
 }

--- a/security/src/main/java/edu/unc/lib/dl/acl/util/IPAddressPatronPrincipalConfig.java
+++ b/security/src/main/java/edu/unc/lib/dl/acl/util/IPAddressPatronPrincipalConfig.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.acl.util;
+
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.util.Assert;
+
+import com.google.common.net.InetAddresses;
+
+/**
+ * Configuration for an IP Address based patron group
+ *
+ * @author bbpennel
+ */
+public class IPAddressPatronPrincipalConfig {
+
+    private String name;
+    private String id;
+    private String ipInclude;
+    private List<IPRange> includeRanges;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getIpInclude() {
+        return ipInclude;
+    }
+
+    public void setIpInclude(String ipInclude) {
+        this.ipInclude = ipInclude;
+
+        includeRanges = Arrays.stream(ipInclude.split(","))
+                .map(IPRange::new)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * @param ipAddr IP address represented as a BigInteger. See {@link IPAddressPatronPrincipalConfig#ipToBigInteger(String)}
+     * @return returns true if the given IP address is within the range of this patron group
+     */
+    public boolean inRange(BigInteger ipAddr) {
+        return includeRanges.stream().anyMatch(range -> range.inRange(ipAddr));
+    }
+
+    /**
+     * Converts a string IP address, in IPv4 or IPv6 form, to a BigInteger
+     * @param addr IP address
+     * @return BigInteger representing the IP address
+     */
+    public static BigInteger ipToBigInteger(String addr) {
+        InetAddress a = InetAddresses.forString(addr);
+        return new BigInteger(1, a.getAddress());
+    }
+
+    /**
+     * An IP address range. Can support exact matches, or ranges.
+     * Open ended ranges are not supported. Ranges are inclusive.
+     * @author bbpennel
+     */
+    private static class IPRange {
+        private BigInteger start;
+        // End will be null for exact IP matchers
+        private BigInteger end;
+
+        public IPRange(String range) {
+            Assert.notNull(range, "Range field must not be null");
+            String[] parts = range.split("-", -1);
+            if (parts.length > 2) {
+                throw new IllegalArgumentException(
+                        "IP Address range may only contain two hyphen separated parts: " + range);
+            }
+            if (StringUtils.isBlank(parts[0])) {
+                throw new IllegalArgumentException(
+                        "Start of IP Address range must not be blank: " + range);
+            }
+            start = ipToBigInteger(parts[0]);
+            if (parts.length == 2) {
+                if (StringUtils.isBlank(parts[1])) {
+                    throw new IllegalArgumentException(
+                            "Must specify end to the range or leave off '-': " + range);
+                }
+                end = ipToBigInteger(parts[1]);
+            }
+        }
+
+        /**
+         * Address is in range if it is greater than or equal to the start of the range, and
+         * if an end
+         *
+         * @param addr
+         * @return
+         */
+        public boolean inRange(BigInteger addr) {
+            int startCompare = addr.compareTo(start);
+            if (startCompare == -1) {
+                return false;
+            }
+            if (end == null) {
+                return startCompare == 0;
+            }
+            return addr.compareTo(end) <= 0;
+        }
+    }
+}

--- a/security/src/main/java/edu/unc/lib/dl/acl/util/IPAddressPatronPrincipalConfig.java
+++ b/security/src/main/java/edu/unc/lib/dl/acl/util/IPAddressPatronPrincipalConfig.java
@@ -73,7 +73,8 @@ public class IPAddressPatronPrincipalConfig {
     }
 
     /**
-     * @param ipAddr IP address represented as a BigInteger. See {@link IPAddressPatronPrincipalConfig#ipToBigInteger(String)}
+     * @param ipAddr IP address represented as a BigInteger. See
+     * {@link IPAddressPatronPrincipalConfig#ipToBigInteger(String)}
      * @return returns true if the given IP address is within the range of this patron group
      */
     public boolean inRange(BigInteger ipAddr) {
@@ -123,10 +124,11 @@ public class IPAddressPatronPrincipalConfig {
 
         /**
          * Address is in range if it is greater than or equal to the start of the range, and
-         * if an end
+         * less than or equal to the end of the range. If no end range is specified,
+         * then the address must be equal to the start of the range.
          *
          * @param addr
-         * @return
+         * @return true if the address is within this ip range
          */
         public boolean inRange(BigInteger addr) {
             int startCompare = addr.compareTo(start);

--- a/security/src/main/java/edu/unc/lib/dl/acl/util/IPAddressPatronPrincipalConfig.java
+++ b/security/src/main/java/edu/unc/lib/dl/acl/util/IPAddressPatronPrincipalConfig.java
@@ -24,6 +24,8 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.util.Assert;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.net.InetAddresses;
 
 /**
@@ -42,6 +44,7 @@ public class IPAddressPatronPrincipalConfig {
         return name;
     }
 
+    @JsonProperty(required = true)
     public void setName(String name) {
         this.name = name;
     }
@@ -50,14 +53,17 @@ public class IPAddressPatronPrincipalConfig {
         return id;
     }
 
+    @JsonProperty(required = true)
     public void setId(String id) {
         this.id = id;
     }
 
+    @JsonIgnore
     public String getIpInclude() {
         return ipInclude;
     }
 
+    @JsonProperty(required = true)
     public void setIpInclude(String ipInclude) {
         this.ipInclude = ipInclude;
 

--- a/security/src/main/java/edu/unc/lib/dl/acl/util/IPAddressPatronPrincipalConfig.java
+++ b/security/src/main/java/edu/unc/lib/dl/acl/util/IPAddressPatronPrincipalConfig.java
@@ -119,6 +119,10 @@ public class IPAddressPatronPrincipalConfig {
                             "Must specify end to the range or leave off '-': " + range);
                 }
                 end = ipToBigInteger(parts[1]);
+                if (start.compareTo(end) == 1) {
+                    throw new IllegalArgumentException(
+                            "Start of range must come before end of range: " + range);
+                }
             }
         }
 

--- a/security/src/main/java/edu/unc/lib/dl/acl/util/IPAddressPatronPrincipalConfig.java
+++ b/security/src/main/java/edu/unc/lib/dl/acl/util/IPAddressPatronPrincipalConfig.java
@@ -36,7 +36,7 @@ import com.google.common.net.InetAddresses;
 public class IPAddressPatronPrincipalConfig {
 
     private String name;
-    private String id;
+    private String principal;
     private String ipInclude;
     private List<IPRange> includeRanges;
 
@@ -49,13 +49,13 @@ public class IPAddressPatronPrincipalConfig {
         this.name = name;
     }
 
-    public String getId() {
-        return id;
+    public String getPrincipal() {
+        return principal;
     }
 
     @JsonProperty(required = true)
-    public void setId(String id) {
-        this.id = id;
+    public void setPrincipal(String principal) {
+        this.principal = principal;
     }
 
     @JsonIgnore

--- a/security/src/main/java/edu/unc/lib/dl/acl/util/PatronPrincipalProvider.java
+++ b/security/src/main/java/edu/unc/lib/dl/acl/util/PatronPrincipalProvider.java
@@ -107,9 +107,9 @@ public class PatronPrincipalProvider {
                 throw new IllegalArgumentException("Field 'name' is required for patron groups");
             }
             if (StringUtils.isBlank(config.getPrincipal())) {
-                throw new IllegalArgumentException("Field 'id' is required for patron groups");
+                throw new IllegalArgumentException("Field 'principal' is required for patron groups");
             } else if (!config.getPrincipal().startsWith(IP_PRINC_NAMESPACE)) {
-                throw new IllegalArgumentException("Field 'id' for IP Principal configuration must begin with "
+                throw new IllegalArgumentException("Field 'principal' for IP Principal configuration must begin with "
                         + IP_PRINC_NAMESPACE);
             }
             if (StringUtils.isBlank(config.getIpInclude())) {

--- a/security/src/main/java/edu/unc/lib/dl/acl/util/PatronPrincipalProvider.java
+++ b/security/src/main/java/edu/unc/lib/dl/acl/util/PatronPrincipalProvider.java
@@ -74,7 +74,7 @@ public class PatronPrincipalProvider {
         BigInteger ipInteger = IPAddressPatronPrincipalConfig.ipToBigInteger(remoteAddr);
         patronPrincConfigs.stream()
                 .filter(config -> config.inRange(ipInteger))
-                .map(IPAddressPatronPrincipalConfig::getId)
+                .map(IPAddressPatronPrincipalConfig::getPrincipal)
                 .forEach(princs::add);
 
         log.error("Returning patron principals {}", princs);
@@ -107,9 +107,9 @@ public class PatronPrincipalProvider {
             if (StringUtils.isBlank(config.getName())) {
                 throw new IllegalArgumentException("Field 'name' is required for patron groups");
             }
-            if (StringUtils.isBlank(config.getId())) {
+            if (StringUtils.isBlank(config.getPrincipal())) {
                 throw new IllegalArgumentException("Field 'id' is required for patron groups");
-            } else if (!config.getId().startsWith(IP_PRINC_NAMESPACE)){
+            } else if (!config.getPrincipal().startsWith(IP_PRINC_NAMESPACE)){
                 throw new IllegalArgumentException("Field 'id' for IP Principal configuration must begin with "
                         + IP_PRINC_NAMESPACE);
             }

--- a/security/src/main/java/edu/unc/lib/dl/acl/util/PatronPrincipalProvider.java
+++ b/security/src/main/java/edu/unc/lib/dl/acl/util/PatronPrincipalProvider.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.acl.util;
+
+import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.AUTHENTICATED_PRINC;
+import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.IP_PRINC_NAMESPACE;
+import static edu.unc.lib.dl.acl.util.RemoteUserUtil.getRemoteUser;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Service which provides patron principals for a request
+ *
+ * @author bbpennel
+ */
+public class PatronPrincipalProvider {
+    public static final String FORWARDED_FOR_HEADER = "X-FORWARDED-FOR";
+
+    private String patronGroupConfigPath;
+    private List<IPAddressPatronPrincipalConfig> patronPrincConfigs;
+
+    /**
+     * Get patron principals for the user making the provided request
+     * @param request
+     * @return list of patron principals
+     */
+    public List<String> getPrincipals(HttpServletRequest request) {
+        List<String> princs = new ArrayList<>();
+        princs.add(AccessPrincipalConstants.PUBLIC_PRINC);
+        String username = getRemoteUser(request);
+        if (!StringUtils.isBlank(username)) {
+            princs.add(AUTHENTICATED_PRINC);
+        }
+
+        String remoteAddr = request.getHeader(FORWARDED_FOR_HEADER);
+        if (StringUtils.isBlank(remoteAddr)) {
+            remoteAddr = request.getRemoteAddr();
+        }
+
+        BigInteger ipInteger = IPAddressPatronPrincipalConfig.ipToBigInteger(remoteAddr);
+        patronPrincConfigs.stream()
+                .filter(config -> config.inRange(ipInteger))
+                .map(IPAddressPatronPrincipalConfig::getId)
+                .forEach(princs::add);
+
+        return princs;
+    }
+
+    /**
+     * List the configured custom patron principals
+     * @return
+     */
+    public List<IPAddressPatronPrincipalConfig> getConfiguredPatronPrincipals() {
+        return patronPrincConfigs;
+    }
+
+    public void setPatronGroupConfigPath(String patronGroupConfigPath) {
+        this.patronGroupConfigPath = patronGroupConfigPath;
+    }
+
+    /**
+     * Initialize the provider by parsing configuration
+     * @throws IOException
+     */
+    public void init() throws IOException {
+        InputStream configStream = new FileInputStream(new File(patronGroupConfigPath));
+        ObjectMapper mapper = new ObjectMapper();
+        patronPrincConfigs = mapper.readValue(configStream,
+                new TypeReference<List<IPAddressPatronPrincipalConfig>>() {});
+        patronPrincConfigs.stream().forEach(config -> {
+            if (StringUtils.isBlank(config.getName())) {
+                throw new IllegalArgumentException("Field 'name' is required for patron groups");
+            }
+            if (StringUtils.isBlank(config.getId())) {
+                throw new IllegalArgumentException("Field 'id' is required for patron groups");
+            } else if (!config.getId().startsWith(IP_PRINC_NAMESPACE)){
+                throw new IllegalArgumentException("Field 'id' for IP Principal configuration must begin with "
+                        + IP_PRINC_NAMESPACE);
+            }
+            if (StringUtils.isBlank(config.getIpInclude())) {
+                throw new IllegalArgumentException("Field 'ipInclude' is required for patron groups");
+            }
+        });
+    }
+}

--- a/security/src/main/java/edu/unc/lib/dl/acl/util/PatronPrincipalProvider.java
+++ b/security/src/main/java/edu/unc/lib/dl/acl/util/PatronPrincipalProvider.java
@@ -69,7 +69,6 @@ public class PatronPrincipalProvider {
                 return princs;
             }
         }
-        log.error("Getting patron principals for user {} from address {}", username, remoteAddr);
 
         BigInteger ipInteger = IPAddressPatronPrincipalConfig.ipToBigInteger(remoteAddr);
         patronPrincConfigs.stream()
@@ -77,7 +76,7 @@ public class PatronPrincipalProvider {
                 .map(IPAddressPatronPrincipalConfig::getPrincipal)
                 .forEach(princs::add);
 
-        log.error("Returning patron principals {}", princs);
+        log.debug("Returning patron principals {}", princs);
 
         return princs;
     }
@@ -109,7 +108,7 @@ public class PatronPrincipalProvider {
             }
             if (StringUtils.isBlank(config.getPrincipal())) {
                 throw new IllegalArgumentException("Field 'id' is required for patron groups");
-            } else if (!config.getPrincipal().startsWith(IP_PRINC_NAMESPACE)){
+            } else if (!config.getPrincipal().startsWith(IP_PRINC_NAMESPACE)) {
                 throw new IllegalArgumentException("Field 'id' for IP Principal configuration must begin with "
                         + IP_PRINC_NAMESPACE);
             }

--- a/security/src/main/java/edu/unc/lib/dl/acl/util/PrincipalClassifier.java
+++ b/security/src/main/java/edu/unc/lib/dl/acl/util/PrincipalClassifier.java
@@ -15,8 +15,9 @@
  */
 package edu.unc.lib.dl.acl.util;
 
+import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.PATRON_PRINC_PATTERN;
+
 import java.util.Set;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -29,9 +30,6 @@ public class PrincipalClassifier {
 
     private PrincipalClassifier() {
     }
-
-    private static final Pattern PATRON_PRINC_PATTERN
-            = Pattern.compile("(everyone|authenticated)");
 
     public static boolean isPatronPrincipal(String principal) {
         return PATRON_PRINC_PATTERN.matcher(principal).matches();

--- a/security/src/test/java/edu/unc/lib/dl/acl/filter/StoreUserAccessControlFilterTest.java
+++ b/security/src/test/java/edu/unc/lib/dl/acl/filter/StoreUserAccessControlFilterTest.java
@@ -162,7 +162,7 @@ public class StoreUserAccessControlFilterTest {
 
         assertEquals(2, accessGroups.size());
         assertTrue("Public must be assigned", accessGroups.contains(PUBLIC_PRINC));
-        assertTrue("Authenticated must be assigned", accessGroups.contains(TEST_IP_PRINC));
+        assertTrue("IP Group must be assigned", accessGroups.contains(TEST_IP_PRINC));
     }
 
     @Test

--- a/security/src/test/java/edu/unc/lib/dl/acl/filter/StoreUserAccessControlFilterTest.java
+++ b/security/src/test/java/edu/unc/lib/dl/acl/filter/StoreUserAccessControlFilterTest.java
@@ -68,7 +68,7 @@ public class StoreUserAccessControlFilterTest {
 
     private static final String TEST_IP = "192.168.150.16";
     private static final String TEST_IP_PRINC = IP_PRINC_NAMESPACE + "test_grp";
-    private static final String CONFIG = "[{ \"id\" : \"" + TEST_IP_PRINC
+    private static final String CONFIG = "[{ \"principal\" : \"" + TEST_IP_PRINC
             + "\", \"name\" : \"Test Group\", \"ipInclude\" : \"" + TEST_IP + "\"}]";
 
     @Rule

--- a/security/src/test/java/edu/unc/lib/dl/acl/util/PatronPrincipalProviderTest.java
+++ b/security/src/test/java/edu/unc/lib/dl/acl/util/PatronPrincipalProviderTest.java
@@ -80,7 +80,7 @@ public class PatronPrincipalProviderTest {
     private void addPatronConfig(String id, String name, String ipInclude) {
         Map<String, String> info = new HashMap<>();
         if (id != null) {
-            info.put("id", id);
+            info.put("principal", id);
         }
         if (name != null) {
             info.put("name", name);

--- a/security/src/test/java/edu/unc/lib/dl/acl/util/PatronPrincipalProviderTest.java
+++ b/security/src/test/java/edu/unc/lib/dl/acl/util/PatronPrincipalProviderTest.java
@@ -1,0 +1,339 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.acl.util;
+
+import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.AUTHENTICATED_PRINC;
+import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.IP_PRINC_NAMESPACE;
+import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.PUBLIC_PRINC;
+import static edu.unc.lib.dl.acl.util.RemoteUserUtil.REMOTE_USER;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * @author bbpennel
+ */
+public class PatronPrincipalProviderTest {
+
+    @Rule
+    public final TemporaryFolder tmpFolder = new TemporaryFolder();
+    private File configFile;
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private List<Map<String, String>> patronConfig;
+
+    private PatronPrincipalProvider provider;
+
+    private static final String TEST_IP = "192.168.150.16";
+    private static final String TEST_IP2 = "192.168.155.27";
+    private static final String TEST_IP3 = "192.168.160.101";
+
+    private static final String USERNAME = "username";
+    private static final String TEST_GROUP_ID = IP_PRINC_NAMESPACE + "test_grp";
+    private static final String TEST_GROUP_NAME = "Test Group";
+    private static final String TEST_GROUP_ID2 = IP_PRINC_NAMESPACE + "other_grp";
+    private static final String TEST_GROUP_NAME2 = "Other Group";
+
+    @Before
+    public void setup() throws Exception {
+        initMocks(this);
+        provider = new PatronPrincipalProvider();
+
+        tmpFolder.create();
+        configFile = tmpFolder.newFile("patronConfig.json");
+
+        provider.setPatronGroupConfigPath(configFile.getAbsolutePath());
+        patronConfig = new ArrayList<>();
+    }
+
+    private void addPatronConfig(String id, String name, String ipInclude) {
+        Map<String, String> info = new HashMap<>();
+        if (id != null) {
+            info.put("id", id);
+        }
+        if (name != null) {
+            info.put("name", name);
+        }
+        if (ipInclude != null) {
+            info.put("ipInclude", ipInclude);
+        }
+        patronConfig.add(info);
+    }
+
+    private void serializeConfigAndInit() throws Exception {
+        objectMapper.writeValue(configFile, patronConfig);
+        provider.init();
+    }
+
+    @Test
+    public void emptyConfigTest() throws Exception {
+        serializeConfigAndInit();
+
+        assertTrue(provider.getConfiguredPatronPrincipals().isEmpty());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void missingPrincipalIdTest() throws Exception {
+        addPatronConfig(null, TEST_GROUP_NAME, TEST_IP2);
+        serializeConfigAndInit();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void invalidPrincipalIdTest() throws Exception {
+        addPatronConfig("some:group:here", TEST_GROUP_NAME, TEST_IP2);
+        serializeConfigAndInit();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void missingPrincipalNameTest() throws Exception {
+        addPatronConfig(TEST_GROUP_ID, null, TEST_IP2);
+        serializeConfigAndInit();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void missingPrincipalIpTest() throws Exception {
+        addPatronConfig(TEST_GROUP_ID, TEST_GROUP_NAME, null);
+        serializeConfigAndInit();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void missingPrincipalInvalidIpTest() throws Exception {
+        addPatronConfig(TEST_GROUP_ID, TEST_GROUP_NAME, "what.is.this.thing");
+        try {
+            serializeConfigAndInit();
+        } catch (JsonMappingException e) {
+            throw (Exception) e.getCause();
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void missingPrincipalUnclosedRangeTest() throws Exception {
+        addPatronConfig(TEST_GROUP_ID, TEST_GROUP_NAME, TEST_IP2 + "-");
+        try {
+            serializeConfigAndInit();
+        } catch (JsonMappingException e) {
+            throw (Exception) e.getCause();
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void missingPrincipalBlankRangeStartTest() throws Exception {
+        addPatronConfig(TEST_GROUP_ID, TEST_GROUP_NAME, "-" + TEST_IP2);
+        try {
+            serializeConfigAndInit();
+        } catch (JsonMappingException e) {
+            throw (Exception) e.getCause();
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void missingPrincipalInvalidRangeEndTest() throws Exception {
+        addPatronConfig(TEST_GROUP_ID, TEST_GROUP_NAME, TEST_IP2 + "-what.is.this.thing");
+        try {
+            serializeConfigAndInit();
+        } catch (JsonMappingException e) {
+            throw (Exception) e.getCause();
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void missingPrincipalInvalidNumberRangePartsTest() throws Exception {
+        addPatronConfig(TEST_GROUP_ID, TEST_GROUP_NAME, TEST_IP2 + "-" + TEST_IP2 + "-" + TEST_IP2);
+        try {
+            serializeConfigAndInit();
+        } catch (JsonMappingException e) {
+            throw (Exception) e.getCause();
+        }
+    }
+
+    @Test
+    public void getPrincipalsPublic() throws Exception {
+        addPatronConfig(TEST_GROUP_ID, TEST_GROUP_NAME, TEST_IP2);
+        serializeConfigAndInit();
+
+        List<String> princs = provider.getPrincipals(mockRequest(false, TEST_IP));
+        assertContainsPrincipals(princs, PUBLIC_PRINC);
+    }
+
+    @Test
+    public void getPrincipalsAuthenticated() throws Exception {
+        addPatronConfig(TEST_GROUP_ID, TEST_GROUP_NAME, TEST_IP2);
+        serializeConfigAndInit();
+
+        List<String> princs = provider.getPrincipals(mockRequest(true, TEST_IP));
+        assertContainsPrincipals(princs, PUBLIC_PRINC, AUTHENTICATED_PRINC);
+    }
+
+    @Test
+    public void getPrincipalsWithNoConfiguredGroups() throws Exception {
+        serializeConfigAndInit();
+
+        List<String> princs = provider.getPrincipals(mockRequest(false, TEST_IP));
+        assertContainsPrincipals(princs, PUBLIC_PRINC);
+    }
+
+    @Test
+    public void getPrincipalsIpMatch() throws Exception {
+        addPatronConfig(TEST_GROUP_ID, TEST_GROUP_NAME, TEST_IP);
+        serializeConfigAndInit();
+
+        List<String> princs = provider.getPrincipals(mockRequest(false, TEST_IP));
+        assertContainsPrincipals(princs, PUBLIC_PRINC, TEST_GROUP_ID);
+    }
+
+    @Test
+    public void getPrincipalsIpStartOfRange() throws Exception {
+        addPatronConfig(TEST_GROUP_ID, TEST_GROUP_NAME, TEST_IP + "-" + TEST_IP2);
+        serializeConfigAndInit();
+
+        List<String> princs = provider.getPrincipals(mockRequest(false, TEST_IP));
+        assertContainsPrincipals(princs, PUBLIC_PRINC, TEST_GROUP_ID);
+    }
+
+    @Test
+    public void getPrincipalsIpEndOfRange() throws Exception {
+        addPatronConfig(TEST_GROUP_ID, TEST_GROUP_NAME, TEST_IP + "-" + TEST_IP2);
+        serializeConfigAndInit();
+
+        List<String> princs = provider.getPrincipals(mockRequest(false, TEST_IP2));
+        assertContainsPrincipals(princs, PUBLIC_PRINC, TEST_GROUP_ID);
+    }
+
+    @Test
+    public void getPrincipalsIpMiddleOfRange() throws Exception {
+        addPatronConfig(TEST_GROUP_ID, TEST_GROUP_NAME, TEST_IP + "-" + TEST_IP3);
+        serializeConfigAndInit();
+
+        List<String> princs = provider.getPrincipals(mockRequest(false, TEST_IP2));
+        assertContainsPrincipals(princs, PUBLIC_PRINC, TEST_GROUP_ID);
+    }
+
+    @Test
+    public void getPrincipalsIpOutOfRange() throws Exception {
+        addPatronConfig(TEST_GROUP_ID, TEST_GROUP_NAME, TEST_IP + "-" + TEST_IP2);
+        serializeConfigAndInit();
+
+        List<String> princs = provider.getPrincipals(mockRequest(false, TEST_IP3));
+        assertContainsPrincipals(princs, PUBLIC_PRINC);
+    }
+
+    @Test
+    public void getPrincipalsIpInList() throws Exception {
+        addPatronConfig(TEST_GROUP_ID, TEST_GROUP_NAME, TEST_IP + "," + TEST_IP3 + "," + TEST_IP2);
+        serializeConfigAndInit();
+
+        assertContainsPrincipals(provider.getPrincipals(mockRequest(false, TEST_IP)),
+                PUBLIC_PRINC, TEST_GROUP_ID);
+        assertContainsPrincipals(provider.getPrincipals(mockRequest(false, TEST_IP2)),
+                PUBLIC_PRINC, TEST_GROUP_ID);
+        assertContainsPrincipals(provider.getPrincipals(mockRequest(false, TEST_IP3)),
+                PUBLIC_PRINC, TEST_GROUP_ID);
+    }
+
+    @Test
+    public void getPrincipalsIpNotInList() throws Exception {
+        addPatronConfig(TEST_GROUP_ID, TEST_GROUP_NAME, TEST_IP + "," + TEST_IP3);
+        serializeConfigAndInit();
+
+        List<String> princs = provider.getPrincipals(mockRequest(false, TEST_IP2));
+        assertContainsPrincipals(princs, PUBLIC_PRINC);
+    }
+
+    @Test
+    public void getPrincipalsIpMixedFormat() throws Exception {
+        addPatronConfig(TEST_GROUP_ID, TEST_GROUP_NAME, TEST_IP + "-" + TEST_IP2 + "," + TEST_IP3);
+        serializeConfigAndInit();
+
+        assertContainsPrincipals(provider.getPrincipals(mockRequest(false, TEST_IP)),
+                PUBLIC_PRINC, TEST_GROUP_ID);
+        assertContainsPrincipals(provider.getPrincipals(mockRequest(false, TEST_IP2)),
+                PUBLIC_PRINC, TEST_GROUP_ID);
+        assertContainsPrincipals(provider.getPrincipals(mockRequest(false, TEST_IP3)),
+                PUBLIC_PRINC, TEST_GROUP_ID);
+        // Just outside of range
+        assertContainsPrincipals(provider.getPrincipals(mockRequest(false, "192.168.155.30")),
+                PUBLIC_PRINC);
+        // Before range
+        assertContainsPrincipals(provider.getPrincipals(mockRequest(false, "192.168.150.14")),
+                PUBLIC_PRINC);
+        // After range
+        assertContainsPrincipals(provider.getPrincipals(mockRequest(false, "192.168.200.1")),
+                PUBLIC_PRINC);
+    }
+
+    @Test
+    public void getPrincipalsMultipleGroups() throws Exception {
+        addPatronConfig(TEST_GROUP_ID, TEST_GROUP_NAME, TEST_IP);
+        addPatronConfig(TEST_GROUP_ID2, TEST_GROUP_NAME2, TEST_IP2);
+        serializeConfigAndInit();
+
+        assertContainsPrincipals(provider.getPrincipals(mockRequest(false, TEST_IP)),
+                PUBLIC_PRINC, TEST_GROUP_ID);
+        assertContainsPrincipals(provider.getPrincipals(mockRequest(false, TEST_IP2)),
+                PUBLIC_PRINC, TEST_GROUP_ID2);
+    }
+
+    @Test
+    public void getPrincipalsOverlappingGroups() throws Exception {
+        addPatronConfig(TEST_GROUP_ID, TEST_GROUP_NAME, TEST_IP2);
+        addPatronConfig(TEST_GROUP_ID2, TEST_GROUP_NAME2, TEST_IP + "-" + TEST_IP3);
+        serializeConfigAndInit();
+
+        assertContainsPrincipals(provider.getPrincipals(mockRequest(false, TEST_IP)),
+                PUBLIC_PRINC, TEST_GROUP_ID2);
+        assertContainsPrincipals(provider.getPrincipals(mockRequest(false, TEST_IP2)),
+                PUBLIC_PRINC, TEST_GROUP_ID, TEST_GROUP_ID2);
+        assertContainsPrincipals(provider.getPrincipals(mockRequest(false, TEST_IP3)),
+                PUBLIC_PRINC, TEST_GROUP_ID2);
+        assertContainsPrincipals(provider.getPrincipals(mockRequest(false, "192.168.200.1")),
+                PUBLIC_PRINC);
+    }
+
+    private void assertContainsPrincipals(List<String> princs, String... expected) {
+        String msg = "Expected [" + String.join(",", expected) + "] received " + princs;
+        assertEquals(msg, expected.length, princs.size());
+        assertTrue(msg, princs.containsAll(Arrays.asList(expected)));
+    }
+
+    private HttpServletRequest mockRequest(boolean isAuthenticated, String ipAddr) {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        if (isAuthenticated) {
+            when(request.getHeader(REMOTE_USER)).thenReturn(USERNAME);
+        }
+        if (ipAddr != null) {
+            when(request.getHeader(PatronPrincipalProvider.FORWARDED_FOR_HEADER)).thenReturn(ipAddr);
+        }
+        return request;
+    }
+}

--- a/security/src/test/java/edu/unc/lib/dl/acl/util/PatronPrincipalProviderTest.java
+++ b/security/src/test/java/edu/unc/lib/dl/acl/util/PatronPrincipalProviderTest.java
@@ -104,13 +104,13 @@ public class PatronPrincipalProviderTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void missingPrincipalIdTest() throws Exception {
+    public void missingPrincipalTest() throws Exception {
         addPatronConfig(null, TEST_GROUP_NAME, TEST_IP2);
         serializeConfigAndInit();
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void invalidPrincipalIdTest() throws Exception {
+    public void invalidPrincipalTest() throws Exception {
         addPatronConfig("some:group:here", TEST_GROUP_NAME, TEST_IP2);
         serializeConfigAndInit();
     }
@@ -170,6 +170,26 @@ public class PatronPrincipalProviderTest {
     @Test(expected = IllegalArgumentException.class)
     public void missingPrincipalInvalidNumberRangePartsTest() throws Exception {
         addPatronConfig(TEST_GROUP_ID, TEST_GROUP_NAME, TEST_IP2 + "-" + TEST_IP2 + "-" + TEST_IP2);
+        try {
+            serializeConfigAndInit();
+        } catch (JsonMappingException e) {
+            throw (Exception) e.getCause();
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void missingPrincipalEndBeforeStartTest() throws Exception {
+        addPatronConfig(TEST_GROUP_ID, TEST_GROUP_NAME, TEST_IP3 + "-" + TEST_IP2);
+        try {
+            serializeConfigAndInit();
+        } catch (JsonMappingException e) {
+            throw (Exception) e.getCause();
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void missingPrincipalIpTooBigTest() throws Exception {
+        addPatronConfig(TEST_GROUP_ID, TEST_GROUP_NAME, "500.0.0.1");
         try {
             serializeConfigAndInit();
         } catch (JsonMappingException e) {

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/AccessControlRetrievalController.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/AccessControlRetrievalController.java
@@ -61,7 +61,7 @@ public class AccessControlRetrievalController {
     private static final Logger log = LoggerFactory.getLogger(AccessControlRetrievalController.class);
     public static final String INHERITED_ROLES = "inherited";
     public static final String ASSIGNED_ROLES = "assigned";
-    public static final String ALLOWED_ADDITIONAL_PRINCIPALS = "allowedPrincipals";
+    public static final String ALLOWED_PATRON_PRINCIPALS = "allowedPrincipals";
     public static final String ROLES_KEY = "roles";
     public static final String EMBARGO_KEY = "embargo";
     public static final String DELETED_KEY = "deleted";
@@ -153,7 +153,7 @@ public class AccessControlRetrievalController {
         } else if (repoObj instanceof ContentObject) {
             result.put(INHERITED_ROLES, addInheritedPatronInfo(repoObj));
             result.put(ASSIGNED_ROLES, addAssignedPatronInfo(pid));
-            result.put(ALLOWED_ADDITIONAL_PRINCIPALS, patronPrincipalProvider.getConfiguredPatronPrincipals());
+            result.put(ALLOWED_PATRON_PRINCIPALS, patronPrincipalProvider.getConfiguredPatronPrincipals());
 
             return new ResponseEntity<>(result, HttpStatus.OK);
         } else {

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/AccessControlRetrievalController.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/AccessControlRetrievalController.java
@@ -16,7 +16,7 @@
 package edu.unc.lib.dl.cdr.services.rest;
 
 import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.USER_NAMESPACE;
-import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -37,6 +37,7 @@ import edu.unc.lib.dl.acl.fcrepo4.InheritedAclFactory;
 import edu.unc.lib.dl.acl.fcrepo4.ObjectAclFactory;
 import edu.unc.lib.dl.acl.service.AccessControlService;
 import edu.unc.lib.dl.acl.util.AgentPrincipals;
+import edu.unc.lib.dl.acl.util.PatronPrincipalProvider;
 import edu.unc.lib.dl.acl.util.Permission;
 import edu.unc.lib.dl.acl.util.RoleAssignment;
 import edu.unc.lib.dl.fcrepo4.AdminUnit;
@@ -60,6 +61,7 @@ public class AccessControlRetrievalController {
     private static final Logger log = LoggerFactory.getLogger(AccessControlRetrievalController.class);
     public static final String INHERITED_ROLES = "inherited";
     public static final String ASSIGNED_ROLES = "assigned";
+    public static final String ALLOWED_ADDITIONAL_PRINCIPALS = "allowedPrincipals";
     public static final String ROLES_KEY = "roles";
     public static final String EMBARGO_KEY = "embargo";
     public static final String DELETED_KEY = "deleted";
@@ -72,8 +74,10 @@ public class AccessControlRetrievalController {
     private InheritedAclFactory inheritedAclFactory;
     @Autowired
     private RepositoryObjectLoader repoObjLoader;
+    @Autowired
+    private PatronPrincipalProvider patronPrincipalProvider;
 
-    @GetMapping(value = "/acl/staff/{id}", produces = APPLICATION_JSON_UTF8_VALUE)
+    @GetMapping(value = "/acl/staff/{id}", produces = APPLICATION_JSON_VALUE)
     @ResponseBody
     public ResponseEntity<Object> getStaffRoles(@PathVariable("id") String id) {
         log.debug("Retrieving staff roles for {}", id);
@@ -129,7 +133,7 @@ public class AccessControlRetrievalController {
      * @param id
      * @return
      */
-    @GetMapping(value = "/acl/patron/{id}", produces = APPLICATION_JSON_UTF8_VALUE)
+    @GetMapping(value = "/acl/patron/{id}", produces = APPLICATION_JSON_VALUE)
     @ResponseBody
     public ResponseEntity<Object> getPatronAccess(@PathVariable("id") String id) {
         log.debug("Retrieving patron access details for {}", id);
@@ -149,6 +153,7 @@ public class AccessControlRetrievalController {
         } else if (repoObj instanceof ContentObject) {
             result.put(INHERITED_ROLES, addInheritedPatronInfo(repoObj));
             result.put(ASSIGNED_ROLES, addAssignedPatronInfo(pid));
+            result.put(ALLOWED_ADDITIONAL_PRINCIPALS, patronPrincipalProvider.getConfiguredPatronPrincipals());
 
             return new ResponseEntity<>(result, HttpStatus.OK);
         } else {

--- a/services/src/main/webapp/WEB-INF/service-context.xml
+++ b/services/src/main/webapp/WEB-INF/service-context.xml
@@ -196,6 +196,15 @@
     
     <!-- Access related beans -->
     
+    <bean name="patronPrincipalProvider" class="edu.unc.lib.dl.acl.util.PatronPrincipalProvider"
+            init-method="init">
+        <property name="patronGroupConfigPath" value="${acl.patronPrincipalConfig.path}" />
+    </bean>
+    
+    <bean name="storeUserAccessControlFilter" class="edu.unc.lib.dl.acl.filter.StoreUserAccessControlFilter">
+        <property name="patronPrincipalProvider" ref="patronPrincipalProvider" />
+    </bean>
+    
     <bean name="storeAccessLevelFilter" class="edu.unc.lib.dl.ui.access.StoreAccessLevelFilter">
         <property name="queryLayer" ref="queryLayer" />
         <property name="requireViewAdmin" value="true" />

--- a/services/src/main/webapp/WEB-INF/web.xml
+++ b/services/src/main/webapp/WEB-INF/web.xml
@@ -66,11 +66,11 @@
     </filter-mapping>
     
     <filter>
-        <filter-name>StoreUserAccessControlFilter</filter-name>
-        <filter-class>edu.unc.lib.dl.acl.filter.StoreUserAccessControlFilter</filter-class>
+        <filter-name>storeUserAccessControlFilter</filter-name>
+        <filter-class>org.springframework.web.filter.DelegatingFilterProxy</filter-class>
     </filter>
     <filter-mapping>
-        <filter-name>StoreUserAccessControlFilter</filter-name>
+        <filter-name>storeUserAccessControlFilter</filter-name>
         <url-pattern>/api/*</url-pattern>
         <url-pattern>/api-s/*</url-pattern>
     </filter-mapping>

--- a/services/src/test/resources/patron-principals.json
+++ b/services/src/test/resources/patron-principals.json
@@ -1,0 +1,7 @@
+[
+	{
+		"principal" : "unc:patron:ipp:test_group",
+		"name" : "Test Patron Group",
+		"ipInclude" : "192.168.1.1"
+	}
+]

--- a/services/src/test/resources/spring-test/acl-service-context.xml
+++ b/services/src/test/resources/spring-test/acl-service-context.xml
@@ -22,6 +22,11 @@
         http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans.xsd">
     
+    <bean name="patronPrincipalProvider" class="edu.unc.lib.dl.acl.util.PatronPrincipalProvider"
+            init-method="init">
+        <property name="patronGroupConfigPath" value="src/test/resources/patron-principals.json" />
+    </bean>
+    
     <bean id="objectAclFactory" class="edu.unc.lib.dl.acl.fcrepo4.ObjectAclFactory"
             init-method="init">
         <property name="cacheMaxSize" value="0" />

--- a/solr-ingest/src/test/java/edu/unc/lib/dl/data/ingest/solr/filter/SetAccessControlFilterTest.java
+++ b/solr-ingest/src/test/java/edu/unc/lib/dl/data/ingest/solr/filter/SetAccessControlFilterTest.java
@@ -19,6 +19,7 @@ import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.AUTHENTICATED_PRI
 import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.PUBLIC_PRINC;
 import static edu.unc.lib.dl.acl.util.UserRole.canDescribe;
 import static edu.unc.lib.dl.acl.util.UserRole.canManage;
+import static edu.unc.lib.dl.acl.util.UserRole.canViewAccessCopies;
 import static edu.unc.lib.dl.acl.util.UserRole.canViewMetadata;
 import static edu.unc.lib.dl.acl.util.UserRole.canViewOriginals;
 import static org.junit.Assert.assertEquals;
@@ -206,6 +207,28 @@ public class SetAccessControlFilterTest {
                 canViewOriginals.name() + "|" + PUBLIC_PRINC));
         assertTrue(listCaptor.getValue().contains(
                 canManage.name() + "|" + PRINC2));
+    }
+
+    @Test
+    public void testHasCustomPatronPrincipal() throws Exception {
+        addPatronAccess(PUBLIC_PRINC, canViewMetadata);
+        addPatronAccess(AUTHENTICATED_PRINC, canViewAccessCopies);
+        String customGroup = AccessPrincipalConstants.IP_PRINC_NAMESPACE + "custom";
+        addPatronAccess(customGroup, canViewOriginals);
+
+        filter.filter(dip);
+
+        verify(idb).setReadGroup(listCaptor.capture());
+        assertPrincipalsPresent("All principals should be granted read rights",
+                listCaptor.getValue(), PUBLIC_PRINC, AUTHENTICATED_PRINC, customGroup);
+
+        verify(idb).setRoleGroup(listCaptor.capture());
+        assertTrue(listCaptor.getValue().contains(
+                canViewMetadata.name() + "|" + PUBLIC_PRINC));
+        assertTrue(listCaptor.getValue().contains(
+                canViewAccessCopies.name() + "|" + AUTHENTICATED_PRINC));
+        assertTrue(listCaptor.getValue().contains(
+                canViewOriginals.name() + "|" + customGroup));
     }
 
     @Test

--- a/static/js/admin/vue-permissions-editor/src/components/patronDisplayRow.vue
+++ b/static/js/admin/vue-permissions-editor/src/components/patronDisplayRow.vue
@@ -1,7 +1,7 @@
 <template>
-    <tr :class="{onyen: user.principal === 'everyone'}">
+    <tr>
         <td class="access-display">
-            {{ principalDisplayName(user.principal) }}
+            {{ principalDisplayName(user.principal, allowedOtherPrincipals) }}
             <div class="display-note-btn" :class="{hidden: nonPublicRole(user.principal)}">
                 <i class="far fa-question-circle" :class="{hidden: nonPublicRole(user.principal)}"></i>
                 <div class="arrow" :class="{'arrow-offset': alignTooltip(user.principal)}"></div>
@@ -34,7 +34,8 @@
         props: {
             containerType: String,
             user: Object,
-            userType: String
+            userType: String,
+            allowedOtherPrincipals: Array
         },
 
         methods: {
@@ -70,12 +71,6 @@
 <style scoped lang="scss">
     #modal-permissions-editor {
         .border {
-            tr.onyen {
-                td {
-                    border-bottom: none;
-                }
-            }
-
             td {
                 height: auto;
                 padding: 7px 0 7px 15px;

--- a/static/js/admin/vue-permissions-editor/src/components/patronDisplayRow.vue
+++ b/static/js/admin/vue-permissions-editor/src/components/patronDisplayRow.vue
@@ -1,7 +1,7 @@
 <template>
     <tr>
         <td class="access-display">
-            {{ principalDisplayName(user.principal, allowedOtherPrincipals) }}
+            {{ principalDisplayName(user.principal, allowedPrincipals) }}
             <div class="display-note-btn" :class="{hidden: nonPublicRole(user.principal)}">
                 <i class="far fa-question-circle" :class="{hidden: nonPublicRole(user.principal)}"></i>
                 <div class="arrow" :class="{'arrow-offset': alignTooltip(user.principal)}"></div>
@@ -35,7 +35,7 @@
             containerType: String,
             user: Object,
             userType: String,
-            allowedOtherPrincipals: Array
+            allowedPrincipals: Array
         },
 
         methods: {

--- a/static/js/admin/vue-permissions-editor/src/components/patronDisplayRow.vue
+++ b/static/js/admin/vue-permissions-editor/src/components/patronDisplayRow.vue
@@ -1,7 +1,7 @@
 <template>
     <tr :class="{onyen: user.principal === 'everyone'}">
         <td class="access-display">
-            {{ formattedPrincipal(user.principal) }}
+            {{ principalDisplayName(user.principal) }}
             <div class="display-note-btn" :class="{hidden: nonPublicRole(user.principal)}">
                 <i class="far fa-question-circle" :class="{hidden: nonPublicRole(user.principal)}"></i>
                 <div class="arrow" :class="{'arrow-offset': alignTooltip(user.principal)}"></div>
@@ -44,16 +44,6 @@
                 }
 
                 return '(Overridden by parent)';
-            },
-
-            formattedPrincipal(user) {
-                if (user === 'everyone') {
-                    return "Public Users"
-                } else if (user === 'staff') {
-                    return 'No Patron Access';
-                } else {
-                    return user;
-                }
             },
 
             formattedRole(role) {

--- a/static/js/admin/vue-permissions-editor/src/components/patronRoles.vue
+++ b/static/js/admin/vue-permissions-editor/src/components/patronRoles.vue
@@ -14,7 +14,7 @@
                 <patron-display-row :user="user"
                                     :user-type="user_type"
                                     :container-type="containerType"
-                                    :allowed-other-principals="allowed_other_principals"></patron-display-row>
+                                    :allowed-principals="allowed_principals"></patron-display-row>
             </template>
             </tbody>
         </table>
@@ -30,7 +30,7 @@
                        id="user_type_patron"><label for="user_type_patron"> Allow patron access</label>
                 <ul id="assigned_principals_editor" class="patron">
                     <li v-for="(patron_princ, index) in selected_patron_assignments" v-bind:key="index" class="patron-assigned">
-                        <p>{{ principalDisplayName(patron_princ.principal, allowed_other_principals) }}</p>
+                        <p>{{ principalDisplayName(patron_princ.principal, allowed_principals) }}</p>
                         <div class="select-wrapper" :class="{'is-disabled': shouldDisable}">
                             <select v-model="patron_princ.role" :disabled="shouldDisable">
                                 <template v-for="(role, index) in possibleRoles">
@@ -43,10 +43,10 @@
                                 :disabled="shouldDisable"
                                 v-if="!patron_princ.protected">Remove</button>
                     </li>
-                    <li id="add-new-patron-principal" v-show="shouldShowAddOtherPrincipals">
+                    <li id="add-new-patron-principal" v-show="shouldShowAddPrincipal">
                         <p class="select-wrapper" :class="{'is-disabled': shouldDisable}">
                             <select id="add-new-patron-principal-id" v-model="new_assignment_principal" :disabled="shouldDisable">
-                                <option v-for="princ in allowed_other_principals" :value="princ.principal">{{ princ.name }}</option>
+                                <option v-for="princ in allowed_principals" :value="princ.principal">{{ princ.name }}</option>
                             </select>
                         </p>
                         <div class="select-wrapper" :class="{'is-disabled': shouldDisable}">
@@ -56,7 +56,7 @@
                         </div>
                     </li>
                     <li>
-                        <button @click="addOtherPrincipal" id="add-other-principal" :disabled="shouldDisable">Add Group</button>
+                        <button @click="addPrincipal" id="add-principal" :disabled="shouldDisable">Add Group</button>
                     </li>
                 </ul>
             </li>
@@ -142,7 +142,7 @@
 
         data() {
             return {
-                allowed_other_principals: [],
+                allowed_principals: [],
                 selected_patron_assignments: [],
                 embargo: null,
                 deleted: false,
@@ -150,7 +150,7 @@
                 new_assignment_principal: '',
                 response_message: '',
                 user_type: null,
-                shouldShowAddOtherPrincipals: false,
+                shouldShowAddPrincipal: false,
                 saved_details: null
             }
         },
@@ -163,7 +163,7 @@
             displayAssignments() {
                 let assigned = cloneDeep(this.assignedPatronRoles);
                 // Display the new assignment before it is committed, if valid
-                if (this.shouldShowAddOtherPrincipals) {
+                if (this.shouldShowAddPrincipal) {
                     try {
                         assigned.push(this.getNewAssignment());
                     } catch (e) {
@@ -261,7 +261,7 @@
                     this._initializeInherited(response.data.inherited);
                     this.deleted = response.data.assigned.deleted;
                     this._initializeSelectedAssignments(response.data.assigned.roles);
-                    this.allowed_other_principals = response.data.allowedPrincipals;
+                    this.allowed_principals = response.data.allowedPrincipals;
                     this.saved_details = this.submissionAccessDetails();
                 }).catch((error) => {
                     let response_msg = `Unable to load current patron roles for: ${this.title}`;
@@ -361,8 +361,8 @@
                 this.is_submitting = true;
                 this.response_message = 'Saving permissions \u2026';
                 // Commit uncommitted new group assignment if one was input
-                if (this.shouldShowAddOtherPrincipals && this.new_assignment_principal !== '') {
-                    this.addOtherPrincipal();
+                if (this.shouldShowAddPrincipal && this.new_assignment_principal !== '') {
+                    this.addPrincipal();
                 }
                 let submissionDetails = this.submissionAccessDetails();
 
@@ -507,9 +507,9 @@
                 this.displayModal();
             },
             
-            addOtherPrincipal() {
-                if (!this.shouldShowAddOtherPrincipals) {
-                    this.shouldShowAddOtherPrincipals = true;
+            addPrincipal() {
+                if (!this.shouldShowAddPrincipal) {
+                    this.shouldShowAddPrincipal = true;
                     return false;
                 }
                 try {
@@ -608,6 +608,7 @@
                         display: flex;
                         text-indent: 0;
                         margin-left: 0;
+                        margin-bottom: 8px;
 
                         p {
                             min-width: 170px;
@@ -658,7 +659,7 @@
         }
     }
 
-    #add-other-principal {
+    #add-principal {
         margin-left: 0;
     }
 

--- a/static/js/admin/vue-permissions-editor/src/mixins/patronHelpers.js
+++ b/static/js/admin/vue-permissions-editor/src/mixins/patronHelpers.js
@@ -14,7 +14,7 @@ export default {
                 return displayName;
             }
             // For custom defined principals
-            let mapping = allowed_other_principals.find(e => e.id === principal);
+            let mapping = allowed_other_principals.find(e => e.principal === principal);
             if (mapping === null) {
                 // no name available, fall back to principal
                 return principal;

--- a/static/js/admin/vue-permissions-editor/src/mixins/patronHelpers.js
+++ b/static/js/admin/vue-permissions-editor/src/mixins/patronHelpers.js
@@ -7,14 +7,14 @@ const PRINCIPAL_DISPLAY_NAMES = {
 
 export default {
     methods: {
-        principalDisplayName(principal) {
+        principalDisplayName(principal, allowed_other_principals) {
             // For reserved principals
             let displayName = PRINCIPAL_DISPLAY_NAMES[principal];
             if (displayName !== undefined) {
                 return displayName;
             }
             // For custom defined principals
-            let mapping = this.allowed_other_principals.find(e => e.id === principal);
+            let mapping = allowed_other_principals.find(e => e.id === principal);
             if (mapping === null) {
                 // no name available, fall back to principal
                 return principal;

--- a/static/js/admin/vue-permissions-editor/src/mixins/patronHelpers.js
+++ b/static/js/admin/vue-permissions-editor/src/mixins/patronHelpers.js
@@ -1,5 +1,27 @@
+const PRINCIPAL_DISPLAY_NAMES = {
+    everyone: 'Public users',
+    authenticated: 'Authenticated users',
+    staff: 'No Patron Access',
+    patron: 'Patron'
+};
+
 export default {
     methods: {
+        principalDisplayName(principal) {
+            // For reserved principals
+            let displayName = PRINCIPAL_DISPLAY_NAMES[principal];
+            if (displayName !== undefined) {
+                return displayName;
+            }
+            // For custom defined principals
+            let mapping = this.allowed_other_principals.find(e => e.id === principal);
+            if (mapping === null) {
+                // no name available, fall back to principal
+                return principal;
+            }
+            return mapping.name;
+        },
+
         possibleRoleList(container) {
             return [
                 { text: '', role: '' },

--- a/static/js/admin/vue-permissions-editor/tests/unit/patronDisplayRow.spec.js
+++ b/static/js/admin/vue-permissions-editor/tests/unit/patronDisplayRow.spec.js
@@ -34,8 +34,8 @@ describe('patronRoles.vue', () => {
         principal = columns.at(0);
         role = columns.at(1);
 
-        expect(principal.text()).toMatch(/^authenticated/);
-        expect(role.text()).toMatch(/^Metadata.Only/);
+        expect(principal.text()).toMatch(/^authenticated/i);
+        expect(role.text()).toMatch(/^Metadata.Only/i);
     });
 
     it("displays an override note", () => {
@@ -52,8 +52,8 @@ describe('patronRoles.vue', () => {
         principal = columns.at(0);
         role = columns.at(1);
 
-        expect(principal.text()).toMatch(/^authenticated/);
-        expect(role.text()).toMatch(/^Metadata.Only.\(Overridden.by.parent\)/);
+        expect(principal.text()).toMatch(/^authenticated/i);
+        expect(role.text()).toMatch(/^Metadata.Only.\(Overridden.by.parent\)/i);
     });
 
     it("does not display an override note if patron access is set to 'inherit from parent'", () => {
@@ -70,9 +70,9 @@ describe('patronRoles.vue', () => {
         principal = columns.at(0);
         role = columns.at(1);
 
-        expect(principal.text()).toMatch(/^authenticated/);
-        expect(role.text()).not.toMatch(/^Metadata.Only.\(Overridden.by.parent\)/);
-        expect(role.text()).toMatch(/^Metadata.Only/);
+        expect(principal.text()).toMatch(/^authenticated/i);
+        expect(role.text()).not.toMatch(/^Metadata.Only.\(Overridden.by.parent\)/i);
+        expect(role.text()).toMatch(/^Metadata.Only/i);
     });
 
     it("does not display an override note for assigned permissions", () => {
@@ -89,14 +89,14 @@ describe('patronRoles.vue', () => {
         principal = columns.at(0);
         role = columns.at(1);
 
-        expect(principal.text()).toMatch(/^authenticated/);
-        expect(role.text()).not.toMatch(/^Metadata.Only.\(Overridden.by.parent\)/);
-        expect(role.text()).toMatch(/^Metadata.Only/);
+        expect(principal.text()).toMatch(/^authenticated/i);
+        expect(role.text()).not.toMatch(/^Metadata.Only.\(Overridden.by.parent\)/i);
+        expect(role.text()).toMatch(/^Metadata.Only/i);
     });
 
     it("displays public assigned patron roles", () => {
-        expect(principal.text()).toMatch(/^Public.Users/);
-        expect(role.text()).toMatch(/^All.of.this.Folder/);
+        expect(principal.text()).toMatch(/^Public.Users/i);
+        expect(role.text()).toMatch(/^All.of.this.Folder/i);
     });
 
     it("displays staff roles", () => {
@@ -113,7 +113,7 @@ describe('patronRoles.vue', () => {
         principal = columns.at(0);
         role = columns.at(1);
 
-        expect(principal.text()).toMatch(/^No.Patron.Access/);
+        expect(principal.text()).toMatch(/^No.Patron.Access/i);
         expect(role.text()).toMatch(/^N\/A/);
     });
 

--- a/static/js/admin/vue-permissions-editor/tests/unit/patronRoles.spec.js
+++ b/static/js/admin/vue-permissions-editor/tests/unit/patronRoles.spec.js
@@ -173,6 +173,34 @@ describe('patronRoles.vue', () => {
         });
     });
 
+    it("new assignment remove button hides inputs", (done) => {
+        const resp_with_allowed_patrons = {
+            inherited: { roles: inherited_roles, deleted: false, embargo: null, assignedTo: null },
+            assigned: { roles: assigned_roles,  deleted: false, embargo: null, assignedTo: UUID },
+            allowedPrincipals: [{ principal: "my:special:group", name: "Special Group" }]
+        };
+        stubDataLoad(resp_with_allowed_patrons);
+
+        moxios.wait(async () => {
+            expect(wrapper.find('#add-new-patron-principal').isVisible()).toBe(false);
+
+            // Click to show the add principal inputs
+            wrapper.find('#add-principal').trigger('click');
+            wrapper.findAll('#add-new-patron-principal-id option').at(0).setSelected();
+            wrapper.findAll('#add-new-patron-principal-role option').at(3).setSelected();
+            await wrapper.vm.$nextTick();
+            expect(wrapper.find('#add-new-patron-principal').isVisible()).toBe(true);
+
+            wrapper.find('#add-new-patron-principal .btn-remove').trigger('click');
+            await wrapper.vm.$nextTick();
+            expect(wrapper.find('#add-new-patron-principal').isVisible()).toBe(false);
+            expect(wrapper.find('#add-new-patron-principal-role').element.value).toEqual('canViewOriginals');
+            expect(wrapper.find('#add-new-patron-principal-id').element.value).toEqual('');
+
+            done();
+        });
+    });
+
     it("retrieves patron roles from the server", (done) => {
         stubDataLoad();
 

--- a/static/js/admin/vue-permissions-editor/tests/unit/patronRoles.spec.js
+++ b/static/js/admin/vue-permissions-editor/tests/unit/patronRoles.spec.js
@@ -148,11 +148,11 @@ describe('patronRoles.vue', () => {
 
         moxios.wait(async () => {
             // Click to show the add other principal inputs
-            wrapper.find('#add-other-principal').trigger('click');
+            wrapper.find('#add-principal').trigger('click');
             // Select the existing patron principal to add
             wrapper.findAll('#add-new-patron-principal-id option').at(0).setSelected();
             wrapper.findAll('#add-new-patron-principal-role option').at(4).setSelected();
-            wrapper.find('#add-other-principal').trigger('click');
+            wrapper.find('#add-principal').trigger('click');
 
             await wrapper.vm.$nextTick();
             stubDataSaveResponse();
@@ -192,7 +192,7 @@ describe('patronRoles.vue', () => {
         });
     });
 
-    it("adds an extra patron group", (done) => {
+    it("adds an custom patron group", (done) => {
         const resp_with_allowed_patrons = {
             inherited: { roles: inherited_roles, deleted: false, embargo: null, assignedTo: null },
             assigned: { roles: assigned_roles,  deleted: false, embargo: null, assignedTo: UUID },
@@ -204,11 +204,11 @@ describe('patronRoles.vue', () => {
             expect(wrapper.vm.assignedPatronRoles).toEqual(resp_with_allowed_patrons.assigned.roles);
 
             // Click to show the add other principal inputs
-            wrapper.find('#add-other-principal').trigger('click');
+            wrapper.find('#add-principal').trigger('click');
             // Select values for new patron role and then click the add button again
             wrapper.findAll('#add-new-patron-principal-id option').at(0).setSelected();
             wrapper.findAll('#add-new-patron-principal-role option').at(4).setSelected();
-            wrapper.find('#add-other-principal').trigger('click');
+            wrapper.find('#add-principal').trigger('click');
 
             // Model should have updated by adding the new role to the list of assigned roles
             const assigned_other_roles = [{ principal: 'everyone', role: 'canViewAccessCopies', assignedTo: UUID  },
@@ -218,14 +218,14 @@ describe('patronRoles.vue', () => {
 
             // Once the UI has refreshed it should now show added entry
             await wrapper.vm.$nextTick();
-            let other_entries = wrapper.findAll('.patron-assigned');
-            expect(other_entries.length).toEqual(3);
-            expect(other_entries.at(0).findAll('p').at(0).text()).toEqual('Public users');
-            expect(other_entries.at(0).findAll('select').at(0).element.value).toEqual('canViewAccessCopies');
-            expect(other_entries.at(1).findAll('p').at(0).text()).toEqual('Authenticated users');
-            expect(other_entries.at(1).findAll('select').at(0).element.value).toEqual('canViewAccessCopies');
-            expect(other_entries.at(2).findAll('p').at(0).text()).toEqual('Special Group');
-            expect(other_entries.at(2).findAll('select').at(0).element.value).toEqual('canViewOriginals');
+            let assigned_patrons = wrapper.findAll('.patron-assigned');
+            expect(assigned_patrons.length).toEqual(3);
+            expect(assigned_patrons.at(0).findAll('p').at(0).text()).toEqual('Public users');
+            expect(assigned_patrons.at(0).findAll('select').at(0).element.value).toEqual('canViewAccessCopies');
+            expect(assigned_patrons.at(1).findAll('p').at(0).text()).toEqual('Authenticated users');
+            expect(assigned_patrons.at(1).findAll('select').at(0).element.value).toEqual('canViewAccessCopies');
+            expect(assigned_patrons.at(2).findAll('p').at(0).text()).toEqual('Special Group');
+            expect(assigned_patrons.at(2).findAll('select').at(0).element.value).toEqual('canViewOriginals');
 
             // The new entry inputs should be cleared
             expect(wrapper.vm.new_assignment_principal).toEqual('');
@@ -258,30 +258,30 @@ describe('patronRoles.vue', () => {
             expect(wrapper.vm.assignedPatronRoles).toEqual(assigned_other_roles);
 
             // Click to show the add other principal inputs
-            wrapper.find('#add-other-principal').trigger('click');
+            wrapper.find('#add-principal').trigger('click');
             // Select the existing patron principal to add
             wrapper.findAll('#add-new-patron-principal-id option').at(0).setSelected();
             wrapper.findAll('#add-new-patron-principal-role option').at(3).setSelected();
-            wrapper.find('#add-other-principal').trigger('click');
+            wrapper.find('#add-principal').trigger('click');
 
             // Try adding principal that has not already been assigned
             wrapper.findAll('#add-new-patron-principal-id option').at(1).setSelected();
-            wrapper.find('#add-other-principal').trigger('click');
+            wrapper.find('#add-principal').trigger('click');
 
             expect(wrapper.vm.assignedPatronRoles).toEqual([assigned_other_roles[0], assigned_other_roles[1], assigned_other_roles[2],
                 { principal: 'the:extra:special:group', role: 'canViewAccessCopies', assignedTo: UUID }]);
 
             await wrapper.vm.$nextTick();
-            let other_entries = wrapper.findAll('.patron-assigned');
-            expect(other_entries.length).toEqual(4);
-            expect(other_entries.at(0).findAll('p').at(0).text()).toEqual('Public users');
-            expect(other_entries.at(0).findAll('select').at(0).element.value).toEqual('canViewAccessCopies');
-            expect(other_entries.at(1).findAll('p').at(0).text()).toEqual('Authenticated users');
-            expect(other_entries.at(1).findAll('select').at(0).element.value).toEqual('canViewAccessCopies');
-            expect(other_entries.at(2).findAll('p').at(0).text()).toEqual('Special Group');
-            expect(other_entries.at(2).findAll('select').at(0).element.value).toEqual('canViewOriginals');
-            expect(other_entries.at(3).findAll('p').at(0).text()).toEqual('Extra Special Group');
-            expect(other_entries.at(3).findAll('select').at(0).element.value).toEqual('canViewAccessCopies');
+            let assigned_patrons = wrapper.findAll('.patron-assigned');
+            expect(assigned_patrons.length).toEqual(4);
+            expect(assigned_patrons.at(0).findAll('p').at(0).text()).toEqual('Public users');
+            expect(assigned_patrons.at(0).findAll('select').at(0).element.value).toEqual('canViewAccessCopies');
+            expect(assigned_patrons.at(1).findAll('p').at(0).text()).toEqual('Authenticated users');
+            expect(assigned_patrons.at(1).findAll('select').at(0).element.value).toEqual('canViewAccessCopies');
+            expect(assigned_patrons.at(2).findAll('p').at(0).text()).toEqual('Special Group');
+            expect(assigned_patrons.at(2).findAll('select').at(0).element.value).toEqual('canViewOriginals');
+            expect(assigned_patrons.at(3).findAll('p').at(0).text()).toEqual('Extra Special Group');
+            expect(assigned_patrons.at(3).findAll('select').at(0).element.value).toEqual('canViewAccessCopies');
             done();
         });
     });
@@ -322,14 +322,14 @@ describe('patronRoles.vue', () => {
             expect(wrapper.vm.assignedPatronRoles).toEqual(
                 [assigned_other_roles[0], assigned_other_roles[1], assigned_other_roles[2]]);
 
-            let other_entries = wrapper.findAll('.patron-assigned');
-            expect(other_entries.length).toEqual(3);
-            expect(other_entries.at(0).findAll('p').at(0).text()).toEqual('Public users');
-            expect(other_entries.at(0).findAll('select').at(0).element.value).toEqual('canViewMetadata');
-            expect(other_entries.at(1).findAll('p').at(0).text()).toEqual('Authenticated users');
-            expect(other_entries.at(1).findAll('select').at(0).element.value).toEqual('canViewMetadata');
-            expect(other_entries.at(2).findAll('p').at(0).text()).toEqual('Another Group');
-            expect(other_entries.at(2).findAll('select').at(0).element.value).toEqual('canViewAccessCopies');
+            let assigned_patrons = wrapper.findAll('.patron-assigned');
+            expect(assigned_patrons.length).toEqual(3);
+            expect(assigned_patrons.at(0).findAll('p').at(0).text()).toEqual('Public users');
+            expect(assigned_patrons.at(0).findAll('select').at(0).element.value).toEqual('canViewMetadata');
+            expect(assigned_patrons.at(1).findAll('p').at(0).text()).toEqual('Authenticated users');
+            expect(assigned_patrons.at(1).findAll('select').at(0).element.value).toEqual('canViewMetadata');
+            expect(assigned_patrons.at(2).findAll('p').at(0).text()).toEqual('Another Group');
+            expect(assigned_patrons.at(2).findAll('select').at(0).element.value).toEqual('canViewAccessCopies');
 
             expect(wrapper.vm.displayAssignments).toEqual([
                 { principal: 'everyone', role: 'canViewMetadata', type: 'assigned', assignedTo: UUID, deleted: false, embargo: false },
@@ -370,16 +370,16 @@ describe('patronRoles.vue', () => {
                 { principal: 'my:special:group', role: 'canViewOriginals', type: 'assigned', assignedTo: UUID, deleted: false, embargo: false }
             ]);
 
-            let other_entries = wrapper.findAll('.patron-assigned');
-            expect(other_entries.length).toEqual(4);
-            expect(other_entries.at(0).findAll('p').at(0).text()).toEqual('Public users');
-            expect(other_entries.at(0).findAll('select').at(0).element.value).toEqual('canViewMetadata');
-            expect(other_entries.at(1).findAll('p').at(0).text()).toEqual('Authenticated users');
-            expect(other_entries.at(1).findAll('select').at(0).element.value).toEqual('canViewMetadata');
-            expect(other_entries.at(2).findAll('p').at(0).text()).toEqual('Another Group');
-            expect(other_entries.at(2).findAll('select').at(0).element.value).toEqual('canViewAccessCopies');
-            expect(other_entries.at(3).findAll('p').at(0).text()).toEqual('Special Group');
-            expect(other_entries.at(3).findAll('select').at(0).element.value).toEqual('canViewOriginals');
+            let assigned_patrons = wrapper.findAll('.patron-assigned');
+            expect(assigned_patrons.length).toEqual(4);
+            expect(assigned_patrons.at(0).findAll('p').at(0).text()).toEqual('Public users');
+            expect(assigned_patrons.at(0).findAll('select').at(0).element.value).toEqual('canViewMetadata');
+            expect(assigned_patrons.at(1).findAll('p').at(0).text()).toEqual('Authenticated users');
+            expect(assigned_patrons.at(1).findAll('select').at(0).element.value).toEqual('canViewMetadata');
+            expect(assigned_patrons.at(2).findAll('p').at(0).text()).toEqual('Another Group');
+            expect(assigned_patrons.at(2).findAll('select').at(0).element.value).toEqual('canViewAccessCopies');
+            expect(assigned_patrons.at(3).findAll('p').at(0).text()).toEqual('Special Group');
+            expect(assigned_patrons.at(3).findAll('select').at(0).element.value).toEqual('canViewOriginals');
 
             done();
         });
@@ -410,14 +410,14 @@ describe('patronRoles.vue', () => {
             await wrapper.vm.$nextTick();
             expect(wrapper.vm.assignedPatronRoles).toEqual([]);
 
-            let other_entries = wrapper.findAll('.patron-assigned');
-            expect(other_entries.length).toEqual(3);
-            expect(other_entries.at(0).findAll('p').at(0).text()).toEqual('Public users');
-            expect(other_entries.at(0).findAll('select').at(0).element.value).toEqual('canViewAccessCopies');
-            expect(other_entries.at(1).findAll('p').at(0).text()).toEqual('Authenticated users');
-            expect(other_entries.at(1).findAll('select').at(0).element.value).toEqual('canViewAccessCopies');
-            expect(other_entries.at(2).findAll('p').at(0).text()).toEqual('Special Group');
-            expect(other_entries.at(2).findAll('select').at(0).element.value).toEqual('canViewOriginals');
+            let assigned_patrons = wrapper.findAll('.patron-assigned');
+            expect(assigned_patrons.length).toEqual(3);
+            expect(assigned_patrons.at(0).findAll('p').at(0).text()).toEqual('Public users');
+            expect(assigned_patrons.at(0).findAll('select').at(0).element.value).toEqual('canViewAccessCopies');
+            expect(assigned_patrons.at(1).findAll('p').at(0).text()).toEqual('Authenticated users');
+            expect(assigned_patrons.at(1).findAll('select').at(0).element.value).toEqual('canViewAccessCopies');
+            expect(assigned_patrons.at(2).findAll('p').at(0).text()).toEqual('Special Group');
+            expect(assigned_patrons.at(2).findAll('select').at(0).element.value).toEqual('canViewOriginals');
 
             wrapper.find('#user_type_patron').trigger('click');
             await wrapper.vm.$nextTick();

--- a/static/js/admin/vue-permissions-editor/tests/unit/patronRoles.spec.js
+++ b/static/js/admin/vue-permissions-editor/tests/unit/patronRoles.spec.js
@@ -227,29 +227,31 @@ describe('patronRoles.vue', () => {
         };
         stubDataLoad(resp_with_allowed_patrons);
 
-        moxios.wait(() => {
+        moxios.wait(async () => {
             expect(wrapper.vm.patron_roles.assigned.roles.length).toEqual(2);
             expect(wrapper.vm.patron_roles.assigned).toEqual(resp_with_allowed_patrons.assigned);
             expect(wrapper.vm.otherAssignedPrincipals).toEqual([]);
 
             wrapper.find('#add-other-principal').trigger('click');
-            wrapper.find('#add-new-patron-principal option').at(0).setSelected();
-            wrapper.find('#add-new-patron-role option').at(1).setSelected();
+            wrapper.findAll('#add-new-patron-principal-id option').at(0).setSelected();
+            wrapper.findAll('#add-new-patron-principal-role option').at(4).setSelected();
             wrapper.find('#add-other-principal').trigger('click');
 
             expect(wrapper.vm.patron_roles.assigned.roles.length).toEqual(3);
             const assigned_other_roles = [{ principal: 'everyone', role: 'canViewAccessCopies', assignedTo: UUID  },
                 { principal: 'authenticated', role: 'canViewAccessCopies', assignedTo: UUID  },
-                { principal: 'my:special:group', role: 'canViewAccessCopies', assignedTo: UUID  }];
+                { principal: 'my:special:group', role: 'canViewOriginals', assignedTo: UUID  }];
 
-            expect(wrapper.vm.patron_roles.assigned).toEqual(assigned_other_roles);
+            expect(wrapper.vm.patron_roles.assigned.roles).toEqual(assigned_other_roles);
 
-            expect(wrapper.vm.otherAssignedPrincipals).toEqual([assigned_other_roles[2]]);
+            expect(wrapper.vm.otherAssignedPrincipals[0]).toEqual(assigned_other_roles[2]);
+            
+            await wrapper.vm.$nextTick();
 
             let other_entries = wrapper.findAll('.other-patron-assigned');
             expect(other_entries.length).toEqual(1);
             expect(other_entries.at(0).findAll('p').at(0).text()).toEqual('Special Group');
-            expect(other_entries.at(0).findAll('select').at(0).element.value).toEqual('canViewAccessCopies');
+            expect(other_entries.at(0).findAll('select').at(0).element.value).toEqual('canViewOriginals');
 
             done();
         });

--- a/static/js/admin/vue-permissions-editor/tests/unit/patronRoles.spec.js
+++ b/static/js/admin/vue-permissions-editor/tests/unit/patronRoles.spec.js
@@ -109,10 +109,7 @@ describe('patronRoles.vue', () => {
 
         moxios.wait(async () => {
             wrapper.setData({
-                submit_roles: {
-                    embargo: embargo_date
-                },
-                unsaved_changes: true
+                embargo: embargo_date
             });
 
             await wrapper.vm.$nextTick();
@@ -124,6 +121,7 @@ describe('patronRoles.vue', () => {
         });
     });
 
+    // TODO
     it("updates assigned permissions after saving to the server", () => {
         wrapper.setData({
             patron_roles: full_roles,
@@ -157,9 +155,9 @@ describe('patronRoles.vue', () => {
         stubDataLoad();
 
         moxios.wait(() => {
-            expect(wrapper.vm.display_roles).toEqual(response);
-            expect(wrapper.vm.patron_roles).toEqual(response);
-            expect(wrapper.vm.submit_roles).toEqual(response.assigned);
+            expect(wrapper.vm.assignedPatronRoles).toEqual(response.assigned.roles);
+            expect(wrapper.vm.embargo).toEqual(response.assigned.embargo);
+            expect(wrapper.vm.submissionAccessDetails()).toEqual(response.assigned);
             expect(wrapper.vm.dedupedRoles).toEqual([{
                 principal: 'patron',
                 role: 'canViewAccessCopies',
@@ -172,57 +170,16 @@ describe('patronRoles.vue', () => {
         });
     });
 
-    it("renders extra patron roles from the server", (done) => {
-        const assigned_other_roles = [{ principal: 'everyone', role: 'canViewAccessCopies', assignedTo: UUID  },
-            { principal: 'authenticated', role: 'canViewAccessCopies', assignedTo: UUID  },
-            { principal: 'my:special:group', role: 'canViewOriginals', assignedTo: UUID  }];
-        const resp_with_allowed_patrons = {
-            inherited: { roles: inherited_roles, deleted: false, embargo: null, assignedTo: 'null' },
-            assigned: { roles: assigned_other_roles,  deleted: false, embargo: null, assignedTo: UUID },
-            allowedPrincipals: [{ id: "my:special:group", name: "Special Group" }]
-        };
-        const resp_without_extras = cloneDeep(resp_with_allowed_patrons);
-        delete resp_without_extras['allowedPrincipals'];
-        stubDataLoad(resp_with_allowed_patrons);
-
-        moxios.wait(() => {
-            expect(wrapper.vm.patron_roles.assigned.roles.length).toEqual(3);
-            expect(wrapper.vm.display_roles).toEqual(resp_without_extras);
-            expect(wrapper.vm.patron_roles).toEqual(resp_without_extras);
-            expect(wrapper.vm.submit_roles).toEqual(resp_with_allowed_patrons.assigned);
-            expect(wrapper.vm.dedupedRoles).toEqual([
-                { principal: 'everyone', role: 'canViewAccessCopies', type: 'assigned', assignedTo: UUID, deleted: false, embargo: false },
-                { principal: 'authenticated', role: 'canViewAccessCopies', type: 'assigned', assignedTo: UUID, deleted: false, embargo: false },
-                { principal: 'my:special:group', role: 'canViewOriginals', type: 'assigned', assignedTo: UUID, deleted: false, embargo: false }
-            ]);
-
-            expect(wrapper.vm.otherAssignedPrincipals).toEqual([assigned_other_roles[2]]);
-
-            let other_entries = wrapper.findAll('.other-patron-assigned');
-            expect(other_entries.length).toEqual(1);
-            expect(other_entries.at(0).findAll('p').at(0).text()).toEqual('Special Group');
-            expect(other_entries.at(0).findAll('select').at(0).element.value).toEqual('canViewOriginals');
-            done();
-        });
-    });
-
     it("adds an extra patron group", (done) => {
         const resp_with_allowed_patrons = {
             inherited: { roles: inherited_roles, deleted: false, embargo: null, assignedTo: 'null' },
             assigned: { roles: assigned_roles,  deleted: false, embargo: null, assignedTo: UUID },
-            allowedPrincipals: [
-                {
-                    id: "my:special:group",
-                    name: "Special Group"
-                }
-            ]
+            allowedPrincipals: [{ id: "my:special:group", name: "Special Group" }]
         };
         stubDataLoad(resp_with_allowed_patrons);
 
         moxios.wait(async () => {
-            expect(wrapper.vm.patron_roles.assigned.roles.length).toEqual(2);
-            expect(wrapper.vm.patron_roles.assigned).toEqual(resp_with_allowed_patrons.assigned);
-            expect(wrapper.vm.otherAssignedPrincipals).toEqual([]);
+            expect(wrapper.vm.assignedPatronRoles).toEqual(resp_with_allowed_patrons.assigned.roles);
 
             // Click to show the add other principal inputs
             wrapper.find('#add-other-principal').trigger('click');
@@ -232,23 +189,25 @@ describe('patronRoles.vue', () => {
             wrapper.find('#add-other-principal').trigger('click');
 
             // Model should have updated by adding the new role to the list of assigned roles
-            expect(wrapper.vm.patron_roles.assigned.roles.length).toEqual(3);
             const assigned_other_roles = [{ principal: 'everyone', role: 'canViewAccessCopies', assignedTo: UUID  },
                 { principal: 'authenticated', role: 'canViewAccessCopies', assignedTo: UUID  },
                 { principal: 'my:special:group', role: 'canViewOriginals', assignedTo: UUID  }];
-            expect(wrapper.vm.patron_roles.assigned.roles).toEqual(assigned_other_roles);
-            expect(wrapper.vm.otherAssignedPrincipals[0]).toEqual(assigned_other_roles[2]);
+            expect(wrapper.vm.assignedPatronRoles).toEqual(assigned_other_roles);
 
             // Once the UI has refreshed it should now show added entry
             await wrapper.vm.$nextTick();
-            let other_entries = wrapper.findAll('.other-patron-assigned');
-            expect(other_entries.length).toEqual(1);
-            expect(other_entries.at(0).findAll('p').at(0).text()).toEqual('Special Group');
-            expect(other_entries.at(0).findAll('select').at(0).element.value).toEqual('canViewOriginals');
+            let other_entries = wrapper.findAll('.patron-assigned');
+            expect(other_entries.length).toEqual(3);
+            expect(other_entries.at(0).findAll('p').at(0).text()).toEqual('Public users');
+            expect(other_entries.at(0).findAll('select').at(0).element.value).toEqual('canViewAccessCopies');
+            expect(other_entries.at(1).findAll('p').at(0).text()).toEqual('Authenticated users');
+            expect(other_entries.at(1).findAll('select').at(0).element.value).toEqual('canViewAccessCopies');
+            expect(other_entries.at(2).findAll('p').at(0).text()).toEqual('Special Group');
+            expect(other_entries.at(2).findAll('select').at(0).element.value).toEqual('canViewOriginals');
 
             // The new entry inputs should be cleared
             expect(wrapper.vm.add_new_princ_id).toEqual('');
-            expect(wrapper.vm.add_new_princ_role).toEqual('none');
+            expect(wrapper.vm.add_new_princ_role).toEqual('canViewOriginals');
 
             done();
         });
@@ -261,24 +220,13 @@ describe('patronRoles.vue', () => {
         const resp_with_allowed_patrons = {
             inherited: { roles: inherited_roles, deleted: false, embargo: null, assignedTo: 'null' },
             assigned: { roles: assigned_other_roles,  deleted: false, embargo: null, assignedTo: UUID },
-            allowedPrincipals: [
-                {
-                    id: "my:special:group",
-                    name: "Special Group"
-                },
-                {
-                    id: "the:extra:special:group",
-                    name: "Extra Special Group"
-                },
-            ]
+            allowedPrincipals: [{ id: "my:special:group", name: "Special Group" },
+                { id: "the:extra:special:group", name: "Extra Special Group" }]
         };
-        const resp_without_extras = cloneDeep(resp_with_allowed_patrons);
-        delete resp_without_extras['allowedPrincipals'];
         stubDataLoad(resp_with_allowed_patrons);
 
         moxios.wait(async () => {
-            expect(wrapper.vm.patron_roles.assigned.roles.length).toEqual(3);
-            expect(wrapper.vm.otherAssignedPrincipals).toEqual([assigned_other_roles[2]]);
+            expect(wrapper.vm.assignedPatronRoles).toEqual(assigned_other_roles);
 
             // Click to show the add other principal inputs
             wrapper.find('#add-other-principal').trigger('click');
@@ -293,16 +241,20 @@ describe('patronRoles.vue', () => {
             wrapper.findAll('#add-new-patron-principal-id option').at(1).setSelected();
             wrapper.find('#add-other-principal').trigger('click');
 
-            expect(wrapper.vm.otherAssignedPrincipals).toEqual([assigned_other_roles[2],
+            expect(wrapper.vm.assignedPatronRoles).toEqual([assigned_other_roles[0], assigned_other_roles[1], assigned_other_roles[2],
                 { principal: 'the:extra:special:group', role: 'canViewAccessCopies', assignedTo: UUID }]);
 
             await wrapper.vm.$nextTick();
-            let other_entries = wrapper.findAll('.other-patron-assigned');
-            expect(other_entries.length).toEqual(2);
-            expect(other_entries.at(0).findAll('p').at(0).text()).toEqual('Special Group');
-            expect(other_entries.at(0).findAll('select').at(0).element.value).toEqual('canViewOriginals');
-            expect(other_entries.at(1).findAll('p').at(0).text()).toEqual('Extra Special Group');
+            let other_entries = wrapper.findAll('.patron-assigned');
+            expect(other_entries.length).toEqual(4);
+            expect(other_entries.at(0).findAll('p').at(0).text()).toEqual('Public users');
+            expect(other_entries.at(0).findAll('select').at(0).element.value).toEqual('canViewAccessCopies');
+            expect(other_entries.at(1).findAll('p').at(0).text()).toEqual('Authenticated users');
             expect(other_entries.at(1).findAll('select').at(0).element.value).toEqual('canViewAccessCopies');
+            expect(other_entries.at(2).findAll('p').at(0).text()).toEqual('Special Group');
+            expect(other_entries.at(2).findAll('select').at(0).element.value).toEqual('canViewOriginals');
+            expect(other_entries.at(3).findAll('p').at(0).text()).toEqual('Extra Special Group');
+            expect(other_entries.at(3).findAll('select').at(0).element.value).toEqual('canViewAccessCopies');
             done();
         });
     });
@@ -310,44 +262,49 @@ describe('patronRoles.vue', () => {
     it("removes other patron principals", (done) => {
         const assigned_other_roles = [{ principal: 'everyone', role: 'canViewMetadata', assignedTo: UUID  },
             { principal: 'authenticated', role: 'canViewMetadata', assignedTo: UUID  },
-            { principal: 'my:special:group', role: 'canViewOriginals', assignedTo: UUID  },
-            { principal: 'less:special:group', role: 'canViewAccessCopies', assignedTo: UUID  }];
+            { principal: 'less:special:group', role: 'canViewAccessCopies', assignedTo: UUID  },
+            { principal: 'my:special:group', role: 'canViewOriginals', assignedTo: UUID  }];
         const resp_with_allowed_patrons = {
             inherited: { roles: inherited_roles, deleted: false, embargo: null, assignedTo: 'null' },
             assigned: { roles: assigned_other_roles,  deleted: false, embargo: null, assignedTo: UUID },
             allowedPrincipals: [{ id: "my:special:group", name: "Special Group" },
                 { id: "less:special:group", name: "Another Group" }]
         };
-        const resp_without_extras = cloneDeep(resp_with_allowed_patrons);
-        delete resp_without_extras['allowedPrincipals'];
         stubDataLoad(resp_with_allowed_patrons);
 
         moxios.wait(async () => {
-            expect(wrapper.vm.patron_roles.assigned.roles.length).toEqual(4);
-            expect(wrapper.vm.submit_roles).toEqual(resp_with_allowed_patrons.assigned);
+            expect(wrapper.vm.assignedPatronRoles.length).toEqual(4);
+            expect(wrapper.vm.submissionAccessDetails()).toEqual(resp_with_allowed_patrons.assigned);
             expect(wrapper.vm.dedupedRoles).toEqual([
                 { principal: 'everyone', role: 'canViewMetadata', type: 'assigned', assignedTo: UUID, deleted: false, embargo: false },
                 { principal: 'authenticated', role: 'canViewMetadata', type: 'assigned', assignedTo: UUID, deleted: false, embargo: false },
-                { principal: 'my:special:group', role: 'canViewOriginals', type: 'assigned', assignedTo: UUID, deleted: false, embargo: false },
-                { principal: 'less:special:group', role: 'canViewAccessCopies', type: 'assigned', assignedTo: UUID, deleted: false, embargo: false }
+                { principal: 'less:special:group', role: 'canViewAccessCopies', type: 'assigned', assignedTo: UUID, deleted: false, embargo: false },
+                { principal: 'my:special:group', role: 'canViewOriginals', type: 'assigned', assignedTo: UUID, deleted: false, embargo: false }
             ]);
-            expect(wrapper.vm.otherAssignedPrincipals).toEqual([assigned_other_roles[2], assigned_other_roles[3]]);
+            expect(wrapper.vm.assignedPatronRoles).toEqual(assigned_other_roles);
 
             // Click the remove button for the first principal assignment
-            wrapper.findAll("#other_assigned_principals_editor .btn-remove").at(0).trigger('click');
+            wrapper.findAll("#assigned_principals_editor .btn-remove").at(1).trigger('click');
 
             await wrapper.vm.$nextTick();
-            expect(wrapper.vm.patron_roles.assigned.roles.length).toEqual(3);
+            expect(wrapper.vm.assignedPatronRoles.length).toEqual(3);
+            expect(wrapper.vm.assignedPatronRoles).toEqual(
+                [assigned_other_roles[0], assigned_other_roles[1], assigned_other_roles[2]]);
 
-            expect(wrapper.vm.otherAssignedPrincipals).toEqual([assigned_other_roles[3]]);
+            // console.log(wrapper.findAll('.inherited-permissions').at(0).html());
+            // console.log(wrapper.find('#assigned_principals_editor').html());
 
-            let other_entries = wrapper.findAll('.other-patron-assigned');
-            expect(other_entries.length).toEqual(1);
-            expect(other_entries.at(0).findAll('p').at(0).text()).toEqual('Another Group');
-            expect(other_entries.at(0).findAll('select').at(0).element.value).toEqual('canViewAccessCopies');
+            let other_entries = wrapper.findAll('.patron-assigned');
+            expect(other_entries.length).toEqual(3);
+            expect(other_entries.at(0).findAll('p').at(0).text()).toEqual('Public users');
+            expect(other_entries.at(0).findAll('select').at(0).element.value).toEqual('canViewMetadata');
+            expect(other_entries.at(1).findAll('p').at(0).text()).toEqual('Authenticated users');
+            expect(other_entries.at(1).findAll('select').at(0).element.value).toEqual('canViewMetadata');
+            expect(other_entries.at(2).findAll('p').at(0).text()).toEqual('Another Group');
+            expect(other_entries.at(2).findAll('select').at(0).element.value).toEqual('canViewAccessCopies');
 
-            expect(wrapper.vm.submit_roles.roles).toEqual([assigned_other_roles[0],
-                assigned_other_roles[1], assigned_other_roles[3]]);
+            expect(wrapper.vm.submissionAccessDetails().roles).toEqual(
+                [assigned_other_roles[0], assigned_other_roles[1], assigned_other_roles[2]]);
             done();
         });
     });


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-2459

* Adds custom patron groups, which will be matched to users based on IP address ranges
    * these groups are added to the user's access groups at request time via a new PatronPrincipalProvider class
    * groups are defined in a config file
    * custom groups must begin with "unc:patron:" and IP groups should begin with "unc:patron:ipp:"
* Updates patron access control editor to allow for custom patron groups to be added
    * Custom patron groups must be selected from the list of allowable configured patron groups
    * Refactoring to separate some interdependencies, data nesting, depend more on computed methods, adjust previews for custom groups, rendering of all patron groups together.
* Updates access control calculation classes to allow for custom patron groups
    * they operate like the existing patron groups, except if the two standard groups are set to `none`, then the custom group will also be assumed to be `none` unless explicitly set.
* Updates solr indexing of access status field so that the "staff only" flag is not shown when a custom group is active, and a few other related adjustments.