### PR TITLE
BXC-3069 - Deregistration content URI patterns

### DIFF
--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/AbstractLongleafRouteTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/AbstractLongleafRouteTest.java
@@ -20,10 +20,13 @@ import static org.junit.Assert.assertTrue;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.net.URI;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
 import org.slf4j.Logger;
+
+import edu.unc.lib.dl.persist.services.transfer.FileSystemTransferHelpers;
 
 /**
  * @author bbpennel
@@ -61,9 +64,15 @@ public abstract class AbstractLongleafRouteTest {
     protected void assertSubmittedPaths(String... contentUris) {
         for (String contentUri : contentUris) {
             URI uri = URI.create(contentUri);
-            String contentPath = uri.getScheme() == null ? contentUri : Paths.get(uri).toString();
+            Path contentPath;
+            if (uri.getScheme() == null) {
+                contentPath = Paths.get(contentUri);
+            } else {
+                contentPath = Paths.get(uri);
+            }
+            String basePath = FileSystemTransferHelpers.getBaseBinaryPath(contentPath);
             assertTrue("Expected content uri to be submitted: " + contentPath,
-                    output.stream().anyMatch(line -> line.contains(contentPath)));
+                    output.stream().anyMatch(line -> line.contains(basePath)));
         }
     }
 

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/AbstractLongleafRouteTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/AbstractLongleafRouteTest.java
@@ -61,7 +61,7 @@ public abstract class AbstractLongleafRouteTest {
     protected void assertSubmittedPaths(String... contentUris) {
         for (String contentUri : contentUris) {
             URI uri = URI.create(contentUri);
-            String contentPath = Paths.get(uri).toString();
+            String contentPath = uri.getScheme() == null ? contentUri : Paths.get(uri).toString();
             assertTrue("Expected content uri to be submitted: " + contentPath,
                     output.stream().anyMatch(line -> line.contains(contentPath)));
         }

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/DeregisterLongleafRouteTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/DeregisterLongleafRouteTest.java
@@ -50,6 +50,7 @@ import org.springframework.test.context.BootstrapWith;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.ContextHierarchy;
 
+import edu.unc.lib.dl.fcrepo4.PIDs;
 import edu.unc.lib.dl.services.MessageSender;
 
 /**
@@ -132,6 +133,31 @@ public class DeregisterLongleafRouteTest extends AbstractLongleafRouteTest {
         assertTrue("Deregister route not satisfied", result1);
 
         assertSubmittedPaths(5000, contentUris);
+    }
+
+    // Should process file uris, and absolute paths without file://, but not http uris or relative
+    @Test
+    public void deregisterMultipleMixOfSchemes() throws Exception {
+        NotifyBuilder notify = new NotifyBuilder(cdrLongleaf)
+                .whenCompleted(2 + 9)
+                .create();
+
+        String[] contentUris = new String[3*4];
+        String[] successUris = new String[3*2];
+        for (int i = 0; i < 3; i++) {
+            contentUris[i*3] = generateContentUri();
+            successUris[i*2] = contentUris[i*3];
+            contentUris[i*3+1] = "/path/to/file/" + UUID.randomUUID().toString();
+            successUris[i*2+1] = contentUris[i*3+1];
+            contentUris[i*3+2] = PIDs.get(UUID.randomUUID().toString()).getRepositoryPath();
+            contentUris[i*3+3] = "file/" + UUID.randomUUID().toString();
+        }
+        sendMessages(contentUris);
+
+        boolean result1 = notify.matches(5l, TimeUnit.SECONDS);
+        assertTrue("Deregister route not satisfied", result1);
+
+        assertSubmittedPaths(10000, successUris);
     }
 
     @SuppressWarnings("unchecked")

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/DeregisterLongleafRouteTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/longleaf/DeregisterLongleafRouteTest.java
@@ -231,7 +231,7 @@ public class DeregisterLongleafRouteTest extends AbstractLongleafRouteTest {
     }
 
     private String generateContentUri() {
-        return "file:///path/to/file/" + UUID.randomUUID().toString();
+        return "file:///path/to/file/" + UUID.randomUUID().toString() + "." + System.nanoTime();
     }
 
     private String[] generateContentUris(int num) {


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3069

* Converts content URIs of binaries being destroyed into base form before submission to longleaf, as longleaf requires the logical path of the file.
* During deregistration, filters out content URIs which are not file paths. There have been instances in the past where PIDs were being supplied as content URIs, causing deregistration to fail.