### PR TITLE
BXC-3096 - Skip viewers for Appledouble files

### DIFF
--- a/access-common/src/main/java/edu/unc/lib/dl/ui/util/DatastreamUtil.java
+++ b/access-common/src/main/java/edu/unc/lib/dl/ui/util/DatastreamUtil.java
@@ -43,6 +43,7 @@ public class DatastreamUtil {
     public static void setDatastreamEndpoint(String uri) {
         datastreamEndpoint = uri;
     }
+
     /**
      * Returns a URL for retrieving a specific datastream of the provided object.
      *
@@ -87,6 +88,31 @@ public class DatastreamUtil {
      */
     public static String getOriginalFileUrl(BriefObjectMetadata metadata) {
         return getDatastreamUrl(metadata, ORIGINAL_FILE.getId());
+    }
+
+    /**
+     * @param metadata metadata record for object
+     * @return Get the mimetype of the original file datastream, or null if no original file
+     */
+    public static String getOriginalFileMimetype(BriefObjectMetadata metadata) {
+        Datastream preferredDS = getPreferredDatastream(metadata, ORIGINAL_FILE.getId());
+        if (preferredDS == null) {
+            return null;
+        }
+        return preferredDS.getMimetype();
+    }
+
+    /**
+     * @param metadata metadata record for object
+     * @param suffix mimetype suffix
+     * @return
+     */
+    public static boolean originalFileMimetypeMatches(BriefObjectMetadata metadata, String pattern) {
+        String mimetype = getOriginalFileMimetype(metadata);
+        if (mimetype == null) {
+            return false;
+        }
+        return mimetype.matches(pattern);
     }
 
     /**

--- a/access-common/src/main/resources/META-INF/cdrUI.tld
+++ b/access-common/src/main/resources/META-INF/cdrUI.tld
@@ -77,6 +77,20 @@
 		</function-signature>
 	</function>
 	<function>
+		<name>originalFileMimetypeMatches</name>
+		<function-class>edu.unc.lib.dl.ui.util.DatastreamUtil</function-class>
+		<function-signature>
+			boolean originalFileMimetypeMatches(edu.unc.lib.dl.search.solr.model.BriefObjectMetadata, java.lang.String)
+		</function-signature>
+	</function>
+	<function>
+		<name>getOriginalFileMimetype</name>
+		<function-class>edu.unc.lib.dl.ui.util.DatastreamUtil</function-class>
+		<function-signature>
+			java.lang.String getOriginalFileMimetype(edu.unc.lib.dl.search.solr.model.BriefObjectMetadata)
+		</function-signature>
+	</function>
+	<function>
 		<name>getPreferredDatastream</name>
 		<function-class>edu.unc.lib.dl.ui.util.DatastreamUtil</function-class>
 		<function-signature>

--- a/access/src/main/webapp/WEB-INF/jsp/fullRecord/aggregateRecord.jsp
+++ b/access/src/main/webapp/WEB-INF/jsp/fullRecord/aggregateRecord.jsp
@@ -33,6 +33,7 @@
 </c:choose>
 
 <c:set var="dataFileUrl">${cdr:getOriginalFileUrl(briefObject)}</c:set>
+<c:set var="hasOriginalFileAccess">${permsHelper.hasOriginalAccess(requestScope.accessGroupSet, briefObject)}</c:set>
 
 <div class="full_record_top">
             <div class="collinfo_metadata browse-header aggregate-record">
@@ -49,7 +50,7 @@
                         </c:if>
 
                         <c:choose>
-                            <c:when test="${permsHelper.hasOriginalAccess(requestScope.accessGroupSet, briefObject)}">
+                            <c:when test="${hasOriginalFileAccess}">
                                 <div class="actionlink right download">
                                     <a class="button" href="${dataFileUrl}?dl=true"><i class="fa fa-download"></i> Download</a>
                                 </div>
@@ -136,7 +137,7 @@
 
             <div class="clear">
                 <c:choose>
-                    <c:when test="${cdr:originalFileMimetypeMatches(briefObject, 'application/(x-)?pdf')}">
+                    <c:when test="${hasOriginalFileAccess && cdr:originalFileMimetypeMatches(briefObject, 'application/(x-)?pdf')}">
                         <c:import url="fullRecord/pdfViewer.jsp" />
                     </c:when>
                     <c:when test="${viewerNeeded}">
@@ -144,14 +145,10 @@
                         <link rel="stylesheet" href="/static/plugins/uv/uv.css">
                         <div id="jp2_viewer" class="jp2_imageviewer_window" data-url="${briefObject.id}"></div>
                     </c:when>
-                    <c:when test="${permsHelper.hasOriginalAccess(requestScope.accessGroupSet, briefObject)}">
-                        <c:choose>
-                            <c:if test="${cdr:originalFileMimetypeMatches(briefObject, 'audio/(x-)?mpeg(-?3)?')}">
-                                <div class="clear_space"></div>
-                                <audio class="audio_player inline_viewer" src="${dataFileUrl}">
-                                </audio>
-                            </c:when>
-                        </c:choose>
+                    <c:when test="${hasOriginalFileAccess && cdr:originalFileMimetypeMatches(briefObject, 'audio/(x-)?mpeg(-?3)?')}">
+                        <div class="clear_space"></div>
+                        <audio class="audio_player inline_viewer" src="${dataFileUrl}">
+                        </audio>
                     </c:when>
                 </c:choose>
             </div>

--- a/access/src/main/webapp/WEB-INF/jsp/fullRecord/aggregateRecord.jsp
+++ b/access/src/main/webapp/WEB-INF/jsp/fullRecord/aggregateRecord.jsp
@@ -136,7 +136,7 @@
 
             <div class="clear">
                 <c:choose>
-                    <c:when test="${briefObject.contentTypeFacet[0].displayValue == 'pdf'}">
+                    <c:when test="${cdr:originalFileMimetypeMatches(briefObject, 'application/(x-)?pdf')}">
                         <c:import url="fullRecord/pdfViewer.jsp" />
                     </c:when>
                     <c:when test="${viewerNeeded}">
@@ -146,7 +146,7 @@
                     </c:when>
                     <c:when test="${permsHelper.hasOriginalAccess(requestScope.accessGroupSet, briefObject)}">
                         <c:choose>
-                            <c:when test="${briefObject.contentTypeFacet[0].displayValue == 'mp3'}">
+                            <c:if test="${cdr:originalFileMimetypeMatches(briefObject, 'audio/(x-)?mpeg(-?3)?')}">
                                 <div class="clear_space"></div>
                                 <audio class="audio_player inline_viewer" src="${dataFileUrl}">
                                 </audio>

--- a/access/src/main/webapp/WEB-INF/jsp/fullRecord/fileRecord.jsp
+++ b/access/src/main/webapp/WEB-INF/jsp/fullRecord/fileRecord.jsp
@@ -23,6 +23,8 @@
 <%@ taglib prefix="cdr" uri="http://cdr.lib.unc.edu/cdrUI"%>
 <%@ taglib prefix="s" uri="http://www.springframework.org/tags" %>
 
+<c:set var="hasOriginalFileAccess">${permsHelper.hasOriginalAccess(requestScope.accessGroupSet, briefObject)}</c:set>
+
 <div class="full_record_top">
     <div class="collinfo_metadata browse-header column">
         <c:import url="fullRecord/navigationBar.jsp" />
@@ -119,7 +121,7 @@
     </div>
     <div class="clear">
         <c:choose>
-            <c:when test="${cdr:originalFileMimetypeMatches(briefObject, 'application/(x-)?pdf')}">
+            <c:when test="${hasOriginalFileAccess && cdr:originalFileMimetypeMatches(briefObject, 'application/(x-)?pdf')}">
                 <c:import url="fullRecord/pdfViewer.jsp" />
             </c:when>
             <c:when test="${permsHelper.hasImagePreviewAccess(requestScope.accessGroupSet, briefObject)}">
@@ -127,12 +129,10 @@
                 <div class="clear_space"></div>
                 <div id="jp2_viewer" class="jp2_imageviewer_window" data-url='${briefObject.id}'></div>
             </c:when>
-            <c:when test="${permsHelper.hasOriginalAccess(requestScope.accessGroupSet, briefObject)}">
-                <c:if test="${cdr:originalFileMimetypeMatches(briefObject, 'audio/(x-)?mpeg(-?3)?')}">
-                    <div class="clear_space"></div>
-                    <audio class="audio_player inline_viewer" src="${cdr:getOriginalFileUrl(briefObject)}">
-                    </audio>
-                </c:if>
+            <c:when test="${hasOriginalFileAccess && cdr:originalFileMimetypeMatches(briefObject, 'audio/(x-)?mpeg(-?3)?')}">
+                <div class="clear_space"></div>
+                <audio class="audio_player inline_viewer" src="${cdr:getOriginalFileUrl(briefObject)}">
+                </audio>
             </c:when>
         </c:choose>
     </div>

--- a/access/src/main/webapp/WEB-INF/jsp/fullRecord/fileRecord.jsp
+++ b/access/src/main/webapp/WEB-INF/jsp/fullRecord/fileRecord.jsp
@@ -119,7 +119,7 @@
     </div>
     <div class="clear">
         <c:choose>
-            <c:when test="${briefObject.contentTypeFacet[0].displayValue == 'pdf'}">
+            <c:when test="${cdr:originalFileMimetypeMatches(briefObject, 'application/(x-)?pdf')}">
                 <c:import url="fullRecord/pdfViewer.jsp" />
             </c:when>
             <c:when test="${permsHelper.hasImagePreviewAccess(requestScope.accessGroupSet, briefObject)}">
@@ -128,7 +128,7 @@
                 <div id="jp2_viewer" class="jp2_imageviewer_window" data-url='${briefObject.id}'></div>
             </c:when>
             <c:when test="${permsHelper.hasOriginalAccess(requestScope.accessGroupSet, briefObject)}">
-                <c:if test="${briefObject.contentTypeFacet[0].displayValue == 'mp3'}">
+                <c:if test="${cdr:originalFileMimetypeMatches(briefObject, 'audio/(x-)?mpeg(-?3)?')}">
                     <div class="clear_space"></div>
                     <audio class="audio_player inline_viewer" src="${cdr:getOriginalFileUrl(briefObject)}">
                     </audio>

--- a/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetContentTypeFilter.java
+++ b/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetContentTypeFilter.java
@@ -78,16 +78,14 @@ public class SetContentTypeFilter implements IndexDocumentFilter {
 
     private FileObject getFileObject(DocumentIndexingPackage dip) throws IndexingException {
         ContentObject obj = dip.getContentObject();
-        FileObject fileObj;
         if (obj instanceof WorkObject) {
-            fileObj = ((WorkObject) obj).getPrimaryObject();
+            return ((WorkObject) obj).getPrimaryObject();
         } else if (obj instanceof FileObject) {
-            fileObj = (FileObject) obj;
+            return (FileObject) obj;
         } else {
             // object being indexed must be a work or a file object
-            fileObj = null;
+            return null;
         }
-        return fileObj;
     }
 
     private String getExtension(String filepath, String mimetype) {

--- a/solr-ingest/src/main/resources/edu/unc/lib/dl/data/ingest/solr/filter/toContentType.properties
+++ b/solr-ingest/src/main/resources/edu/unc/lib/dl/data/ingest/solr/filter/toContentType.properties
@@ -61,3 +61,4 @@ ext.zip=archive
 ext.dmg=diskimage
 ext.iso=diskimage
 ext.disk=diskimage
+mime.multipart/appledouble=unknown


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3096

* Checks mimetype to determine if pdf and mp3 viewers should be shown
* contentType field now indexes appledouble files as "unknown" category rather than the type of the actual file the sidecar file is describing
    * Fixes bug where mimetype to content type category mapping was being overridden by extension to category mapping.
    * Tidies up code and removes duplication