### PR TITLE
BXC-3043 - MODS Title and Collection Number in Add Container

### DIFF
--- a/metadata/src/main/java/edu/unc/lib/dl/util/DescriptionConstants.java
+++ b/metadata/src/main/java/edu/unc/lib/dl/util/DescriptionConstants.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.util;
+
+/**
+ * Constants used in description records
+ * @author bbpennel
+ */
+public class DescriptionConstants {
+    public static final String COLLECTION_NUMBER_EL = "identifier";
+    public static final String COLLECTION_NUMBER_TYPE = "local";
+    public static final String COLLECTION_NUMBER_LABEL = "Collection Number";
+
+    private DescriptionConstants() {
+    }
+}

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/modify/AddContainerController.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/modify/AddContainerController.java
@@ -18,25 +18,21 @@ package edu.unc.lib.dl.cdr.services.rest.modify;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.jena.rdf.model.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 import edu.unc.lib.dl.acl.exception.AccessRestrictionException;
 import edu.unc.lib.dl.acl.util.AgentPrincipals;
 import edu.unc.lib.dl.cdr.services.processing.AddContainerService;
-import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.cdr.services.processing.AddContainerService.AddContainerRequest;
 import edu.unc.lib.dl.fedora.AuthorizationException;
-import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.rdf.Cdr;
 
 /**
@@ -54,45 +50,35 @@ public class AddContainerController {
 
     @RequestMapping(value = "edit/create/adminUnit/{id}", method = RequestMethod.POST)
     @ResponseBody
-    public ResponseEntity<Object> createAdminUnit(@PathVariable("id") String id,
-                                                  @RequestParam("label") String label) {
-        return createContainer(id, label, false, Cdr.AdminUnit);
+    public ResponseEntity<Object> createAdminUnit(AddContainerRequest addRequest) {
+        return createContainer(addRequest.withContainerType(Cdr.AdminUnit));
     }
 
     @RequestMapping(value = "edit/create/collection/{id}", method = RequestMethod.POST)
     @ResponseBody
-    public ResponseEntity<Object> createCollection(@PathVariable("id") String id, @RequestParam("label") String label,
-                                                   @RequestParam(value = "staffOnly", defaultValue = "false")
-                                                           boolean staffOnly) {
-        return createContainer(id, label, staffOnly, Cdr.Collection);
+    public ResponseEntity<Object> createCollection(AddContainerRequest addRequest) {
+        return createContainer(addRequest.withContainerType(Cdr.Collection));
     }
 
     @RequestMapping(value = "edit/create/folder/{id}", method = RequestMethod.POST)
     @ResponseBody
-    public ResponseEntity<Object> createFolder(@PathVariable("id") String id, @RequestParam("label") String label,
-                                               @RequestParam(value = "staffOnly", defaultValue = "false")
-                                                       boolean staffOnly) {
-        return createContainer(id, label, staffOnly, Cdr.Folder);
+    public ResponseEntity<Object> createFolder(AddContainerRequest addRequest) {
+        return createContainer(addRequest.withContainerType(Cdr.Folder));
     }
 
     @RequestMapping(value = "edit/create/work/{id}", method = RequestMethod.POST)
     @ResponseBody
-    public ResponseEntity<Object> createWork(@PathVariable("id") String id, @RequestParam("label") String label) {
-        return createContainer(id, label, false, Cdr.Work);
+    public ResponseEntity<Object> createWork(AddContainerRequest addRequest) {
+        return createContainer(addRequest.withContainerType(Cdr.Work));
     }
 
-    private ResponseEntity<Object> createContainer(String id, String label, boolean staff_only,
-                                                   Resource containerType) {
+    private ResponseEntity<Object> createContainer(AddContainerRequest addRequest) {
         Map<String, Object> result = new HashMap<>();
         result.put("action", "create");
-        result.put("pid", id);
-
-        PID parentPid = PIDs.get(id);
+        result.put("pid", addRequest.getParentPid().getId());
 
         try {
-            addContainerService.addContainer(
-                    AgentPrincipals.createFromThread(), parentPid, label, staff_only, containerType
-            );
+            addContainerService.addContainer(addRequest.withAgent(AgentPrincipals.createFromThread()));
         } catch (Exception e) {
             result.put("error", e.getMessage());
             Throwable t = e.getCause();

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/modify/AddContainerController.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/modify/AddContainerController.java
@@ -33,7 +33,7 @@ import edu.unc.lib.dl.acl.util.AgentPrincipals;
 import edu.unc.lib.dl.cdr.services.processing.AddContainerService;
 import edu.unc.lib.dl.cdr.services.processing.AddContainerService.AddContainerRequest;
 import edu.unc.lib.dl.fedora.AuthorizationException;
-import edu.unc.lib.dl.rdf.Cdr;
+import edu.unc.lib.dl.util.ResourceType;
 
 /**
  * API controller for creating new containers
@@ -51,25 +51,25 @@ public class AddContainerController {
     @RequestMapping(value = "edit/create/adminUnit/{id}", method = RequestMethod.POST)
     @ResponseBody
     public ResponseEntity<Object> createAdminUnit(AddContainerRequest addRequest) {
-        return createContainer(addRequest.withContainerType(Cdr.AdminUnit));
+        return createContainer(addRequest.withContainerType(ResourceType.AdminUnit));
     }
 
     @RequestMapping(value = "edit/create/collection/{id}", method = RequestMethod.POST)
     @ResponseBody
     public ResponseEntity<Object> createCollection(AddContainerRequest addRequest) {
-        return createContainer(addRequest.withContainerType(Cdr.Collection));
+        return createContainer(addRequest.withContainerType(ResourceType.Collection));
     }
 
     @RequestMapping(value = "edit/create/folder/{id}", method = RequestMethod.POST)
     @ResponseBody
     public ResponseEntity<Object> createFolder(AddContainerRequest addRequest) {
-        return createContainer(addRequest.withContainerType(Cdr.Folder));
+        return createContainer(addRequest.withContainerType(ResourceType.Folder));
     }
 
     @RequestMapping(value = "edit/create/work/{id}", method = RequestMethod.POST)
     @ResponseBody
     public ResponseEntity<Object> createWork(AddContainerRequest addRequest) {
-        return createContainer(addRequest.withContainerType(Cdr.Work));
+        return createContainer(addRequest.withContainerType(ResourceType.Work));
     }
 
     private ResponseEntity<Object> createContainer(AddContainerRequest addRequest) {

--- a/services/src/main/webapp/WEB-INF/service-context.xml
+++ b/services/src/main/webapp/WEB-INF/service-context.xml
@@ -244,6 +244,7 @@
         <property name="transactionManager" ref="transactionManager" />
         <property name="operationsMessageSender" ref="operationsMessageSender" />
         <property name="storageLocationManager" ref="storageLocationManager" />
+        <property name="updateDescriptionService" ref="updateDescriptionService" />
     </bean>
     
     <bean id="editFilenameService" class="edu.unc.lib.dl.persist.services.edit.EditFilenameService">

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/processing/AddContainerServiceTest.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/processing/AddContainerServiceTest.java
@@ -63,6 +63,7 @@ import edu.unc.lib.dl.fedora.ObjectTypeMismatchException;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.persist.api.storage.StorageLocation;
 import edu.unc.lib.dl.persist.api.storage.StorageLocationManager;
+import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService;
 import edu.unc.lib.dl.rdf.Cdr;
 import edu.unc.lib.dl.rdf.Premis;
 import edu.unc.lib.dl.services.OperationsMessageSender;
@@ -99,6 +100,8 @@ public class AddContainerServiceTest {
     private StorageLocationManager storageLocationManager;
     @Mock
     private StorageLocation storageLocation;
+    @Mock
+    private UpdateDescriptionService updateDescService;
 
     @Captor
     private ArgumentCaptor<Collection<PID>> destinationsCaptor;
@@ -145,6 +148,7 @@ public class AddContainerServiceTest {
         service.setTransactionManager(txManager);
         service.setOperationsMessageSender(messageSender);
         service.setStorageLocationManager(storageLocationManager);
+        service.setUpdateDescriptionService(updateDescService);
     }
 
     private AddContainerRequest createRequest(String label, boolean staffOnly, Resource containerType) {

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/processing/AddContainerServiceTest.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/processing/AddContainerServiceTest.java
@@ -68,6 +68,7 @@ import edu.unc.lib.dl.rdf.Cdr;
 import edu.unc.lib.dl.rdf.Premis;
 import edu.unc.lib.dl.services.OperationsMessageSender;
 import edu.unc.lib.dl.test.SelfReturningAnswer;
+import edu.unc.lib.dl.util.ResourceType;
 
 /**
  *
@@ -151,7 +152,7 @@ public class AddContainerServiceTest {
         service.setUpdateDescriptionService(updateDescService);
     }
 
-    private AddContainerRequest createRequest(String label, boolean staffOnly, Resource containerType) {
+    private AddContainerRequest createRequest(String label, boolean staffOnly, ResourceType containerType) {
         AddContainerRequest req = new AddContainerRequest();
         req.setParentPid(parentPid);
         req.setLabel(label);
@@ -165,7 +166,7 @@ public class AddContainerServiceTest {
                 .assertHasAccess(anyString(), eq(parentPid), any(AccessGroupSet.class), eq(ingest));
 
         try {
-            service.addContainer(createRequest("folder", false, Cdr.Folder));
+            service.addContainer(createRequest("folder", false, ResourceType.Folder));
         } catch (TransactionCancelledException e) {
             assertEquals(AccessRestrictionException.class, e.getCause().getClass());
             throw new TransactionCancelledException();
@@ -181,7 +182,7 @@ public class AddContainerServiceTest {
         doThrow(new ObjectTypeMismatchException("")).when(folder).addMember(collection);
 
         try {
-            service.addContainer(createRequest("collection", false, Cdr.Collection));
+            service.addContainer(createRequest("collection", false, ResourceType.Collection));
         } catch (TransactionCancelledException e) {
             assertEquals(ObjectTypeMismatchException.class, e.getCause().getClass());
             throw new TransactionCancelledException();
@@ -203,7 +204,7 @@ public class AddContainerServiceTest {
         });
         when(folder.getPremisLog()).thenReturn(premisLogger);
 
-        service.addContainer(createRequest("folder", false, Cdr.Folder));
+        service.addContainer(createRequest("folder", false, ResourceType.Folder));
 
         verify(premisLogger).buildEvent(eq(Premis.Creation));
         verify(eventBuilder).writeAndClose();
@@ -239,7 +240,7 @@ public class AddContainerServiceTest {
         });
         when(work.getPremisLog()).thenReturn(premisLogger);
 
-        service.addContainer(createRequest("work", false, Cdr.Work));
+        service.addContainer(createRequest("work", false, ResourceType.Work));
 
         verify(premisLogger).buildEvent(eq(Premis.Creation));
         verify(eventBuilder).writeAndClose();

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/AddContainerIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/AddContainerIT.java
@@ -20,6 +20,7 @@ import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.PUBLIC_PRINC;
 import static edu.unc.lib.dl.acl.util.UserRole.canViewOriginals;
 import static edu.unc.lib.dl.acl.util.UserRole.none;
 import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.CONTENT_ROOT_ID;
+import static edu.unc.lib.dl.xml.SecureXMLFactory.createSAXBuilder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -29,6 +30,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.Map;
 
 import org.apache.jena.rdf.model.Resource;
+import org.jdom2.Document;
+import org.jdom2.input.SAXBuilder;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.test.context.ContextConfiguration;
@@ -48,6 +51,7 @@ import edu.unc.lib.dl.fcrepo4.WorkObject;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.rdf.DcElements;
 import edu.unc.lib.dl.test.AclModelBuilder;
+import edu.unc.lib.dl.xml.JDOMNamespaceUtil;
 
 /**
  *
@@ -390,6 +394,14 @@ public class AddContainerIT extends AbstractAPIIT {
     private void assertChildContainerAdded(ContentContainerObject parent, String label, Class<?> memberClass) {
         ContentObject member = getMemberByLabel(parent, label);
         assertTrue(memberClass.isInstance(member));
+    }
+
+    public void assertModsPopulated(ContentObject member, String label) throws Exception {
+        SAXBuilder sb = createSAXBuilder();
+        Document doc = sb.build(member.getDescription().getBinaryStream());
+        String title = doc.getRootElement().getChild("titleInfo", JDOMNamespaceUtil.MODS_V3_NS)
+                .getChildText("title", JDOMNamespaceUtil.MODS_V3_NS);
+        assertEquals("Title did not match expected value", label, title);
     }
 
     private void assertChildContainerNotAdded(ContentContainerObject parent) {

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/AddContainerIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/AddContainerIT.java
@@ -20,9 +20,13 @@ import static edu.unc.lib.dl.acl.util.AccessPrincipalConstants.PUBLIC_PRINC;
 import static edu.unc.lib.dl.acl.util.UserRole.canViewOriginals;
 import static edu.unc.lib.dl.acl.util.UserRole.none;
 import static edu.unc.lib.dl.fcrepo4.RepositoryPathConstants.CONTENT_ROOT_ID;
+import static edu.unc.lib.dl.util.DescriptionConstants.COLLECTION_NUMBER_EL;
+import static edu.unc.lib.dl.util.DescriptionConstants.COLLECTION_NUMBER_LABEL;
+import static edu.unc.lib.dl.xml.JDOMNamespaceUtil.MODS_V3_NS;
 import static edu.unc.lib.dl.xml.SecureXMLFactory.createSAXBuilder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -31,6 +35,7 @@ import java.util.Map;
 
 import org.apache.jena.rdf.model.Resource;
 import org.jdom2.Document;
+import org.jdom2.Element;
 import org.jdom2.input.SAXBuilder;
 import org.junit.Before;
 import org.junit.Test;
@@ -51,7 +56,7 @@ import edu.unc.lib.dl.fcrepo4.WorkObject;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.rdf.DcElements;
 import edu.unc.lib.dl.test.AclModelBuilder;
-import edu.unc.lib.dl.xml.JDOMNamespaceUtil;
+import edu.unc.lib.dl.util.DescriptionConstants;
 
 /**
  *
@@ -341,7 +346,7 @@ public class AddContainerIT extends AbstractAPIIT {
 
         treeIndexer.indexAll(baseAddress);
 
-        String label = "collection";
+        String label = "staff only collection";
         String adminId = adminUnit.getPid().getId();
         MvcResult result = mvc.perform(post("/edit/create/collection/" + adminId)
                 .param("label", label)
@@ -360,6 +365,39 @@ public class AddContainerIT extends AbstractAPIIT {
         ContentObject member = getMemberByLabel(adminUnit, label);
         assertHasAssignment(PUBLIC_PRINC, none, member);
         assertHasAssignment(AUTHENTICATED_PRINC, none, member);
+
+        assertModsPopulated(member, label, null);
+    }
+
+    @Test
+    public void testAddCollectionWithCollectionNumber() throws UnsupportedOperationException, Exception {
+        AdminUnit adminUnit = repositoryObjectFactory.createAdminUnit(null);
+        contentRoot.addMember(adminUnit);
+
+        treeIndexer.indexAll(baseAddress);
+
+        String label = "collection with number";
+        String collNum = "12345678";
+        String adminId = adminUnit.getPid().getId();
+        MvcResult result = mvc.perform(post("/edit/create/collection/" + adminId)
+                .param("label", label)
+                .param("collectionNumber", collNum))
+                .andExpect(status().is2xxSuccessful())
+                .andReturn();
+
+        treeIndexer.indexAll(baseAddress);
+
+        assertChildContainerAdded(adminUnit, label, CollectionObject.class);
+
+        // Verify response from api
+        Map<String, Object> respMap = getMapFromResponse(result);
+        assertEquals(adminId, respMap.get("pid"));
+        assertEquals("create", respMap.get("action"));
+        ContentObject member = getMemberByLabel(adminUnit, label);
+        assertHasAssignment(PUBLIC_PRINC, canViewOriginals, member);
+        assertHasAssignment(AUTHENTICATED_PRINC, canViewOriginals, member);
+
+        assertModsPopulated(member, label, collNum);
     }
 
     @Test
@@ -396,12 +434,21 @@ public class AddContainerIT extends AbstractAPIIT {
         assertTrue(memberClass.isInstance(member));
     }
 
-    public void assertModsPopulated(ContentObject member, String label) throws Exception {
+    public void assertModsPopulated(ContentObject member, String label, String expectedCollNum) throws Exception {
         SAXBuilder sb = createSAXBuilder();
         Document doc = sb.build(member.getDescription().getBinaryStream());
-        String title = doc.getRootElement().getChild("titleInfo", JDOMNamespaceUtil.MODS_V3_NS)
-                .getChildText("title", JDOMNamespaceUtil.MODS_V3_NS);
+        String title = doc.getRootElement().getChild("titleInfo", MODS_V3_NS)
+                .getChildText("title", MODS_V3_NS);
         assertEquals("Title did not match expected value", label, title);
+
+        Element idEl = doc.getRootElement().getChild(COLLECTION_NUMBER_EL, MODS_V3_NS);
+        if (expectedCollNum != null) {
+            assertEquals(COLLECTION_NUMBER_LABEL, idEl.getAttributeValue("displayLabel"));
+            assertEquals(DescriptionConstants.COLLECTION_NUMBER_TYPE, idEl.getAttributeValue("type"));
+            assertEquals(expectedCollNum, idEl.getText());
+        } else {
+            assertNull(idEl);
+        }
     }
 
     private void assertChildContainerNotAdded(ContentContainerObject parent) {

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/AddContainerIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/AddContainerIT.java
@@ -156,7 +156,7 @@ public class AddContainerIT extends AbstractAPIIT {
 
         String label = "folder_label";
         String staffOnly = "false";
-        MvcResult result = mvc.perform(post("/edit/create/folder/" + collObj.getPid().getId())
+        mvc.perform(post("/edit/create/folder/" + collObj.getPid().getId())
                 .param("label", label)
                 .param("staffOnly", staffOnly))
                 .andExpect(status().is4xxClientError())
@@ -176,7 +176,7 @@ public class AddContainerIT extends AbstractAPIIT {
 
         String label = "folder_label";
         String staffOnly = "true";
-        MvcResult result = mvc.perform(post("/edit/create/folder/" + collObj.getPid().getId())
+        mvc.perform(post("/edit/create/folder/" + collObj.getPid().getId())
                 .param("label", label)
                 .param("staffOnly", staffOnly))
                 .andExpect(status().is4xxClientError())

--- a/services/src/test/resources/add-container-it-servlet.xml
+++ b/services/src/test/resources/add-container-it-servlet.xml
@@ -40,6 +40,7 @@
         <property name="transactionManager" ref="transactionManager" />
         <property name="operationsMessageSender" ref="operationsMessageSender" />
         <property name="storageLocationManager" ref="storageLocationManager" />
+        <property name="updateDescriptionService" ref="updateDescriptionService" />
     </bean>
 
     <bean id="patronService" class="edu.unc.lib.dl.persist.services.acl.PatronAccessAssignmentService">

--- a/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetDescriptiveMetadataFilter.java
+++ b/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetDescriptiveMetadataFilter.java
@@ -15,6 +15,9 @@
  */
 package edu.unc.lib.dl.data.ingest.solr.filter;
 
+import static edu.unc.lib.dl.util.DescriptionConstants.COLLECTION_NUMBER_EL;
+import static edu.unc.lib.dl.util.DescriptionConstants.COLLECTION_NUMBER_LABEL;
+import static edu.unc.lib.dl.util.DescriptionConstants.COLLECTION_NUMBER_TYPE;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.io.IOException;
@@ -263,7 +266,7 @@ public class SetDescriptiveMetadataFilter implements IndexDocumentFilter {
     }
 
     private void extractCollectionId(Element mods, IndexDocumentBean idb) {
-        List<Element> identifiers = mods.getChildren("identifier", JDOMNamespaceUtil.MODS_V3_NS);
+        List<Element> identifiers = mods.getChildren(COLLECTION_NUMBER_EL, JDOMNamespaceUtil.MODS_V3_NS);
         String collectionId = null;
 
         if (!identifiers.isEmpty()) {
@@ -275,7 +278,8 @@ public class SetDescriptiveMetadataFilter implements IndexDocumentFilter {
                     continue;
                 }
 
-                if (collection.getValue().equals("Collection Number") && type.getValue().equals("local")) {
+                if (collection.getValue().equals(COLLECTION_NUMBER_LABEL)
+                        && type.getValue().equals(COLLECTION_NUMBER_TYPE)) {
                     collectionId = aid.getValue();
                     break;
                 }

--- a/static/js/admin/src/CreateContainerForm.js
+++ b/static/js/admin/src/CreateContainerForm.js
@@ -46,6 +46,7 @@ define('CreateContainerForm', [ 'jquery', 'jquery-ui', 'underscore', 'RemoteStat
 	
 	CreateContainerForm.prototype.preprocessForm = function(resultObject) {
 		this.containerName = $("input[name='name']", this.$form).val();
+		let collNumber = $("input[name='coll_number']", this.$form).val();
 		this.staffOnly = $("input[name='staff_only']", this.$form);
 
 		var pid;
@@ -58,6 +59,9 @@ define('CreateContainerForm', [ 'jquery', 'jquery-ui', 'underscore', 'RemoteStat
 		var typeName = this.options.containerType.charAt(0).toLowerCase() + this.options.containerType.substr(1);
 		var apiUrl = "/services/api/edit/create/" + typeName + "/" + pid + "?label=" + this.containerName;
 
+		if (collNumber !== undefined && collNumber.length > 0) {
+			apiUrl += "&collectionNumber=" + collNumber;
+		}
 		if (this.staffOnly.length > 0) {
 			apiUrl += "&staffOnly=" + this.staffOnly.is(':checked');
 		}

--- a/static/templates/admin/createContainerForm.html
+++ b/static/templates/admin/createContainerForm.html
@@ -1,8 +1,14 @@
 <form id="create_container_form" method="post" class="edit_form">
 	<div class="form_field">
-		<label><%= options.containerType %> Name*</label>
-		<input name="name" size="38"></input>
+		<label for="add_container_name"><%= options.containerType %> Name <span class="required">*</span></label>
+		<input name="name" id="add_container_name" size="38"></input>
 	</div>
+	<% if (options.containerType == "Collection") { %>
+		<div class="form_field">
+			<label for="add_container_coll_number">Collection Number</label>
+			<input name="coll_number" id="add_container_coll_number" size="38"></input>
+		</div>
+	<% } %>
 	<% if (options.staffOnly) { %>
 		<div class="form_field">
 			<label for="staff_only">Restrict to staff only access?</label>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3043

* In the Add Container workflow, the label field is now added to a mods:titleInfo/mods:title field in addition to the dc:title rdf field
* When creating a collection, the user may optionally add a Collection Number field.
* Refactored AddContainerService and controller to take a AddContainerRequest object, since the number of parameters was getting excessive.