### PR TITLE
BXC-3091 - Indexing delays

### DIFF
--- a/access-common/src/test/resources/spring-test/acl-service-context.xml
+++ b/access-common/src/test/resources/spring-test/acl-service-context.xml
@@ -26,7 +26,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="0" />
         <property name="cacheTimeToLive" value="0" />
-        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
     </bean>
     
     <bean id="contentPathFactory" class="edu.unc.lib.dl.fedora.ContentPathFactory"

--- a/access-common/src/test/resources/spring-test/cdr-client-container.xml
+++ b/access-common/src/test/resources/spring-test/cdr-client-container.xml
@@ -28,7 +28,7 @@
         <property name="client" ref="fcrepoClient" />
         <property name="ldpFactory" ref="ldpContainerFactory" />
         <property name="pidMinter" ref="repositoryPIDMinter" />
-        <property name="repositoryObjectDriver" ref="repositoryObjectDriver" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
         <property name="sparqlUpdateService" ref="fedoraSparqlUpdateService" />
     </bean>
     

--- a/access-common/src/test/resources/spring-test/solr-indexing-context.xml
+++ b/access-common/src/test/resources/spring-test/solr-indexing-context.xml
@@ -165,7 +165,7 @@
           init-method="init">
         <property name="cacheMaxSize" value="100" />
         <property name="cacheTimeToLive" value="100" />
-        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
     </bean>
 
     <bean id="childrenCountService" class="edu.unc.lib.dl.search.solr.service.ChildrenCountService">

--- a/access/src/main/webapp/WEB-INF/access-fedora-context.xml
+++ b/access/src/main/webapp/WEB-INF/access-fedora-context.xml
@@ -74,7 +74,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="${cache.objectAcls.maxSize}" />
         <property name="cacheTimeToLive" value="${cache.objectAcls.timeToLive}" />
-        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
     </bean>
     
     <bean id="inheritedPermissionEvaluator" class="edu.unc.lib.dl.acl.fcrepo4.InheritedPermissionEvaluator">

--- a/access/src/test/resources/spring-test/cdr-client-container.xml
+++ b/access/src/test/resources/spring-test/cdr-client-container.xml
@@ -33,7 +33,7 @@
         <property name="client" ref="fcrepoClient" />
         <property name="ldpFactory" ref="ldpContainerFactory" />
         <property name="pidMinter" ref="repositoryPIDMinter" />
-        <property name="repositoryObjectDriver" ref="repositoryObjectDriver" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
         <property name="sparqlUpdateService" ref="fedoraSparqlUpdateService" />
     </bean>
     

--- a/admin/src/main/webapp/WEB-INF/access-fedora-context.xml
+++ b/admin/src/main/webapp/WEB-INF/access-fedora-context.xml
@@ -57,7 +57,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="${cache.objectAcls.maxSize}" />
         <property name="cacheTimeToLive" value="${cache.objectAcls.timeToLive}" />
-        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
     </bean>
     
     <bean id="fcrepoClientFactory" class="edu.unc.lib.dl.fcrepo4.FcrepoClientFactory" factory-method="factory">

--- a/deposit/src/main/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJob.java
@@ -93,6 +93,7 @@ import edu.unc.lib.dl.model.DatastreamType;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferSession;
 import edu.unc.lib.dl.persist.services.deposit.DepositModelHelpers;
 import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService;
+import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService.UpdateDescriptionRequest;
 import edu.unc.lib.dl.rdf.Cdr;
 import edu.unc.lib.dl.rdf.CdrAcl;
 import edu.unc.lib.dl.rdf.CdrDeposit;
@@ -834,7 +835,8 @@ public class IngestContentObjectsJob extends AbstractDepositJob {
         }
 
         InputStream modsStream = Files.newInputStream(modsPath);
-        updateDescService.updateDescription(logTransferSession, agent, obj, modsStream);
+        updateDescService.updateDescription(
+                new UpdateDescriptionRequest(agent, obj, modsStream).withTransferSession(logTransferSession));
     }
 
     private void addDescriptionHistory(ContentObject obj, Resource dResc) throws IOException {

--- a/deposit/src/main/webapp/WEB-INF/fcrepo-clients-context.xml
+++ b/deposit/src/main/webapp/WEB-INF/fcrepo-clients-context.xml
@@ -38,7 +38,7 @@
         <property name="client" ref="fcrepoClient" />
         <property name="ldpFactory" ref="ldpContainerFactory" />
         <property name="pidMinter" ref="pidMinter" />
-        <property name="repositoryObjectDriver" ref="repositoryObjectDriver" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
         <property name="sparqlUpdateService" ref="fedoraSparqlUpdateService" />
     </bean>
     

--- a/deposit/src/main/webapp/WEB-INF/service-context.xml
+++ b/deposit/src/main/webapp/WEB-INF/service-context.xml
@@ -217,7 +217,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="${cache.objectAcls.maxSize}" />
         <property name="cacheTimeToLive" value="${cache.objectAcls.timeToLive}" />
-        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
     </bean>
     
     <bean id="inheritedPermissionEvaluator" class="edu.unc.lib.dl.acl.fcrepo4.InheritedPermissionEvaluator">

--- a/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJobIT.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJobIT.java
@@ -256,7 +256,7 @@ public class IngestContentObjectsJobIT extends AbstractFedoraDepositJobIT {
         // Try directly retrieving the folder
         FolderObject folder = repoObjLoader.getFolderObject(folderPid);
         // Verify that its title was set to the expected value
-        String title = folder.getResource().getProperty(DC.title).getString();
+        String title = folder.getResource(true).getProperty(DC.title).getString();
         assertEquals("Folder title was not correctly set", label, title);
         // Verify that ingestion event gets added for folder
         Model logModel = folder.getPremisLog().getEventsModel();
@@ -729,6 +729,8 @@ public class IngestContentObjectsJobIT extends AbstractFedoraDepositJobIT {
         // Order of the children isn't guaranteed, so find by primary obj pid
         WorkObject workA = (WorkObject) folderMembers.get(0);
         WorkObject workB = (WorkObject) folderMembers.get(1);
+        workA.refresh();
+        workB.refresh();
 
         FileObject file1Obj;
         FileObject file2Obj;
@@ -1072,15 +1074,15 @@ public class IngestContentObjectsJobIT extends AbstractFedoraDepositJobIT {
 
         // Verify that the correct original deposit ids are assigned to each folder
         FolderObject folder1 = repoObjLoader.getFolderObject(folderObj1Pid);
-        Resource f1DepositResc = folder1.getResource().getProperty(Cdr.originalDeposit).getResource();
+        Resource f1DepositResc = folder1.getResource(true).getProperty(Cdr.originalDeposit).getResource();
         assertEquals(deposit2Pid.getRepositoryPath(), f1DepositResc.getURI());
 
         FolderObject folder2 = repoObjLoader.getFolderObject(folderObj2Pid);
-        Resource f2DepositResc = folder2.getResource().getProperty(Cdr.originalDeposit).getResource();
+        Resource f2DepositResc = folder2.getResource(true).getProperty(Cdr.originalDeposit).getResource();
         assertEquals(depositPid.getRepositoryPath(), f2DepositResc.getURI());
 
         FolderObject folder3 = repoObjLoader.getFolderObject(folderObj3Pid);
-        Resource f3DepositResc = folder3.getResource().getProperty(Cdr.originalDeposit).getResource();
+        Resource f3DepositResc = folder3.getResource(true).getProperty(Cdr.originalDeposit).getResource();
         assertEquals(deposit3Pid.getRepositoryPath(), f3DepositResc.getURI());
 
         ContentObject destObj = repoObjLoader.getFolderObject(destinationPid);
@@ -1319,7 +1321,7 @@ public class IngestContentObjectsJobIT extends AbstractFedoraDepositJobIT {
 
     private void assertStorageLocationPresent(ContentObject contentObj) {
         assertTrue("Storage location property was not set",
-                contentObj.getResource().hasLiteral(Cdr.storageLocation, LOC1_ID));
+                contentObj.getResource(true).hasLiteral(Cdr.storageLocation, LOC1_ID));
     }
 
     private String getSha1(Path filePath) throws Exception {

--- a/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJobIT.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJobIT.java
@@ -729,8 +729,8 @@ public class IngestContentObjectsJobIT extends AbstractFedoraDepositJobIT {
         // Order of the children isn't guaranteed, so find by primary obj pid
         WorkObject workA = (WorkObject) folderMembers.get(0);
         WorkObject workB = (WorkObject) folderMembers.get(1);
-        workA.refresh();
-        workB.refresh();
+        workA.shouldRefresh();
+        workB.shouldRefresh();
 
         FileObject file1Obj;
         FileObject file2Obj;

--- a/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/fcrepo4/IngestContentObjectsJobTest.java
@@ -37,7 +37,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
-import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -71,7 +70,6 @@ import edu.unc.lib.deposit.work.JobInterruptedException;
 import edu.unc.lib.dl.acl.exception.AccessRestrictionException;
 import edu.unc.lib.dl.acl.service.AccessControlService;
 import edu.unc.lib.dl.acl.util.AccessGroupSet;
-import edu.unc.lib.dl.acl.util.AgentPrincipals;
 import edu.unc.lib.dl.acl.util.Permission;
 import edu.unc.lib.dl.event.PremisEventBuilder;
 import edu.unc.lib.dl.event.PremisLogger;
@@ -80,7 +78,6 @@ import edu.unc.lib.dl.fcrepo4.AdminUnit;
 import edu.unc.lib.dl.fcrepo4.BinaryObject;
 import edu.unc.lib.dl.fcrepo4.CollectionObject;
 import edu.unc.lib.dl.fcrepo4.ContentContainerObject;
-import edu.unc.lib.dl.fcrepo4.ContentObject;
 import edu.unc.lib.dl.fcrepo4.ContentRootObject;
 import edu.unc.lib.dl.fcrepo4.FedoraTransaction;
 import edu.unc.lib.dl.fcrepo4.FileObject;
@@ -100,6 +97,7 @@ import edu.unc.lib.dl.persist.api.transfer.BinaryTransferService;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferSession;
 import edu.unc.lib.dl.persist.services.deposit.DepositModelHelpers;
 import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService;
+import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService.UpdateDescriptionRequest;
 import edu.unc.lib.dl.rdf.Cdr;
 import edu.unc.lib.dl.rdf.CdrAcl;
 import edu.unc.lib.dl.rdf.CdrDeposit;
@@ -470,8 +468,7 @@ public class IngestContentObjectsJobTest extends AbstractDepositJobTest {
 
         BinaryObject mockDescBin = mock(BinaryObject.class);
         when(mockDescBin.getContentUri()).thenReturn(URI.create("file://path/to/desc"));
-        when(updateDescService.updateDescription(eq(mockTransferSession), any(AgentPrincipals.class),
-                any(ContentObject.class), any(InputStream.class))).thenReturn(mockDescBin);
+        when(updateDescService.updateDescription(any(UpdateDescriptionRequest.class))).thenReturn(mockDescBin);
 
         Path modsPath = job.getModsPath(workPid, true);
         FileUtils.writeStringToFile(modsPath.toFile(), "Mods content", UTF_8);
@@ -499,8 +496,7 @@ public class IngestContentObjectsJobTest extends AbstractDepositJobTest {
         verify(repoObjFactory).createWorkObject(eq(workPid), any(Model.class));
         verify(destinationObj).addMember(eq(work));
 
-        verify(updateDescService).updateDescription(eq(mockTransferSession), any(AgentPrincipals.class),
-                any(ContentObject.class), any(InputStream.class));
+        verify(updateDescService).updateDescription(any(UpdateDescriptionRequest.class));
 
         verify(work, times(2)).addDataFile(eq(mainPid), any(URI.class), eq(mainLoc),
                 eq(mainMime), anyString(), anyString(), any(Model.class));

--- a/deposit/src/test/resources/spring-test/cdr-client-container.xml
+++ b/deposit/src/test/resources/spring-test/cdr-client-container.xml
@@ -122,8 +122,8 @@
     </bean>
     
     <bean id="repositoryObjectLoader" class="edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader" init-method="init">
-        <property name="cacheTimeToLive" value="1000" />
-        <property name="cacheMaxSize" value="50" />
+        <property name="cacheTimeToLive" value="10000" />
+        <property name="cacheMaxSize" value="500" />
         <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
     </bean>
     

--- a/deposit/src/test/resources/spring-test/cdr-client-container.xml
+++ b/deposit/src/test/resources/spring-test/cdr-client-container.xml
@@ -27,7 +27,7 @@
         <property name="client" ref="fcrepoClient" />
         <property name="ldpFactory" ref="ldpContainerFactory" />
         <property name="pidMinter" ref="pidMinter" />
-        <property name="repositoryObjectDriver" ref="repositoryObjectDriver" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
         <property name="sparqlUpdateService" ref="fedoraSparqlUpdateService" />
     </bean>
     

--- a/deposit/src/test/resources/spring-test/cdr-client-container.xml
+++ b/deposit/src/test/resources/spring-test/cdr-client-container.xml
@@ -89,7 +89,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="100" />
         <property name="cacheTimeToLive" value="100" />
-        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
     </bean>
     
     <bean id="inheritedPermissionEvaluator" class="edu.unc.lib.dl.acl.fcrepo4.InheritedPermissionEvaluator">

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/acl/fcrepo4/ObjectAclFactory.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/acl/fcrepo4/ObjectAclFactory.java
@@ -43,7 +43,7 @@ import com.google.common.cache.LoadingCache;
 import edu.unc.lib.dl.acl.util.RoleAssignment;
 import edu.unc.lib.dl.acl.util.UserRole;
 import edu.unc.lib.dl.fcrepo4.RepositoryObject;
-import edu.unc.lib.dl.fcrepo4.RepositoryObjectCacheLoader;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.rdf.Cdr;
 import edu.unc.lib.dl.rdf.CdrAcl;
@@ -67,7 +67,7 @@ public class ObjectAclFactory implements AclFactory {
     private long cacheTimeToLive;
     private long cacheMaxSize;
 
-    private RepositoryObjectCacheLoader repositoryObjectCacheLoader;
+    private RepositoryObjectLoader repoObjLoader;
 
     private final List<String> roleUris;
 
@@ -164,6 +164,14 @@ public class ObjectAclFactory implements AclFactory {
         return objAclCache.getUnchecked(pid);
     }
 
+    /**
+     * Invalidates cached data for the provided pid
+     * @param pid
+     */
+    public void invalidate(PID pid) {
+        objAclCache.invalidate(pid);
+    }
+
     public long getCacheTimeToLive() {
         return cacheTimeToLive;
     }
@@ -181,10 +189,10 @@ public class ObjectAclFactory implements AclFactory {
     }
 
     /**
-     * @param repositoryObjectCacheLoader the repositoryObjectCacheLoader to set
+     * @param repositoryObjectLoader the repositoryObjectLoader to set
      */
-    public void setRepositoryObjectCacheLoader(RepositoryObjectCacheLoader repositoryObjectCacheLoader) {
-        this.repositoryObjectCacheLoader = repositoryObjectCacheLoader;
+    public void setRepositoryObjectLoader(RepositoryObjectLoader repositoryObjectLoader) {
+        this.repoObjLoader = repositoryObjectLoader;
     }
 
     /**
@@ -199,7 +207,7 @@ public class ObjectAclFactory implements AclFactory {
         public List<Entry<String, String>> load(PID pid) {
             List<Entry<String, String>> valueResults = new ArrayList<>();
 
-            RepositoryObject repoObj = repositoryObjectCacheLoader.load(pid);
+            RepositoryObject repoObj = repoObjLoader.getRepositoryObject(pid);
             Model model = repoObj.getModel();
             StmtIterator it = model.listStatements();
             while (it.hasNext()) {

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/event/RepositoryPremisLogger.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/event/RepositoryPremisLogger.java
@@ -168,7 +168,6 @@ public class RepositoryPremisLogger implements PremisLogger {
 
         // Link from the repository object to its event log
         repoObjFactory.createRelationship(repoObject, Cdr.hasEvents, eventsObj.getResource());
-        repoObject.shouldRefresh();
 
         return this;
     }

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/event/RepositoryPremisLogger.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/event/RepositoryPremisLogger.java
@@ -111,7 +111,7 @@ public class RepositoryPremisLogger implements PremisLogger {
         try {
             Model logModel = ModelFactory.createDefaultModel();
 
-            Statement s = repoObject.getResource().getProperty(Cdr.hasEvents);
+            Statement s = repoObject.getResource(true).getProperty(Cdr.hasEvents);
             boolean isNewLog = s == null;
 
             // For new logs, add in representation statement
@@ -168,6 +168,7 @@ public class RepositoryPremisLogger implements PremisLogger {
 
         // Link from the repository object to its event log
         repoObjFactory.createRelationship(repoObject, Cdr.hasEvents, eventsObj.getResource());
+        repoObject.refresh();
 
         return this;
     }

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/event/RepositoryPremisLogger.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/event/RepositoryPremisLogger.java
@@ -168,7 +168,7 @@ public class RepositoryPremisLogger implements PremisLogger {
 
         // Link from the repository object to its event log
         repoObjFactory.createRelationship(repoObject, Cdr.hasEvents, eventsObj.getResource());
-        repoObject.refresh();
+        repoObject.shouldRefresh();
 
         return this;
     }

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/AdminUnit.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/AdminUnit.java
@@ -41,6 +41,7 @@ public class AdminUnit extends ContentContainerObject {
                     + " as a member of AdminUnit " + pid.getQualifiedId());
         }
         repoObjFactory.addMember(this, member);
+        member.refresh();
         return this;
     }
 

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/AdminUnit.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/AdminUnit.java
@@ -41,7 +41,7 @@ public class AdminUnit extends ContentContainerObject {
                     + " as a member of AdminUnit " + pid.getQualifiedId());
         }
         repoObjFactory.addMember(this, member);
-        member.refresh();
+        member.shouldRefresh();
         return this;
     }
 

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/CollectionObject.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/CollectionObject.java
@@ -60,7 +60,7 @@ public class CollectionObject extends ContentContainerObject {
         }
 
         repoObjFactory.addMember(this, member);
-        member.refresh();
+        member.shouldRefresh();
         return this;
     }
 

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/CollectionObject.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/CollectionObject.java
@@ -60,6 +60,7 @@ public class CollectionObject extends ContentContainerObject {
         }
 
         repoObjFactory.addMember(this, member);
+        member.refresh();
         return this;
     }
 

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/ContentRootObject.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/ContentRootObject.java
@@ -43,7 +43,7 @@ public class ContentRootObject extends ContentContainerObject {
         }
 
         repoObjFactory.addMember(this, member);
-        member.refresh();
+        member.shouldRefresh();
         return this;
     }
 

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/ContentRootObject.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/ContentRootObject.java
@@ -43,6 +43,7 @@ public class ContentRootObject extends ContentContainerObject {
         }
 
         repoObjFactory.addMember(this, member);
+        member.refresh();
         return this;
     }
 

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/DepositRecord.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/DepositRecord.java
@@ -68,7 +68,7 @@ public class DepositRecord extends RepositoryObject {
         }
         BinaryObject manifestObj = repoObjFactory.createOrUpdateBinary(
                 manifestPid, manifestUri, filename, mimetype, sha1, md5, null);
-        refresh();
+        shouldRefresh();
         return manifestObj;
     }
 

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/DepositRecord.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/DepositRecord.java
@@ -66,7 +66,10 @@ public class DepositRecord extends RepositoryObject {
         if (mimetype == null) {
             mimetype = "text/plain";
         }
-        return repoObjFactory.createOrUpdateBinary(manifestPid, manifestUri, filename, mimetype, sha1, md5, null);
+        BinaryObject manifestObj = repoObjFactory.createOrUpdateBinary(
+                manifestPid, manifestUri, filename, mimetype, sha1, md5, null);
+        refresh();
+        return manifestObj;
     }
 
     /**

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/FileObject.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/FileObject.java
@@ -156,7 +156,7 @@ public class FileObject extends ContentObject {
                     associationRelation, createResource(getOriginalFilePid(pid).getRepositoryPath()));
         }
 
-        refresh();
+        shouldRefresh();
         return binObj;
     }
 

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/FileObject.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/FileObject.java
@@ -156,6 +156,7 @@ public class FileObject extends ContentObject {
                     associationRelation, createResource(getOriginalFilePid(pid).getRepositoryPath()));
         }
 
+        refresh();
         return binObj;
     }
 

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/FolderObject.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/FolderObject.java
@@ -59,6 +59,7 @@ public class FolderObject extends ContentContainerObject {
         }
 
         repoObjFactory.addMember(this, member);
+        member.refresh();
         return this;
     }
 
@@ -80,10 +81,11 @@ public class FolderObject extends ContentContainerObject {
      * @return the newly created folder object
      */
     public FolderObject addFolder(Model model) {
-        FolderObject work = repoObjFactory.createFolderObject(model);
-        repoObjFactory.addMember(this, work);
+        FolderObject folder = repoObjFactory.createFolderObject(model);
+        repoObjFactory.addMember(this, folder);
+        folder.refresh();
 
-        return work;
+        return folder;
     }
 
     /**
@@ -105,6 +107,7 @@ public class FolderObject extends ContentContainerObject {
     public WorkObject addWork(Model model) {
         WorkObject work = repoObjFactory.createWorkObject(model);
         repoObjFactory.addMember(this, work);
+        work.refresh();
 
         return work;
     }

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/FolderObject.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/FolderObject.java
@@ -59,7 +59,7 @@ public class FolderObject extends ContentContainerObject {
         }
 
         repoObjFactory.addMember(this, member);
-        member.refresh();
+        member.shouldRefresh();
         return this;
     }
 
@@ -83,7 +83,7 @@ public class FolderObject extends ContentContainerObject {
     public FolderObject addFolder(Model model) {
         FolderObject folder = repoObjFactory.createFolderObject(model);
         repoObjFactory.addMember(this, folder);
-        folder.refresh();
+        folder.shouldRefresh();
 
         return folder;
     }
@@ -107,7 +107,7 @@ public class FolderObject extends ContentContainerObject {
     public WorkObject addWork(Model model) {
         WorkObject work = repoObjFactory.createWorkObject(model);
         repoObjFactory.addMember(this, work);
-        work.refresh();
+        work.shouldRefresh();
 
         return work;
     }

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObject.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObject.java
@@ -282,9 +282,9 @@ public abstract class RepositoryObject {
     }
 
     /**
-     * Refresh the state of this object from data sources
+     * Indicate that the state of this object should be refreshed
      */
-    public void refresh() {
+    public void shouldRefresh() {
         model = null;
         premisLog = null;
         types = null;

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObject.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObject.java
@@ -78,7 +78,12 @@ public abstract class RepositoryObject {
      * @throws FedoraException
      */
     public Model getModel() throws FedoraException {
-        driver.loadModel(this);
+        driver.loadModel(this, false);
+        return model;
+    }
+
+    public Model getModel(boolean checkForUpdates) throws FedoraException {
+        driver.loadModel(this, checkForUpdates);
         return model;
     }
 
@@ -104,7 +109,11 @@ public abstract class RepositoryObject {
     }
 
     public Resource getResource() throws FedoraException {
-        return getModel().getResource(getUri().toString());
+        return getResource(false);
+    }
+
+    public Resource getResource(boolean checkForUpdates) throws FedoraException {
+        return getModel(checkForUpdates).getResource(getUri().toString());
     }
 
     /**
@@ -270,6 +279,16 @@ public abstract class RepositoryObject {
             return false;
         }
         return remoteEtag.equals(getEtag());
+    }
+
+    /**
+     * Refresh the state of this object from data sources
+     */
+    public void refresh() {
+        model = null;
+        premisLog = null;
+        types = null;
+        etag = null;
     }
 
     @Override

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectCacheLoader.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectCacheLoader.java
@@ -62,8 +62,15 @@ public class RepositoryObjectCacheLoader extends CacheLoader<PID, RepositoryObje
 
     @Override
     public RepositoryObject load(PID pid) {
-        log.debug("Loading repository object {} for cache", pid);
+        long start = System.nanoTime();
+        try {
+            return loadObject(pid);
+        } finally {
+            log.debug("Loaded repository object {} in {}s", pid, (System.nanoTime() - start) / 1e9);
+        }
+    }
 
+    public RepositoryObject loadObject(PID pid) {
         String etag;
         try (FcrepoResponse response = client.head(pid.getRepositoryUri())
                 .perform()) {

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectDriver.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectDriver.java
@@ -118,7 +118,6 @@ public class RepositoryObjectDriver {
                 .accept(TURTLE_MIMETYPE)
                 .perform()) {
 
-            log.debug("Retrieving new model for {}", obj.getPid());
             Model model = ModelFactory.createDefaultModel();
             model.read(response.getBody(), null, Lang.TURTLE.getName());
 

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectDriver.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectDriver.java
@@ -100,13 +100,15 @@ public class RepositoryObjectDriver {
      * repository object
      *
      * @param obj
+     * @param checkForUpdates if true, will reload the model if the object has changed
      * @return
      * @throws FedoraException
      */
-    public RepositoryObjectDriver loadModel(RepositoryObject obj) throws FedoraException {
+    public RepositoryObjectDriver loadModel(RepositoryObject obj, boolean checkForUpdates) throws FedoraException {
+        long start = System.nanoTime();
         URI metadataUri = obj.getMetadataUri();
-        // If the object is up to date and has already loaded the model then we're done
-        if (obj.hasModel() && obj.isUnmodified()) {
+        // Model needs to be loaded if not present, or if checkForUpdates is true and either in a tx or obj has changed
+        if (obj.hasModel() && !(checkForUpdates && (FedoraTransaction.isStillAlive() || !obj.isUnmodified()))) {
             log.debug("Object unchanged, reusing existing model for {}", obj.getPid());
             return this;
         }
@@ -125,6 +127,7 @@ public class RepositoryObjectDriver {
 
             // Store updated modification info to track if the object changes
             obj.setEtag(parseEtag(response));
+            log.debug("Retrieved new model for {} in {}s", obj.getPid(), (System.nanoTime() - start) / 1e9);
 
             return this;
         } catch (IOException e) {

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectFactory.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectFactory.java
@@ -70,7 +70,7 @@ public class RepositoryObjectFactory {
 
     private FcrepoClient client;
 
-    private RepositoryObjectDriver repoObjDriver;
+    private RepositoryObjectLoader repoObjLoader;
 
     private RepositoryPIDMinter pidMinter;
 
@@ -120,8 +120,7 @@ public class RepositoryObjectFactory {
         }
 
         log.debug("Retrieving created deposit record object {}", pid.getId());
-        DepositRecord depositRecord = new DepositRecord(pid, repoObjDriver, this);
-        return depositRecord;
+        return repoObjLoader.getDepositRecord(pid);
     }
 
     /**
@@ -153,7 +152,7 @@ public class RepositoryObjectFactory {
 
         createContentContainerObject(pid.getRepositoryUri(), model);
 
-        return new AdminUnit(pid, repoObjDriver, this);
+        return repoObjLoader.getAdminUnit(pid);
     }
 
     /**
@@ -202,7 +201,7 @@ public class RepositoryObjectFactory {
 
         createContentContainerObject(pid.getRepositoryUri(), model);
 
-        return new CollectionObject(pid, repoObjDriver, this);
+        return repoObjLoader.getCollectionObject(pid);
     }
 
     /**
@@ -234,7 +233,7 @@ public class RepositoryObjectFactory {
 
         createContentContainerObject(pid.getRepositoryUri(), model);
 
-        return new FolderObject(pid, repoObjDriver, this);
+        return repoObjLoader.getFolderObject(pid);
     }
 
     /**
@@ -266,7 +265,7 @@ public class RepositoryObjectFactory {
 
         createContentContainerObject(pid.getRepositoryUri(), model);
 
-        return new WorkObject(pid, repoObjDriver, this);
+        return repoObjLoader.getWorkObject(pid);
     }
 
     /**
@@ -316,7 +315,7 @@ public class RepositoryObjectFactory {
             throw ClientFaultResolver.resolve(e);
         }
 
-        return new FileObject(pid, repoObjDriver, this);
+        return repoObjLoader.getFileObject(pid);
     }
 
     /**
@@ -373,7 +372,9 @@ public class RepositoryObjectFactory {
             resultUriString = resultUriString.replace("/" + FCR_METADATA, "");
         }
 
-        return new BinaryObject(PIDs.get(resultUriString), storageUri, repoObjDriver, this);
+        PID binPid = PIDs.get(resultUriString);
+        repoObjLoader.invalidate(binPid);
+        return repoObjLoader.getBinaryObject(binPid);
     }
 
     private void updateBinaryDescription(PID binPid, URI describedBy, Model model) {
@@ -459,7 +460,7 @@ public class RepositoryObjectFactory {
                 throw ClientFaultResolver.resolve(e);
             }
         }
-        return new BinaryObject(PIDs.get(resultUri), repoObjDriver, this);
+        return repoObjLoader.getBinaryObject(PIDs.get(resultUri));
     }
 
     /**
@@ -530,7 +531,9 @@ public class RepositoryObjectFactory {
                  throw ClientFaultResolver.resolve(e);
              }
          }
-         return new BinaryObject(PIDs.get(updatePath), repoObjDriver, this);
+         PID binPid = PIDs.get(updatePath);
+         repoObjLoader.invalidate(binPid);
+         return repoObjLoader.getBinaryObject(binPid);
      }
 
     /**
@@ -675,8 +678,8 @@ public class RepositoryObjectFactory {
         this.ldpFactory = ldpFactory;
     }
 
-    public void setRepositoryObjectDriver(RepositoryObjectDriver repoObjDriver) {
-        this.repoObjDriver = repoObjDriver;
+    public void setRepositoryObjectLoader(RepositoryObjectLoader repoObjLoader) {
+        this.repoObjLoader = repoObjLoader;
     }
 
     public void setPidMinter(RepositoryPIDMinter pidMinter) {

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectFactory.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectFactory.java
@@ -562,7 +562,7 @@ public class RepositoryObjectFactory {
      * @param object all of the new values for the property
      */
     public void createExclusiveRelationship(RepositoryObject repoObj, Property property, Object object) {
-        NodeIterator valuesIt = repoObj.getModel().listObjectsOfProperty(property);
+        NodeIterator valuesIt = repoObj.getModel(true).listObjectsOfProperty(property);
         List<Object> previousValues = null;
         if (valuesIt != null && valuesIt.hasNext()) {
             previousValues = new ArrayList<>();

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectFactory.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectFactory.java
@@ -556,6 +556,7 @@ public class RepositoryObjectFactory {
         String sparqlUpdate = SparqlUpdateHelper.createSparqlInsert(subject.getPid().getRepositoryPath(),
                 property, object);
         persistTripleToFedora(subject.getMetadataUri(), sparqlUpdate);
+        subject.shouldRefresh();
     }
 
     /**
@@ -577,6 +578,7 @@ public class RepositoryObjectFactory {
         String sparqlUpdate = SparqlUpdateHelper.createSparqlReplace(subject.getRepositoryPath(), property, object,
                 previousValues);
         persistTripleToFedora(repoObj.getMetadataUri(), sparqlUpdate);
+        repoObj.shouldRefresh();
     }
 
     /**
@@ -589,6 +591,7 @@ public class RepositoryObjectFactory {
         String sparqlUpdate = SparqlUpdateHelper.createSparqlDelete(
                 subject.getRepositoryPath(), property, null);
         sparqlUpdateService.executeUpdate(repoObj.getMetadataUri().toString(), sparqlUpdate);
+        repoObj.shouldRefresh();
     }
 
     /**
@@ -601,6 +604,7 @@ public class RepositoryObjectFactory {
         String sparqlUpdate = SparqlUpdateHelper.createSparqlInsert(subject.getPid().getRepositoryPath(),
                 property, object);
         persistTripleToFedora(subject.getMetadataUri(), sparqlUpdate);
+        subject.shouldRefresh();
     }
 
     /**
@@ -611,6 +615,7 @@ public class RepositoryObjectFactory {
     public void createRelationships(RepositoryObject subject, Model model) {
         String sparqlUpdate = SparqlUpdateHelper.createSparqlInsert(model);
         persistTripleToFedora(subject.getMetadataUri(), sparqlUpdate);
+        subject.shouldRefresh();
     }
 
     /**

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectLoader.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectLoader.java
@@ -144,4 +144,15 @@ public class RepositoryObjectLoader {
         }
     }
 
+    /**
+     * Clear any cache entry for the provided pid
+     * @param pid
+     */
+    public void invalidate(PID pid) {
+        repositoryObjCache.invalidate(pid);
+    }
+
+    public LoadingCache<PID, RepositoryObject> getRepositoryObjectCache() {
+        return repositoryObjCache;
+    }
 }

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/WorkObject.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/WorkObject.java
@@ -89,7 +89,7 @@ public class WorkObject extends ContentContainerObject {
 
         // Add the relation
         repoObjFactory.createExclusiveRelationship(this, Cdr.primaryObject, primaryObj.getResource());
-        refresh();
+        shouldRefresh();
     }
 
     /**
@@ -117,7 +117,7 @@ public class WorkObject extends ContentContainerObject {
         }
 
         repoObjFactory.addMember(this, member);
-        member.refresh();
+        member.shouldRefresh();
         return this;
     }
 
@@ -185,8 +185,8 @@ public class WorkObject extends ContentContainerObject {
         // Add the new file object as a member of this Work
         repoObjFactory.addMember(this, fileObj);
         // Force the work and its new file to refresh to reflect membership change
-        fileObj.refresh();
-        refresh();
+        fileObj.shouldRefresh();
+        shouldRefresh();
 
         return fileObj;
     }

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/WorkObject.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/WorkObject.java
@@ -89,6 +89,7 @@ public class WorkObject extends ContentContainerObject {
 
         // Add the relation
         repoObjFactory.createExclusiveRelationship(this, Cdr.primaryObject, primaryObj.getResource());
+        refresh();
     }
 
     /**
@@ -116,6 +117,7 @@ public class WorkObject extends ContentContainerObject {
         }
 
         repoObjFactory.addMember(this, member);
+        member.refresh();
         return this;
     }
 
@@ -182,6 +184,9 @@ public class WorkObject extends ContentContainerObject {
 
         // Add the new file object as a member of this Work
         repoObjFactory.addMember(this, fileObj);
+        // Force the work and its new file to refresh to reflect membership change
+        fileObj.refresh();
+        refresh();
 
         return fileObj;
     }

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/WorkObject.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/WorkObject.java
@@ -89,7 +89,6 @@ public class WorkObject extends ContentContainerObject {
 
         // Add the relation
         repoObjFactory.createExclusiveRelationship(this, Cdr.primaryObject, primaryObj.getResource());
-        shouldRefresh();
     }
 
     /**

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/persist/api/indexing/IndexingPriority.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/persist/api/indexing/IndexingPriority.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.persist.api.indexing;
+
+/**
+ * Indexing priority flag values
+ *
+ * @author bbpennel
+ */
+public enum IndexingPriority {
+    low, normal, high;
+}

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/acl/fcrepo4/AccessControlServiceImplIT.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/acl/fcrepo4/AccessControlServiceImplIT.java
@@ -40,7 +40,7 @@ import edu.unc.lib.dl.fcrepo4.ContentRootObject;
 import edu.unc.lib.dl.fcrepo4.FolderObject;
 import edu.unc.lib.dl.fcrepo4.PIDs;
 import edu.unc.lib.dl.fcrepo4.RepositoryInitializer;
-import edu.unc.lib.dl.fcrepo4.RepositoryObjectCacheLoader;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
 import edu.unc.lib.dl.fcrepo4.RepositoryPaths;
 import edu.unc.lib.dl.fcrepo4.WorkObject;
 import edu.unc.lib.dl.fedora.ContentPathFactory;
@@ -89,7 +89,7 @@ public class AccessControlServiceImplIT extends AbstractFedoraIT {
     @Autowired
     private ContentPathFactory pathFactory;
     @Autowired
-    private RepositoryObjectCacheLoader repositoryObjectCacheLoader;
+    private RepositoryObjectLoader repositoryObjectLoader;
     @Autowired
     private RepositoryInitializer repoInitializer;
 
@@ -108,7 +108,7 @@ public class AccessControlServiceImplIT extends AbstractFedoraIT {
         globalPermissionEvaluator = new GlobalPermissionEvaluator(properties);
 
         aclFactory = new ObjectAclFactory();
-        aclFactory.setRepositoryObjectCacheLoader(repositoryObjectCacheLoader);
+        aclFactory.setRepositoryObjectLoader(repositoryObjectLoader);
         aclFactory.setCacheMaxSize(CACHE_MAX_SIZE);
         aclFactory.setCacheTimeToLive(CACHE_TIME_TO_LIVE);
         aclFactory.init();

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/BinaryObjectTest.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/BinaryObjectTest.java
@@ -17,6 +17,7 @@ package edu.unc.lib.dl.fcrepo4;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 
@@ -74,7 +75,7 @@ public class BinaryObjectTest extends AbstractFedoraTest {
 
         binObj = new BinaryObject(mockPid, driver, repoObjFactory);
 
-        when(driver.loadModel(binObj)).thenReturn(driver);
+        when(driver.loadModel(eq(binObj), anyBoolean())).thenReturn(driver);
 
         setupModel();
     }

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectFactoryIT.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectFactoryIT.java
@@ -338,7 +338,7 @@ public class RepositoryObjectFactoryIT extends AbstractFedoraIT {
         // test one existing relationship
         Resource resc3 = createResource(repoObj3.getPid().getRepositoryPath());
         repoObjFactory.createExclusiveRelationship(repoObj1, DC.relation, resc3);
-        Model replaceModel1 = repoObj1.getModel();
+        Model replaceModel1 = getModel(repoObj1.getPid());
         Resource updatedResc1 = replaceModel1.getResource(repoObj1.getPid().getRepositoryPath());
         assertTrue(updatedResc1.hasProperty(DC.relation, resc3));
         assertFalse(updatedResc1.hasProperty(DC.relation, resc2));
@@ -347,14 +347,14 @@ public class RepositoryObjectFactoryIT extends AbstractFedoraIT {
         Resource resc4 = createResource(repoObj4.getPid().getRepositoryPath());
         // add second relationship
         repoObjFactory.createRelationship(repoObj1, DC.relation, resc2);
-        replaceModel1 = repoObj1.getModel();
+        replaceModel1 = repoObj1.getModel(true);
         updatedResc1 = replaceModel1.getResource(repoObj1.getPid().getRepositoryPath());
         // check to see that the subject has two relationships using the property DC.relation
         assertTrue(updatedResc1.hasProperty(DC.relation, resc3));
         assertTrue(updatedResc1.hasProperty(DC.relation, resc2));
         // create a new exclusive relationship to a new resource
         repoObjFactory.createExclusiveRelationship(repoObj1, DC.relation, resc4);
-        Model replaceModel1Again = repoObj1.getModel();
+        Model replaceModel1Again = repoObj1.getModel(true);
         Resource updatedResc1Again = replaceModel1Again.getResource(repoObj1.getPid().getRepositoryPath());
         assertTrue(updatedResc1Again.hasProperty(DC.relation, resc4));
         assertFalse(updatedResc1Again.hasProperty(DC.relation, resc2));

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectFactoryTest.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectFactoryTest.java
@@ -185,7 +185,7 @@ public class RepositoryObjectFactoryTest {
         PID memberPid = pidMinter.mintContentPid();
         ContentObject member = mock(ContentObject.class);
         when(member.getPid()).thenReturn(memberPid);
-        when(member.getModel()).thenReturn(memberModel);
+        when(member.getModel(true)).thenReturn(memberModel);
         when(member.getMetadataUri()).thenReturn(memberPid.getRepositoryUri());
 
         repoObjFactory.addMember(parent, member);

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectFactoryTest.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectFactoryTest.java
@@ -58,9 +58,7 @@ public class RepositoryObjectFactoryTest {
     @Mock
     private LdpContainerFactory ldpFactory;
     @Mock
-    private RepositoryObjectCacheLoader objectCacheLoader;
-    @Mock
-    private RepositoryObjectDriver driver;
+    private RepositoryObjectLoader repoObjLoader;
     @Mock
     private SparqlUpdateService sparqlUpdateService;
     @Mock
@@ -85,6 +83,7 @@ public class RepositoryObjectFactoryTest {
         repoObjFactory.setClient(fcrepoClient);
         repoObjFactory.setLdpFactory(ldpFactory);
         repoObjFactory.setSparqlUpdateService(sparqlUpdateService);
+        repoObjFactory.setRepositoryObjectLoader(repoObjLoader);
         pidMinter = new RepositoryPIDMinter();
         repoObjFactory.setPidMinter(pidMinter);
         linkHeaders = new ArrayList<>();
@@ -104,42 +103,42 @@ public class RepositoryObjectFactoryTest {
 
     @Test
     public void createDepositRecordTest() {
-
+        when(repoObjLoader.getDepositRecord(any(PID.class))).thenReturn(mock(DepositRecord.class));
         DepositRecord obj = repoObjFactory.createDepositRecord(null);
         assertNotNull(obj);
     }
 
     @Test
     public void createAdminUnitTest() {
-
+        when(repoObjLoader.getAdminUnit(any(PID.class))).thenReturn(mock(AdminUnit.class));
         AdminUnit obj = repoObjFactory.createAdminUnit(null);
         assertNotNull(obj);
     }
 
     @Test
     public void createCollectionObjectTest() throws Exception {
-
+        when(repoObjLoader.getCollectionObject(any(PID.class))).thenReturn(mock(CollectionObject.class));
         CollectionObject obj = repoObjFactory.createCollectionObject(null);
         assertNotNull(obj);
     }
 
     @Test
     public void createFolderObjectTest() throws Exception {
-
+        when(repoObjLoader.getFolderObject(any(PID.class))).thenReturn(mock(FolderObject.class));
         FolderObject obj = repoObjFactory.createFolderObject(null);
         assertNotNull(obj);
     }
 
     @Test
     public void createWorkObjectTest() {
-
+        when(repoObjLoader.getWorkObject(any(PID.class))).thenReturn(mock(WorkObject.class));
         WorkObject obj = repoObjFactory.createWorkObject(null);
         assertNotNull(obj);
     }
 
     @Test
     public void createFileObjectTest() {
-
+        when(repoObjLoader.getFileObject(any(PID.class))).thenReturn(mock(FileObject.class));
         FileObject obj = repoObjFactory.createFileObject(null);
         assertNotNull(obj);
     }
@@ -147,7 +146,9 @@ public class RepositoryObjectFactoryTest {
     @Test
     public void createFolderWithPidTest() {
         PID pid = pidMinter.mintContentPid();
-
+        FileObject mockFile = mock(FileObject.class);
+        when(mockFile.getPid()).thenReturn(pid);
+        when(repoObjLoader.getFileObject(pid)).thenReturn(mockFile);
         FileObject obj = repoObjFactory.createFileObject(pid, null);
         assertNotNull(obj);
         assertEquals(pid, obj.getPid());
@@ -158,6 +159,9 @@ public class RepositoryObjectFactoryTest {
         PID pid = pidMinter.mintContentPid();
         URI binaryUri = pid.getRepositoryUri();
         when(mockResponse.getLocation()).thenReturn(binaryUri);
+        BinaryObject mockBinary = mock(BinaryObject.class);
+        when(mockBinary.getPid()).thenReturn(pid);
+        when(repoObjLoader.getBinaryObject(any(PID.class))).thenReturn(mockBinary);
 
         String slug = "slug";
         InputStream content = mock(InputStream.class);
@@ -169,7 +173,7 @@ public class RepositoryObjectFactoryTest {
                 mimetype, sha1Checksum, null, null);
 
         assertTrue(obj.getPid().getRepositoryPath().startsWith(binaryUri.toString()));
-     // check to see that client creates FcrepoResponse
+        // check to see that client creates FcrepoResponse
         verify(mockPostBuilder).perform();
     }
 

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/WorkObjectTest.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/fcrepo4/WorkObjectTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -102,7 +103,7 @@ public class WorkObjectTest extends AbstractFedoraTest {
             }
         });
 
-        when(driver.loadModel(eq(work))).thenAnswer(new Answer<RepositoryObjectDriver>() {
+        when(driver.loadModel(eq(work), anyBoolean())).thenAnswer(new Answer<RepositoryObjectDriver>() {
             @Override
             public RepositoryObjectDriver answer(InvocationOnMock invocation) throws Throwable {
                 work.storeModel(model);

--- a/fcrepo-clients/src/test/resources/spring-test/cdr-client-container.xml
+++ b/fcrepo-clients/src/test/resources/spring-test/cdr-client-container.xml
@@ -28,7 +28,7 @@
     <bean id="repositoryObjectFactory" class="edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory">
         <property name="client" ref="fcrepoClient" />
         <property name="ldpFactory" ref="ldpContainerFactory" />
-        <property name="repositoryObjectDriver" ref="repositoryObjectDriver" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
         <property name="pidMinter" ref="repositoryPIDMinter" />
         <property name="sparqlUpdateService" ref="sparqlUpdateService" />
     </bean>

--- a/migration-util/src/main/resources/spring/service-context.xml
+++ b/migration-util/src/main/resources/spring/service-context.xml
@@ -44,7 +44,7 @@
     <bean id="repositoryObjectFactory" class="edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory">
         <property name="client" ref="fcrepoClient" />
         <property name="ldpFactory" ref="ldpContainerFactory" />
-        <property name="repositoryObjectDriver" ref="repositoryObjectDriver" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
         <property name="pidMinter" ref="repositoryPIDMinter" />
         <property name="sparqlUpdateService" ref="sparqlUpdateService" />
     </bean>

--- a/migration-util/src/test/resources/spring-test/cdr-client-container.xml
+++ b/migration-util/src/test/resources/spring-test/cdr-client-container.xml
@@ -28,7 +28,7 @@
     <bean id="repositoryObjectFactory" class="edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory">
         <property name="client" ref="fcrepoClient" />
         <property name="ldpFactory" ref="ldpContainerFactory" />
-        <property name="repositoryObjectDriver" ref="repositoryObjectDriver" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
         <property name="pidMinter" ref="repositoryPIDMinter" />
         <property name="sparqlUpdateService" ref="sparqlUpdateService" />
     </bean>

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/acl/ExpireEmbargoService.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/acl/ExpireEmbargoService.java
@@ -92,7 +92,7 @@ public class ExpireEmbargoService {
                     PID pid = PIDs.get(rescUri);
                     currentPid = pid;
                     RepositoryObject repoObj = repoObjLoader.getRepositoryObject(pid);
-                    Resource resc = repoObj.getResource();
+                    Resource resc = repoObj.getResource(true);
 
                     // remove embargo
                     String embargoDate = resc.getProperty(embargoUntil).getString();

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/acl/PatronAccessAssignmentService.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/acl/PatronAccessAssignmentService.java
@@ -117,7 +117,7 @@ public class PatronAccessAssignmentService {
                     + ", objects of type " + repoObj.getClass().getName() + " are not eligible.");
             }
 
-            Model updated = ModelFactory.createDefaultModel().add(repoObj.getModel());
+            Model updated = ModelFactory.createDefaultModel().add(repoObj.getModel(true));
             Resource rolesEventResc = replacePatronRoles(repoObj, agent, updated, accessDetails.getRoles());
             Resource embargoEventResc = updateEmbargo(repoObj, agent, updated, accessDetails.getEmbargo());
 

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/acl/StaffRoleAssignmentService.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/acl/StaffRoleAssignmentService.java
@@ -134,7 +134,7 @@ public class StaffRoleAssignmentService {
 
     private void replaceStaffRoles(RepositoryObject repoObj, Collection<RoleAssignment> assignments) {
         // Update a copy of the model for this object
-        Model model = ModelFactory.createDefaultModel().add(repoObj.getModel());
+        Model model = ModelFactory.createDefaultModel().add(repoObj.getModel(true));
         Resource resc = model.getResource(repoObj.getPid().getRepositoryPath());
 
         // Clear out all the existing staff roles

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsCompletelyJob.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsCompletelyJob.java
@@ -95,7 +95,7 @@ public class DestroyObjectsCompletelyJob extends AbstractDestroyObjectsJob {
         }
 
         List<URI> binaryUris = new ArrayList<>();
-        addBinariesForCleanup(rootOfTree.getModel(), binaryUris);
+        addBinariesForCleanup(rootOfTree.getModel(true), binaryUris);
         cleanupBinaryUris.addAll(binaryUris);
 
         sendBinariesDestroyedMsg(rootOfTree, binaryUris);

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsJob.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsJob.java
@@ -93,7 +93,7 @@ public class DestroyObjectsJob extends AbstractDestroyObjectsJob {
                     continue;
                 }
 
-                if (!repoObj.getResource().hasProperty(RDF.type, Cdr.Tombstone)) {
+                if (!repoObj.getResource(true).hasProperty(RDF.type, Cdr.Tombstone)) {
                     RepositoryObject parentObj = repoObj.getParent();
 
                     // purge tree with repoObj as root from repository
@@ -142,7 +142,7 @@ public class DestroyObjectsJob extends AbstractDestroyObjectsJob {
             }
         }
 
-        Resource rootResc = rootOfTree.getResource();
+        Resource rootResc = rootOfTree.getResource(true);
         Model rootModel = rootResc.getModel();
         List<URI> binaryUris = null;
         if (rootOfTree instanceof FileObject) {
@@ -196,7 +196,7 @@ public class DestroyObjectsJob extends AbstractDestroyObjectsJob {
 
     private void addBinaryMetadataToParent(Resource parentResc, BinaryObject child) {
         log.debug("Adding binary metadata from {} to parent {}", child.getPid().getQualifiedId(), parentResc);
-        Resource childResc = child.getResource();
+        Resource childResc = child.getResource(true);
         TombstonePropertySelector selector = new TombstonePropertySelector(childResc);
         Model childModel = childResc.getModel();
         StmtIterator iter = childModel.listStatements(selector);

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/edit/EditTitleService.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/edit/EditTitleService.java
@@ -38,6 +38,7 @@ import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.fedora.ServiceException;
 import edu.unc.lib.dl.metrics.TimerFactory;
+import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService.UpdateDescriptionRequest;
 import edu.unc.lib.dl.services.OperationsMessageSender;
 import io.dropwizard.metrics5.Timer;
 
@@ -99,7 +100,7 @@ public class EditTitleService {
             new XMLOutputter().output(newMods, outStream);
             InputStream newModsStream = new ByteArrayInputStream(outStream.toByteArray());
 
-            updateDescriptionService.updateDescription(agent, pid, newModsStream);
+            updateDescriptionService.updateDescription(new UpdateDescriptionRequest(agent, pid, newModsStream));
         } catch (JDOMException e) {
             throw new ServiceException("Unable to build mods document for " + pid, e);
         } catch (IOException e) {

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/edit/UpdateDescriptionService.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/edit/UpdateDescriptionService.java
@@ -151,7 +151,6 @@ public class UpdateDescriptionService {
                         username, asList(obj.getPid()), request.getPriority());
             }
 
-            obj.shouldRefresh();
             return descBinary;
         }
     }

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/edit/UpdateDescriptionService.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/edit/UpdateDescriptionService.java
@@ -40,6 +40,7 @@ import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
 import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.metrics.TimerFactory;
+import edu.unc.lib.dl.persist.api.indexing.IndexingPriority;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferSession;
 import edu.unc.lib.dl.persist.services.versioning.VersionedDatastreamService;
 import edu.unc.lib.dl.persist.services.versioning.VersionedDatastreamService.DatastreamVersion;
@@ -146,7 +147,8 @@ public class UpdateDescriptionService {
             }
 
             if (sendsMessages) {
-                operationsMessageSender.sendUpdateDescriptionOperation(username, asList(obj.getPid()));
+                operationsMessageSender.sendUpdateDescriptionOperation(
+                        username, asList(obj.getPid()), request.getPriority());
             }
 
             return descBinary;
@@ -212,6 +214,7 @@ public class UpdateDescriptionService {
         private BinaryTransferSession transferSession;
         private AgentPrincipals agent;
         private InputStream modsStream;
+        private IndexingPriority priority;
 
         public UpdateDescriptionRequest(AgentPrincipals agent, PID pid, InputStream modsStream) {
             this.agent = agent;
@@ -265,6 +268,15 @@ public class UpdateDescriptionService {
 
         public void setModsStream(InputStream modsStream) {
             this.modsStream = modsStream;
+        }
+
+        public IndexingPriority getPriority() {
+            return priority;
+        }
+
+        public UpdateDescriptionRequest withPriority(IndexingPriority priority) {
+            this.priority = priority;
+            return this;
         }
     }
 }

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/edit/UpdateDescriptionService.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/edit/UpdateDescriptionService.java
@@ -151,7 +151,7 @@ public class UpdateDescriptionService {
                         username, asList(obj.getPid()), request.getPriority());
             }
 
-            obj.refresh();
+            obj.shouldRefresh();
             return descBinary;
         }
     }

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/edit/UpdateDescriptionService.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/edit/UpdateDescriptionService.java
@@ -151,6 +151,7 @@ public class UpdateDescriptionService {
                         username, asList(obj.getPid()), request.getPriority());
             }
 
+            obj.refresh();
             return descBinary;
         }
     }

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/importxml/ImportXMLJob.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/importxml/ImportXMLJob.java
@@ -54,6 +54,7 @@ import edu.unc.lib.dl.fedora.FedoraException;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.fedora.ServiceException;
 import edu.unc.lib.dl.metrics.TimerFactory;
+import edu.unc.lib.dl.persist.api.indexing.IndexingPriority;
 import edu.unc.lib.dl.persist.api.storage.StorageLocationManager;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferService;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferSession;
@@ -357,8 +358,10 @@ public class ImportXMLJob implements Runnable {
                                             currentPid.getQualifiedId());
                                     BinaryTransferSession transferSession =
                                             session.forDestination(locationManager.getStorageLocation(currentPid));
-                                    updateService.updateDescription(new UpdateDescriptionRequest(
-                                            agent, currentPid, modsStream).withTransferSession(transferSession));
+                                    updateService.updateDescription(
+                                            new UpdateDescriptionRequest(agent, currentPid, modsStream)
+                                                .withTransferSession(transferSession)
+                                                .withPriority(IndexingPriority.low));
                                     updated.add(currentPid.getId());
                                     log.debug("Finished updating object {} with id {}", objectCount, currentPid);
                                 } catch (AccessRestrictionException ex) {

--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/importxml/ImportXMLJob.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/importxml/ImportXMLJob.java
@@ -59,6 +59,7 @@ import edu.unc.lib.dl.persist.api.transfer.BinaryTransferService;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferSession;
 import edu.unc.lib.dl.persist.api.transfer.MultiDestinationTransferSession;
 import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService;
+import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService.UpdateDescriptionRequest;
 import edu.unc.lib.dl.validation.MetadataValidationException;
 import io.dropwizard.metrics5.Timer;
 
@@ -356,7 +357,8 @@ public class ImportXMLJob implements Runnable {
                                             currentPid.getQualifiedId());
                                     BinaryTransferSession transferSession =
                                             session.forDestination(locationManager.getStorageLocation(currentPid));
-                                    updateService.updateDescription(transferSession, agent, currentPid, modsStream);
+                                    updateService.updateDescription(new UpdateDescriptionRequest(
+                                            agent, currentPid, modsStream).withTransferSession(transferSession));
                                     updated.add(currentPid.getId());
                                     log.debug("Finished updating object {} with id {}", objectCount, currentPid);
                                 } catch (AccessRestrictionException ex) {

--- a/persistence/src/main/java/edu/unc/lib/dl/services/IndexingMessageSender.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/services/IndexingMessageSender.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.persist.api.indexing.IndexingPriority;
 import edu.unc.lib.dl.util.IndexingActionType;
 
 /**
@@ -45,7 +46,7 @@ public class IndexingMessageSender extends MessageSender {
      * @param actionType type of indexing action to perform
      */
     public void sendIndexingOperation(String userid, PID targetPid, IndexingActionType actionType) {
-        sendIndexingOperation(userid, targetPid, null, actionType, null);
+        sendIndexingOperation(userid, targetPid, null, actionType, null, null);
     }
 
     /**
@@ -58,7 +59,7 @@ public class IndexingMessageSender extends MessageSender {
      */
     public void sendIndexingOperation(String userid, PID targetPid, Collection<PID> children,
             IndexingActionType actionType) {
-        sendIndexingOperation(userid, targetPid, children, actionType, null);
+        sendIndexingOperation(userid, targetPid, children, actionType, null, null);
     }
 
     /**
@@ -72,8 +73,8 @@ public class IndexingMessageSender extends MessageSender {
      *            message
      */
     public void sendIndexingOperation(String userid, PID targetPid, Collection<PID> children,
-            IndexingActionType actionType, Map<String, String> parameters) {
-        Document msg = makeIndexingOperationBody(userid, targetPid, children, actionType, parameters);
+            IndexingActionType actionType, Map<String, String> parameters, IndexingPriority priority) {
+        Document msg = makeIndexingOperationBody(userid, targetPid, children, actionType, parameters, priority);
 
         LOG.debug("sending solr update message for {} of type {}", targetPid, actionType.toString());
         sendMessage(msg);

--- a/persistence/src/main/java/edu/unc/lib/dl/services/MessageSender.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/services/MessageSender.java
@@ -45,6 +45,10 @@ public class MessageSender {
         jmsTemplate.send(new MessageCreator() {
             @Override
             public Message createMessage(Session session) throws JMSException {
+                // Committing the session to flush changes in long running threads
+                if (session.getTransacted()) {
+                    session.commit();
+                }
                 return session.createTextMessage(msgStr);
             }
         });

--- a/persistence/src/main/java/edu/unc/lib/dl/services/OperationsMessageSender.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/services/OperationsMessageSender.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.persist.api.indexing.IndexingPriority;
 import edu.unc.lib.dl.util.JMSMessageUtil.CDRActions;
 import edu.unc.lib.dl.util.ResourceType;
 
@@ -274,6 +275,10 @@ public class OperationsMessageSender extends MessageSender {
         return getMessageId(msg);
     }
 
+    public String sendUpdateDescriptionOperation(String userid, Collection<PID> pids) {
+        return sendUpdateDescriptionOperation(userid, pids, null);
+    }
+
     /**
      * Sends Update MODS operation message.
      *
@@ -281,7 +286,7 @@ public class OperationsMessageSender extends MessageSender {
      * @param pids objects whose MODS changed
      * @return id of operation message
      */
-    public String sendUpdateDescriptionOperation(String userid, Collection<PID> pids) {
+    public String sendUpdateDescriptionOperation(String userid, Collection<PID> pids, IndexingPriority priority) {
         Element contentEl = createAtomEntry(userid, pids.iterator().next(),
                 CDRActions.UPDATE_DESCRIPTION);
 
@@ -292,6 +297,10 @@ public class OperationsMessageSender extends MessageSender {
         updateEl.addContent(subjects);
         for (PID sub : pids) {
             subjects.addContent(new Element("pid", CDR_MESSAGE_NS).setText(sub.getRepositoryPath()));
+        }
+
+        if (priority != null) {
+            contentEl.getParentElement().addContent(new Element("category", ATOM_NS).setText(priority.name()));
         }
 
         Document msg = contentEl.getDocument();

--- a/persistence/src/main/java/edu/unc/lib/dl/util/IndexingMessageHelper.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/util/IndexingMessageHelper.java
@@ -28,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.persist.api.indexing.IndexingPriority;
 
 /**
  * Helper methods for generating indexing messages
@@ -44,11 +45,11 @@ public class IndexingMessageHelper {
 
     public static Document makeIndexingOperationBody(String userid, PID targetPid, Collection<PID> children,
             IndexingActionType actionType) {
-        return makeIndexingOperationBody(userid, targetPid, children, actionType, null);
+        return makeIndexingOperationBody(userid, targetPid, children, actionType, null, null);
     }
 
     public static Document makeIndexingOperationBody(String userid, PID targetPid, Collection<PID> children,
-            IndexingActionType actionType, Map<String, String> params) {
+            IndexingActionType actionType, Map<String, String> params, IndexingPriority priority) {
         Document msg = new Document();
         Element entry = new Element("entry", ATOM_NS);
         msg.addContent(entry);
@@ -73,6 +74,10 @@ public class IndexingMessageHelper {
                 paramEl.setText(param.getValue());
                 paramsEl.addContent(paramEl);
             }
+        }
+
+        if (priority != null) {
+            entry.addContent(new Element("category", ATOM_NS).setText(priority.name()));
         }
 
         return msg;

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsJobIT.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/destroy/DestroyObjectsJobIT.java
@@ -320,9 +320,9 @@ public class DestroyObjectsJobIT {
         assertTrue(logParentModel.contains(null, RDF.type, Premis.Deletion));
         assertTrue(logParentModel.contains(null, Premis.note, "3 object(s) were destroyed"));
 
-        Resource fileResc = fileObj.getResource();
-        Resource workResc = workObj.getResource();
-        Resource folderResc = folderObj.getResource();
+        Resource fileResc = fileObj.getResource(true);
+        Resource workResc = workObj.getResource(true);
+        Resource folderResc = folderObj.getResource(true);
         assertTrue(fileResc.hasProperty(RDF.type, Cdr.Tombstone));
         assertTrue(fileResc.hasProperty(PcdmModels.memberOf, workResc));
         assertTrue(workResc.hasProperty(RDF.type, Cdr.Tombstone));

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/edit/EditTitleServiceTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/edit/EditTitleServiceTest.java
@@ -32,7 +32,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URI;
 import java.util.List;
 import java.util.UUID;
 
@@ -57,6 +56,7 @@ import edu.unc.lib.dl.fcrepo4.ContentObject;
 import edu.unc.lib.dl.fcrepo4.PIDs;
 import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
 import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService.UpdateDescriptionRequest;
 import edu.unc.lib.dl.services.OperationsMessageSender;
 
 public class EditTitleServiceTest {
@@ -79,13 +79,9 @@ public class EditTitleServiceTest {
     private OperationsMessageSender operationsMessageSender;
 
     @Captor
-    private ArgumentCaptor<PID> pidCaptor;
+    private ArgumentCaptor<UpdateDescriptionRequest> updateCaptor;
     @Captor
     private ArgumentCaptor<List<PID>> pidListCaptor;
-    @Captor
-    private ArgumentCaptor<InputStream> inputStreamCaptor;
-    @Captor
-    private ArgumentCaptor<URI> uriCaptor;
 
     private EditTitleService service;
     private PID pid;
@@ -124,10 +120,9 @@ public class EditTitleServiceTest {
 
         service.editTitle(agent, pid, title);
 
-        verify(updateDescriptionService).updateDescription(
-                eq(agent), pidCaptor.capture(), inputStreamCaptor.capture());
+        verify(updateDescriptionService).updateDescription(updateCaptor.capture());
 
-        assertEquals(pid, pidCaptor.getValue());
+        assertEquals(pid, updateCaptor.getValue().getPid());
 
         Document updatedDoc = getUpdatedDescriptionDocument();
         assertTrue(hasTitleValue(updatedDoc, title));
@@ -157,10 +152,9 @@ public class EditTitleServiceTest {
 
         service.editTitle(agent, pid, title);
 
-        verify(updateDescriptionService).updateDescription(
-                eq(agent), pidCaptor.capture(), inputStreamCaptor.capture());
+        verify(updateDescriptionService).updateDescription(updateCaptor.capture());
 
-        assertEquals(pid, pidCaptor.getValue());
+        assertEquals(pid, updateCaptor.getValue().getPid());
 
         Document updatedDoc = getUpdatedDescriptionDocument();
         assertTrue(hasTitleValue(updatedDoc, title));
@@ -179,10 +173,9 @@ public class EditTitleServiceTest {
 
         service.editTitle(agent, pid, title);
 
-        verify(updateDescriptionService).updateDescription(
-                eq(agent), pidCaptor.capture(), inputStreamCaptor.capture());
+        verify(updateDescriptionService).updateDescription(updateCaptor.capture());
 
-        assertEquals(pid, pidCaptor.getValue());
+        assertEquals(pid, updateCaptor.getValue().getPid());
 
         Document updatedDoc = getUpdatedDescriptionDocument();
         assertTrue(hasTitleValue(updatedDoc, title));
@@ -200,11 +193,9 @@ public class EditTitleServiceTest {
 
         service.editTitle(agent, pid, title);
 
-        verify(updateDescriptionService).updateDescription(
-                eq(agent), pidCaptor.capture(), inputStreamCaptor.capture());
+        verify(updateDescriptionService).updateDescription(updateCaptor.capture());
 
-        assertEquals(pid, pidCaptor.getValue());
-
+        assertEquals(pid, updateCaptor.getValue().getPid());
 
         Document updatedDoc = getUpdatedDescriptionDocument();
         assertTrue(hasTitleValue(updatedDoc, title));
@@ -222,7 +213,7 @@ public class EditTitleServiceTest {
 
     private Document getUpdatedDescriptionDocument() throws IOException, JDOMException {
         SAXBuilder sb = createSAXBuilder();
-        return sb.build(inputStreamCaptor.getValue());
+        return sb.build(updateCaptor.getValue().getModsStream());
     }
 
     private boolean hasTitleValue(Document document, String expectedTitle) {

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/edit/UpdateDescriptionServiceIT.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/edit/UpdateDescriptionServiceIT.java
@@ -49,6 +49,7 @@ import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
 import edu.unc.lib.dl.fcrepo4.WorkObject;
 import edu.unc.lib.dl.model.DatastreamPids;
 import edu.unc.lib.dl.model.DatastreamType;
+import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService.UpdateDescriptionRequest;
 import edu.unc.lib.dl.test.TestHelper;
 
 /**
@@ -123,7 +124,7 @@ public class UpdateDescriptionServiceIT {
         Document doc = new Document()
                 .addContent(modsWithTitleAndDate(title, date));
         InputStream modsStream = documentToInputStream(doc);
-        updateService.updateDescription(null, agent, contentObj, modsStream);
+        updateService.updateDescription(new UpdateDescriptionRequest(agent, contentObj, modsStream));
     }
 
     private void assertHasMods(InputStream updatedMods, String expectedTitle, String expectedDate)

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/edit/UpdateDescriptionServiceTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/edit/UpdateDescriptionServiceTest.java
@@ -52,6 +52,7 @@ import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.persist.api.storage.StorageLocation;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferSession;
+import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService.UpdateDescriptionRequest;
 import edu.unc.lib.dl.persist.services.versioning.VersionedDatastreamService;
 import edu.unc.lib.dl.persist.services.versioning.VersionedDatastreamService.DatastreamVersion;
 import edu.unc.lib.dl.services.OperationsMessageSender;
@@ -132,7 +133,7 @@ public class UpdateDescriptionServiceTest {
 
     @Test
     public void updateDescriptionTest() throws Exception {
-        service.updateDescription(agent, objPid, modsStream);
+        service.updateDescription(new UpdateDescriptionRequest(agent, objPid, modsStream));
 
         verify(versioningService).addVersion(versionCaptor.capture());
         DatastreamVersion version = versionCaptor.getValue();
@@ -147,7 +148,7 @@ public class UpdateDescriptionServiceTest {
     public void updateDescriptionAlreadyExistsTest() throws Exception {
         when(repoObjFactory.objectExists(modsPid.getRepositoryUri())).thenReturn(true);
 
-        service.updateDescription(agent, objPid, modsStream);
+        service.updateDescription(new UpdateDescriptionRequest(agent, objPid, modsStream));
 
         verify(versioningService).addVersion(versionCaptor.capture());
         DatastreamVersion version = versionCaptor.getValue();
@@ -163,7 +164,7 @@ public class UpdateDescriptionServiceTest {
         doThrow(new AccessRestrictionException()).when(aclService)
                 .assertHasAccess(anyString(), eq(objPid), any(AccessGroupSet.class), any(Permission.class));
 
-        service.updateDescription(agent, objPid, modsStream);
+        service.updateDescription(new UpdateDescriptionRequest(agent, objPid, modsStream));
     }
 
     @Test
@@ -173,7 +174,7 @@ public class UpdateDescriptionServiceTest {
 
         service.setChecksAccess(false);
 
-        service.updateDescription(agent, objPid, modsStream);
+        service.updateDescription(new UpdateDescriptionRequest(agent, objPid, modsStream));
 
         verify(versioningService).addVersion(any());
         assertMessageSent();
@@ -183,7 +184,7 @@ public class UpdateDescriptionServiceTest {
     public void invalidModsTest() throws Exception {
         doThrow(new MetadataValidationException()).when(modsValidator).validate(any(InputStream.class));
 
-        service.updateDescription(agent, objPid, modsStream);
+        service.updateDescription(new UpdateDescriptionRequest(agent, objPid, modsStream));
     }
 
     @Test
@@ -191,12 +192,14 @@ public class UpdateDescriptionServiceTest {
         service.setValidate(false);
         doThrow(new MetadataValidationException()).when(modsValidator).validate(any(InputStream.class));
 
-        service.updateDescription(transferSession, agent, objPid, modsStream);
+        service.updateDescription(new UpdateDescriptionRequest(agent, objPid, modsStream)
+                .withTransferSession(transferSession));
     }
 
     @Test
     public void updateDescriptionProvidedSession() throws Exception {
-        service.updateDescription(transferSession, agent, objPid, modsStream);
+        service.updateDescription(new UpdateDescriptionRequest(agent, objPid, modsStream)
+                .withTransferSession(transferSession));
 
         verify(versioningService).addVersion(versionCaptor.capture());
         DatastreamVersion version = versionCaptor.getValue();
@@ -210,7 +213,7 @@ public class UpdateDescriptionServiceTest {
     public void updateDescriptionDisableMassgesTest() throws Exception {
         service.setSendsMessages(false);
 
-        service.updateDescription(agent, objPid, modsStream);
+        service.updateDescription(new UpdateDescriptionRequest(agent, objPid, modsStream));
 
         verify(versioningService).addVersion(versionCaptor.capture());
         DatastreamVersion version = versionCaptor.getValue();

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/edit/UpdateDescriptionServiceTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/edit/UpdateDescriptionServiceTest.java
@@ -50,6 +50,7 @@ import edu.unc.lib.dl.fcrepo4.PIDs;
 import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
 import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
 import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.persist.api.indexing.IndexingPriority;
 import edu.unc.lib.dl.persist.api.storage.StorageLocation;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferSession;
 import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService.UpdateDescriptionRequest;
@@ -225,7 +226,8 @@ public class UpdateDescriptionServiceTest {
     }
 
     private void assertMessageSent() {
-        verify(messageSender).sendUpdateDescriptionOperation(anyString(), pidsCaptor.capture());
+        verify(messageSender).sendUpdateDescriptionOperation(
+                anyString(), pidsCaptor.capture(), any(IndexingPriority.class));
         Collection<PID> pids = pidsCaptor.getValue();
         assertEquals(1, pids.size());
         assertTrue(pids.contains(objPid));

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/importxml/ImportXMLJobIT.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/importxml/ImportXMLJobIT.java
@@ -64,6 +64,7 @@ import edu.unc.lib.dl.fedora.ContentPathFactory;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.persist.api.storage.StorageLocationManager;
 import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService;
+import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService.UpdateDescriptionRequest;
 import edu.unc.lib.dl.persist.services.transfer.BinaryTransferServiceImpl;
 import edu.unc.lib.dl.test.TestHelper;
 
@@ -295,7 +296,7 @@ public class ImportXMLJobIT {
         Document doc = new Document()
                 .addContent(modsWithTitleAndDate(ORIGINAL_TITLE, ORIGINAL_DATE));
         InputStream modsStream = documentToInputStream(doc);
-        updateService.updateDescription(null, agent, workObj, modsStream);
+        updateService.updateDescription(new UpdateDescriptionRequest(agent, workObj, modsStream));
         return workPid;
     }
 

--- a/persistence/src/test/resources/spring-test/acl-service-context.xml
+++ b/persistence/src/test/resources/spring-test/acl-service-context.xml
@@ -26,7 +26,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="0" />
         <property name="cacheTimeToLive" value="0" />
-        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
     </bean>
     
     <bean id="contentPathFactory" class="edu.unc.lib.dl.fedora.ContentPathFactory"

--- a/persistence/src/test/resources/spring-test/cdr-client-container.xml
+++ b/persistence/src/test/resources/spring-test/cdr-client-container.xml
@@ -27,7 +27,7 @@
         <property name="client" ref="fcrepoClient" />
         <property name="ldpFactory" ref="ldpContainerFactory" />
         <property name="pidMinter" ref="repositoryPIDMinter" />
-        <property name="repositoryObjectDriver" ref="repositoryObjectDriver" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
         <property name="sparqlUpdateService" ref="fedoraSparqlUpdateService" />
     </bean>
     

--- a/persistence/src/test/resources/spring-test/staff-role-service-container.xml
+++ b/persistence/src/test/resources/spring-test/staff-role-service-container.xml
@@ -17,7 +17,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="0" />
         <property name="cacheTimeToLive" value="0" />
-        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
     </bean>
     
     <bean id="inheritedAclFactory" class="edu.unc.lib.dl.acl.fcrepo4.InheritedAclFactory">

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/routing/MetaServicesRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/routing/MetaServicesRouter.java
@@ -28,6 +28,7 @@ import org.fcrepo.client.FcrepoOperationFailedException;
 import org.slf4j.Logger;
 
 import edu.unc.lib.dl.services.camel.BinaryMetadataProcessor;
+import edu.unc.lib.dl.services.camel.util.CacheInvalidatingProcessor;
 
 /**
  * Meta router which sequences all service routes to run on events.
@@ -40,6 +41,9 @@ public class MetaServicesRouter extends RouteBuilder {
 
     @BeanInject(value = "binaryMetadataProcessor")
     private BinaryMetadataProcessor mdProcessor;
+
+    @BeanInject(value = "cacheInvalidatingProcessor")
+    private CacheInvalidatingProcessor cacheInvalidatingProcessor;
 
     @PropertyInject(value = "cdr.enhancement.processingThreads")
     private Integer enhancementThreads;
@@ -75,6 +79,7 @@ public class MetaServicesRouter extends RouteBuilder {
                     }
                 })
             .end()
+            .bean(cacheInvalidatingProcessor)
             .filter().method(FedoraIdFilters.class, "allowedForLongleaf")
                 .wireTap("direct-vm:filter.longleaf")
             .end().end() // ending the filter and the wiretap

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/solr/CdrEventToSolrUpdateProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/solr/CdrEventToSolrUpdateProcessor.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import edu.unc.lib.dl.fcrepo4.PIDs;
 import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.persist.api.indexing.IndexingPriority;
 import edu.unc.lib.dl.services.IndexingMessageSender;
 import edu.unc.lib.dl.util.IndexingActionType;
 import edu.unc.lib.dl.util.JMSMessageUtil;
@@ -61,7 +62,8 @@ public class CdrEventToSolrUpdateProcessor implements Processor {
             return;
         }
 
-        Element content = body.getRootElement().getChild("content", JDOMNamespaceUtil.ATOM_NS);
+        Element rootEl = body.getRootElement();
+        Element content = rootEl.getChild("content", JDOMNamespaceUtil.ATOM_NS);
         Element contentBody = content.getChildren().get(0);
 
         if (contentBody == null || contentBody.getChildren().size() == 0) {
@@ -117,8 +119,11 @@ public class CdrEventToSolrUpdateProcessor implements Processor {
             return;
         }
 
+        String priorityString = rootEl.getChildText("category", JDOMNamespaceUtil.ATOM_NS);
+        IndexingPriority priority = priorityString == null ? null : IndexingPriority.valueOf(priorityString);
+
         messageSender.sendIndexingOperation(userid, PIDs.get(targetId), childPids,
-                indexingActionType);
+                indexingActionType, null, priority);
     }
 
     private List<String> populateList(String field, Element contentBody) {

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/solrUpdate/SolrUpdatePreprocessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/solrUpdate/SolrUpdatePreprocessor.java
@@ -70,6 +70,11 @@ public class SolrUpdatePreprocessor implements Processor {
         String pidString = body.getChild("pid", ATOM_NS).getTextTrim();
         PID pid = PIDs.get(pidString);
         in.setHeader(FcrepoHeaders.FCREPO_URI, pid.getRepositoryPath());
+
+        String priority = body.getChildTextTrim("category", ATOM_NS);
+        if (priority != null) {
+            in.setHeader(CdrFcrepoHeaders.CdrSolrIndexingPriority, priority);
+        }
     }
 
     private static final Set<IndexingActionType> LARGE_ACTIONS =

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/solrUpdate/SolrUpdatePreprocessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/solrUpdate/SolrUpdatePreprocessor.java
@@ -32,6 +32,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Header;
 import org.apache.camel.Message;
 import org.apache.camel.Processor;
+import org.fcrepo.camel.FcrepoHeaders;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.output.Format;
@@ -39,6 +40,8 @@ import org.jdom2.output.XMLOutputter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.services.camel.util.CdrFcrepoHeaders;
 import edu.unc.lib.dl.services.camel.util.MessageUtil;
 import edu.unc.lib.dl.util.IndexingActionType;
@@ -64,8 +67,9 @@ public class SolrUpdatePreprocessor implements Processor {
 
         // Store the action type as a header
         in.setHeader(CdrFcrepoHeaders.CdrSolrUpdateAction, actionType);
-        // Serialize the message for persistence
-        in.setBody(new XMLOutputter().outputString(msgBody));
+        String pidString = body.getChild("pid", ATOM_NS).getTextTrim();
+        PID pid = PIDs.get(pidString);
+        in.setHeader(FcrepoHeaders.FCREPO_URI, pid.getRepositoryPath());
     }
 
     private static final Set<IndexingActionType> LARGE_ACTIONS =

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/solrUpdate/SolrUpdateRouter.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/solrUpdate/SolrUpdateRouter.java
@@ -23,6 +23,7 @@ import org.apache.camel.builder.RouteBuilder;
 import org.slf4j.Logger;
 
 import edu.unc.lib.dl.fedora.NotFoundException;
+import edu.unc.lib.dl.services.camel.util.CacheInvalidatingProcessor;
 
 /**
  * Route for performing solr updates for update requests.
@@ -42,6 +43,9 @@ public class SolrUpdateRouter extends RouteBuilder {
     @BeanInject(value = "solrUpdatePreprocessor")
     private SolrUpdatePreprocessor solrUpdatePreprocessor;
 
+    @BeanInject(value = "cacheInvalidatingProcessor")
+    private CacheInvalidatingProcessor cacheInvalidatingProcessor;
+
     @Override
     public void configure() throws Exception {
         onException(NotFoundException.class)
@@ -60,24 +64,19 @@ public class SolrUpdateRouter extends RouteBuilder {
             .routeId("CdrServiceSolrUpdate")
             .startupOrder(510)
             .bean(solrUpdatePreprocessor)
+            // Ensure that data for the object being directly indexed is up to date
+            .bean(cacheInvalidatingProcessor)
             .log(LoggingLevel.DEBUG, log, "Received solr update message with action ${header[CdrSolrUpdateAction]}")
             .choice()
                 .when().method(SolrUpdatePreprocessor.class, "isLargeAction")
-                    .to("{{cdr.solrupdate.large.consumer}}")
+                    .to("{{cdr.solrupdate.large.camel}}")
                 .when().method(SolrUpdatePreprocessor.class, "isSmallAction")
-                    .to("{{cdr.solrupdate.small.dest}}")
+                    .bean(solrSmallUpdateProcessor)
                 .otherwise()
                     .bean(solrUpdatePreprocessor, "logUnknownSolrUpdate")
             .endChoice();
 
-        from("{{cdr.solrupdate.small.consumer}}")
-            .routeId("CdrSolrUpdateSmall")
-            .startupOrder(508)
-            .log(LoggingLevel.DEBUG, log, "Performing batch of small solr updates")
-            .split(body())
-            .bean(solrSmallUpdateProcessor);
-
-        from("{{cdr.solrupdate.large.consumer}}")
+        from("{{cdr.solrupdate.large.camel}}")
             .routeId("CdrSolrUpdateLarge")
             .startupOrder(507)
             .log(LoggingLevel.DEBUG, log, "Performing large solr update")

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/util/CacheInvalidatingProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/util/CacheInvalidatingProcessor.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.services.camel.util;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+import org.fcrepo.camel.FcrepoHeaders;
+import org.slf4j.Logger;
+
+import edu.unc.lib.dl.acl.fcrepo4.ObjectAclFactory;
+import edu.unc.lib.dl.fcrepo4.FcrepoJmsConstants;
+import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.fedora.PIDConstants;
+
+/**
+ * Processor which invalidates cache entries for updated objects
+ *
+ * @author bbpennel
+ */
+public class CacheInvalidatingProcessor implements Processor {
+    private static final Logger log = getLogger(CacheInvalidatingProcessor.class);
+    private RepositoryObjectLoader repoObjLoader;
+    private ObjectAclFactory objectAclFactory;
+
+    @Override
+    public void process(Exchange exchange) throws Exception {
+        Message in = exchange.getIn();
+        String fcrepoUri = (String) in.getHeader(FcrepoHeaders.FCREPO_URI);
+        if (fcrepoUri == null) {
+            String fcrepoId = (String) in.getHeader(FcrepoJmsConstants.IDENTIFIER);
+            String fcrepoBaseUrl = (String) in.getHeader(FcrepoJmsConstants.BASE_URL);
+            fcrepoUri = fcrepoBaseUrl + fcrepoId;
+        }
+
+        PID pid;
+        try {
+            pid = PIDs.get(fcrepoUri);
+        } catch (Exception e) {
+            log.debug("Failed to parse fcrepo id {} as PID while filtering: {}", fcrepoUri, e.getMessage());
+            return;
+        }
+        // Filter out non-content objects
+        if (pid == null || !PIDConstants.CONTENT_QUALIFIER.equals(pid.getQualifier())) {
+            return;
+        }
+        log.warn("Invalidating caches for {}", pid);
+        repoObjLoader.invalidate(pid);
+        objectAclFactory.invalidate(pid);
+    }
+
+    public void setRepositoryObjectLoader(RepositoryObjectLoader repoObjLoader) {
+        this.repoObjLoader = repoObjLoader;
+    }
+
+    public void setObjectAclFactory(ObjectAclFactory objectAclFactory) {
+        this.objectAclFactory = objectAclFactory;
+    }
+}

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/util/CacheInvalidatingProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/util/CacheInvalidatingProcessor.java
@@ -61,7 +61,7 @@ public class CacheInvalidatingProcessor implements Processor {
         if (pid == null || !PIDConstants.CONTENT_QUALIFIER.equals(pid.getQualifier())) {
             return;
         }
-        log.warn("Invalidating caches for {}", pid);
+        log.debug("Invalidating caches for {}", pid);
         repoObjLoader.invalidate(pid);
         objectAclFactory.invalidate(pid);
     }

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/util/CdrFcrepoHeaders.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/util/CdrFcrepoHeaders.java
@@ -45,4 +45,6 @@ public abstract class CdrFcrepoHeaders {
     public static final String CdrEnhancementSet = "CdrEnhancementSet";
 
     public static final String CdrSolrUpdateAction = "CdrSolrUpdateAction";
+
+    public static final String CdrSolrIndexingPriority = "CdrSolrIndexingPriority";
 }

--- a/services-camel/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel/src/main/webapp/WEB-INF/service-context.xml
@@ -66,7 +66,7 @@
         <property name="client" ref="fcrepoClient" />
         <property name="ldpFactory" ref="ldpContainerFactory" />
         <property name="pidMinter" ref="repositoryPIDMinter" />
-        <property name="repositoryObjectDriver" ref="repositoryObjectDriver" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
         <property name="sparqlUpdateService" ref="fedoraSparqlUpdateService" />
     </bean>
 

--- a/services-camel/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel/src/main/webapp/WEB-INF/service-context.xml
@@ -120,7 +120,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="${cache.objectAcls.maxSize}" />
         <property name="cacheTimeToLive" value="${cache.objectAcls.timeToLive}" />
-        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
     </bean>
     
     <bean id="inheritedPermissionEvaluator" class="edu.unc.lib.dl.acl.fcrepo4.InheritedPermissionEvaluator">
@@ -205,6 +205,11 @@
     
     <bean id="binaryMetadataProcessor" class="edu.unc.lib.dl.services.camel.BinaryMetadataProcessor">
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+    </bean>
+    
+    <bean id="cacheInvalidatingProcessor" class="edu.unc.lib.dl.services.camel.util.CacheInvalidatingProcessor">
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
+        <property name="objectAclFactory" ref="objectAclFactory" />
     </bean>
 
     <bean id="addSmallThumbnailProcessor" class="edu.unc.lib.dl.services.camel.images.AddDerivativeProcessor">

--- a/services-camel/src/main/webapp/WEB-INF/solr-indexing-context.xml
+++ b/services-camel/src/main/webapp/WEB-INF/solr-indexing-context.xml
@@ -110,8 +110,8 @@
         class="edu.unc.lib.dl.data.ingest.solr.indexing.SolrUpdateDriver"
         init-method="init">
         <property name="solrSettings" ref="solrSettings" />
-        <property name="autoPushCount" value="1000" />
-        <property name="updateThreads" value="2" />
+        <property name="autoPushCount" value="${solr.update.autoPushCount}" />
+        <property name="updateThreads" value="${solr.update.updateThreads}" />
     </bean>
     
     <util:properties id="searchProperties" location="classpath:search.properties" />

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/cdrEvents/CdrEventRoutingIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/cdrEvents/CdrEventRoutingIT.java
@@ -113,11 +113,11 @@ public class CdrEventRoutingIT {
         List<PID> added = pidList(3);
         List<PID> destinations = pidList(1);
 
-        opsMsgSender.sendAddOperation(USER_ID, destinations, added, emptyList(), DEPOSIT_ID);
-
         NotifyBuilder notify = new NotifyBuilder(cdrServiceSolrUpdate)
                 .whenCompleted(1)
                 .create();
+
+        opsMsgSender.sendAddOperation(USER_ID, destinations, added, emptyList(), DEPOSIT_ID);
 
         notify.matches(3l, TimeUnit.SECONDS);
 
@@ -134,11 +134,11 @@ public class CdrEventRoutingIT {
         int numPids = 3;
         List<PID> pids = pidList(numPids);
 
-        opsMsgSender.sendMarkForDeletionOperation(USER_ID, pids);
-
         NotifyBuilder notify = new NotifyBuilder(cdrServiceSolrUpdate)
                 .whenCompleted(1)
                 .create();
+
+        opsMsgSender.sendMarkForDeletionOperation(USER_ID, pids);
 
         notify.matches(3l, TimeUnit.SECONDS);
 

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/destroy/DestroyObjectsRouterTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/destroy/DestroyObjectsRouterTest.java
@@ -115,7 +115,7 @@ public class DestroyObjectsRouterTest extends CamelSpringTestSupport {
         Model model = createDefaultModel();
         Resource resc = model.getResource(pid.getRepositoryPath());
         resc.addProperty(RDF.type, Cdr.Work);
-        when(workObj.getResource()).thenReturn(resc);
+        when(workObj.getResource(true)).thenReturn(resc);
         when(workObj.getPid()).thenReturn(pid);
         when(workObj.getUri()).thenReturn(pid.getRepositoryUri());
         when(workObj.getTypes()).thenReturn(Collections.singletonList(Cdr.Work.getURI()));

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/enhancements/EnhancementRouterIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/enhancements/EnhancementRouterIT.java
@@ -70,6 +70,7 @@ import edu.unc.lib.dl.fcrepo4.PIDs;
 import edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService;
+import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService.UpdateDescriptionRequest;
 import edu.unc.lib.dl.rdf.Cdr;
 import edu.unc.lib.dl.services.camel.BinaryMetadataProcessor;
 import edu.unc.lib.dl.services.camel.NonBinaryEnhancementProcessor;
@@ -278,8 +279,8 @@ public class EnhancementRouterIT {
     @Test
     public void testProcessFilterOutDescriptiveMDSolr() throws Exception {
         FileObject fileObj = repoObjectFactory.createFileObject(null);
-        BinaryObject descObj = updateDescriptionService.updateDescription(mock(AgentPrincipals.class),
-                fileObj.getPid(), new ByteArrayInputStream(FILE_CONTENT.getBytes()));
+        BinaryObject descObj = updateDescriptionService.updateDescription(new UpdateDescriptionRequest(
+                mock(AgentPrincipals.class), fileObj.getPid(), new ByteArrayInputStream(FILE_CONTENT.getBytes())));
 
         NotifyBuilder notify = new NotifyBuilder(cdrEnhancements)
                 .whenCompleted(1)

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/routing/MetaServicesRouterTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/routing/MetaServicesRouterTest.java
@@ -89,7 +89,7 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
 
         createContext(META_ROUTE);
 
-        NotifyBuilder notify = new NotifyBuilder(context).whenDone(1).create();
+        NotifyBuilder notify = new NotifyBuilder(context).whenCompleted(1).create();
         template.sendBodyAndHeaders("", createEvent(CONTAINER_ID, Container.getURI()));
         notify.matches(1l, TimeUnit.SECONDS);
 
@@ -104,9 +104,11 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
 
         createContext(META_ROUTE);
 
-        NotifyBuilder notify = new NotifyBuilder(context).whenDone(1).create();
+        NotifyBuilder notify = new NotifyBuilder(context).whenCompleted(1).create();
         template.sendBodyAndHeaders("", createEvent(CONTAINER_ID + "/" + FCR_VERSIONS,
                 Fcrepo4Repository.Container.getURI()));
+        // delay so that message has time to reach all routes that expect 0
+        Thread.sleep(100);
         notify.matches(1l, TimeUnit.SECONDS);
 
         assertMockEndpointsSatisfied();
@@ -120,9 +122,11 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
 
         createContext(META_ROUTE);
 
-        NotifyBuilder notify = new NotifyBuilder(context).whenDone(1).create();
+        NotifyBuilder notify = new NotifyBuilder(context).whenCompleted(1).create();
         template.sendBodyAndHeaders("", createEvent(CONTAINER_ID + "/datafs",
                 Fcrepo4Repository.Container.getURI()));
+        // delay so that message has time to reach all routes that expect 0
+        Thread.sleep(100);
         notify.matches(1l, TimeUnit.SECONDS);
 
         assertMockEndpointsSatisfied();
@@ -136,9 +140,11 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
 
         createContext(META_ROUTE);
 
-        NotifyBuilder notify = new NotifyBuilder(context).whenDone(1).create();
+        NotifyBuilder notify = new NotifyBuilder(context).whenCompleted(1).create();
         template.sendBodyAndHeaders("", createEvent(DEPOSIT_ID,
                 Fcrepo4Repository.Container.getURI()));
+        // delay so that message has time to reach all routes that expect 0
+        Thread.sleep(100);
         notify.matches(1l, TimeUnit.SECONDS);
 
         assertMockEndpointsSatisfied();
@@ -152,9 +158,11 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
 
         createContext(META_ROUTE);
 
-        NotifyBuilder notify = new NotifyBuilder(context).whenDone(1).create();
+        NotifyBuilder notify = new NotifyBuilder(context).whenCompleted(1).create();
         template.sendBodyAndHeaders("", createEvent("what/is/going/on",
                 Fcrepo4Repository.Container.getURI()));
+        // delay so that message has time to reach all routes that expect 0
+        Thread.sleep(100);
         notify.matches(1l, TimeUnit.SECONDS);
 
         assertMockEndpointsSatisfied();
@@ -164,11 +172,12 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
     public void testRouteStartCollections() throws Exception {
         getMockEndpoint("mock:direct-vm:index.start").expectedMessageCount(1);
         getMockEndpoint("mock:direct-vm:filter.longleaf").expectedMessageCount(0);
-        getMockEndpoint("mock:direct:process.enhancement").expectedMessageCount(0);
+        // Enhancements call for root obj to trigger indexing
+        getMockEndpoint("mock:direct:process.enhancement").expectedMessageCount(1);
 
         createContext(META_ROUTE);
 
-        NotifyBuilder notify = new NotifyBuilder(context).whenDone(1).create();
+        NotifyBuilder notify = new NotifyBuilder(context).whenCompleted(1).create();
         template.sendBodyAndHeaders("", createEvent("/content/" + RepositoryPathConstants.CONTENT_ROOT_ID,
                 Fcrepo4Repository.Container.getURI()));
         notify.matches(1l, TimeUnit.SECONDS);
@@ -184,12 +193,14 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
 
         createContext(META_ROUTE);
 
-        NotifyBuilder notify = new NotifyBuilder(context).whenDone(1).create();
+        NotifyBuilder notify = new NotifyBuilder(context).whenCompleted(1).create();
         // fcr:metadata nodes come through as Binaries with an internal modeshape path as the identifier
         Map<String, Object> eventMap = createEvent(CONTAINER_ID + "/datafs/original_file/fcr:metadata",
                 Fcrepo4Repository.Binary.getURI());
         eventMap.put(IDENTIFIER, CONTAINER_ID + "/datafs/original_file/fedora:metadata");
         template.sendBodyAndHeaders("", eventMap);
+        // delay so that message has time to reach all routes that expect 0
+        Thread.sleep(100);
 
         notify.matches(1l, TimeUnit.SECONDS);
 
@@ -204,7 +215,7 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
 
         createContext(META_ROUTE);
 
-        NotifyBuilder notify = new NotifyBuilder(context).whenDone(1).create();
+        NotifyBuilder notify = new NotifyBuilder(context).whenCompleted(1).create();
         template.sendBodyAndHeaders("", createEvent(CONTAINER_ID + "/datafs/original_file",
                 Fcrepo4Repository.Binary.getURI()));
         notify.matches(1l, TimeUnit.SECONDS);
@@ -220,9 +231,11 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
 
         createContext(META_ROUTE);
 
-        NotifyBuilder notify = new NotifyBuilder(context).whenDone(1).create();
+        NotifyBuilder notify = new NotifyBuilder(context).whenCompleted(1).create();
         template.sendBodyAndHeaders("", createEvent(CONTAINER_ID + "/md/event_log",
                 Fcrepo4Repository.Binary.getURI()));
+        // delay so that message has time to reach all routes that expect 0
+        Thread.sleep(100);
         notify.matches(1l, TimeUnit.SECONDS);
 
         assertMockEndpointsSatisfied();
@@ -237,7 +250,7 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
         Map<String, Object> headers = createEvent(FILE_ID, Binary.getURI());
         headers.put(EVENT_TYPE, "ResourceDeletion");
 
-        NotifyBuilder notify = new NotifyBuilder(context).whenDone(1).create();
+        NotifyBuilder notify = new NotifyBuilder(context).whenCompleted(1).create();
         template.sendBodyAndHeaders("", headers);
         notify.matches(1l, TimeUnit.SECONDS);
 
@@ -250,7 +263,7 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
 
         createContext(META_ROUTE);
 
-        NotifyBuilder notify = new NotifyBuilder(context).whenDone(1).create();
+        NotifyBuilder notify = new NotifyBuilder(context).whenCompleted(1).create();
         Map<String, Object> headers = createEvent(FILE_ID, Binary.getURI());
         template.sendBodyAndHeaders("", headers);
         notify.matches(1l, TimeUnit.SECONDS);
@@ -267,7 +280,7 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
         Map<String, Object> headers = createEvent("/not/binary", Container.getURI());
         headers.put(EVENT_TYPE, EVENT_UPDATE);
 
-        NotifyBuilder notify = new NotifyBuilder(context).whenDone(1).create();
+        NotifyBuilder notify = new NotifyBuilder(context).whenCompleted(1).create();
         template.sendBodyAndHeaders("", headers);
         notify.matches(1l, TimeUnit.SECONDS);
 
@@ -281,7 +294,7 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
         createContext(PROCESS_ENHANCEMENT_ROUTE);
         Map<String, Object> headers = createEvent(FILE_ID, Binary.getURI());
 
-        NotifyBuilder notify = new NotifyBuilder(context).whenDone(1).create();
+        NotifyBuilder notify = new NotifyBuilder(context).whenCompleted(1).create();
         template.sendBodyAndHeaders("", headers);
         notify.matches(1l, TimeUnit.SECONDS);
 
@@ -303,7 +316,7 @@ public class MetaServicesRouterTest extends CamelSpringTestSupport {
     private static Map<String, Object> createEvent(final String identifier, final String... type) {
 
         final Map<String, Object> headers = new HashMap<>();
-        headers.put(FCREPO_URI, identifier);
+        headers.put(FCREPO_URI, baseUri + identifier);
         headers.put(EVENT_TYPE, EVENT_CREATE);
         headers.put(IDENTIFIER, identifier);
         headers.put(BASE_URL, baseUri);

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solr/CdrEventToSolrUpdateProcessorTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solr/CdrEventToSolrUpdateProcessorTest.java
@@ -22,8 +22,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyCollectionOf;
+import static org.mockito.Matchers.anyMapOf;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -46,6 +48,7 @@ import org.mockito.Mock;
 
 import edu.unc.lib.dl.fcrepo4.PIDs;
 import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.persist.api.indexing.IndexingPriority;
 import edu.unc.lib.dl.services.IndexingMessageSender;
 import edu.unc.lib.dl.util.IndexingActionType;
 import edu.unc.lib.dl.util.JMSMessageUtil.CDRActions;
@@ -126,7 +129,7 @@ public class CdrEventToSolrUpdateProcessorTest {
         processor.process(exchange);
 
         verify(messageSender).sendIndexingOperation(stringCaptor.capture(), pidCaptor.capture(), pidsCaptor.capture(),
-                actionTypeCaptor.capture());
+                actionTypeCaptor.capture(), anyMapOf(String.class, String.class), isNull(IndexingPriority.class));
 
         verifyTargetPid(pidCaptor.getValue());
 
@@ -147,7 +150,7 @@ public class CdrEventToSolrUpdateProcessorTest {
         processor.process(exchange);
 
         verify(messageSender).sendIndexingOperation(stringCaptor.capture(), pidCaptor.capture(), pidsCaptor.capture(),
-                actionTypeCaptor.capture());
+                actionTypeCaptor.capture(), anyMapOf(String.class, String.class), isNull(IndexingPriority.class));
 
         verifyTargetPid(pidCaptor.getValue());
 

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solr/SolrIngestProcessorIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solr/SolrIngestProcessorIT.java
@@ -52,6 +52,7 @@ import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
 import edu.unc.lib.dl.fcrepo4.WorkObject;
 import edu.unc.lib.dl.model.DatastreamType;
 import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService;
+import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService.UpdateDescriptionRequest;
 import edu.unc.lib.dl.rdf.Cdr;
 import edu.unc.lib.dl.rdf.CdrAcl;
 import edu.unc.lib.dl.rdf.Fcrepo4Repository;
@@ -107,7 +108,7 @@ public class SolrIngestProcessorIT extends AbstractSolrProcessorIT {
                 "text.txt", "text/plain", null, null);
         workObj.setPrimaryObject(fileObj.getPid());
         InputStream modsStream = streamResource("/datastreams/simpleMods.xml");
-        updateDescriptionService.updateDescription(agent, workObj.getPid(), modsStream);
+        updateDescriptionService.updateDescription(new UpdateDescriptionRequest(agent, workObj.getPid(), modsStream));
 
         indexObjectsInTripleStore();
 

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solrUpdate/SolrUpdateProcessorIT.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solrUpdate/SolrUpdateProcessorIT.java
@@ -70,6 +70,7 @@ import edu.unc.lib.dl.fcrepo4.CollectionObject;
 import edu.unc.lib.dl.fcrepo4.RepositoryObject;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService;
+import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService.UpdateDescriptionRequest;
 import edu.unc.lib.dl.search.solr.model.BriefObjectMetadata;
 import edu.unc.lib.dl.search.solr.model.BriefObjectMetadataBean;
 import edu.unc.lib.dl.search.solr.util.FacetConstants;
@@ -133,14 +134,12 @@ public class SolrUpdateProcessorIT extends AbstractSolrProcessorIT {
         makeIndexingMessage(unitObj, null, UPDATE_ACCESS_TREE);
 
         NotifyBuilder notify = new NotifyBuilder(cdrServiceSolrUpdate)
-                .whenCompleted(4)
+                .whenCompleted(2)
                 .create();
 
         processor.process(exchange);
 
         assertTrue(notify.matches(6l, TimeUnit.SECONDS));
-
-        Thread.sleep(100);
 
         server.commit();
 
@@ -167,7 +166,7 @@ public class SolrUpdateProcessorIT extends AbstractSolrProcessorIT {
     @Test
     public void testUpdateDescription() throws Exception {
         InputStream modsStream = streamResource("/datastreams/simpleMods.xml");
-        updateDescriptionService.updateDescription(agent, collObj.getPid(), modsStream);
+        updateDescriptionService.updateDescription(new UpdateDescriptionRequest(agent, collObj, modsStream));
 
         indexObjectsInTripleStore();
 
@@ -259,7 +258,7 @@ public class SolrUpdateProcessorIT extends AbstractSolrProcessorIT {
 
         // Wait for indexing to complete
         NotifyBuilder notify = new NotifyBuilder(cdrServiceSolrUpdate)
-                .whenCompleted(4)
+                .whenCompleted(2)
                 .create();
 
         makeIndexingMessage(rootObj, null, RECURSIVE_ADD);
@@ -267,14 +266,10 @@ public class SolrUpdateProcessorIT extends AbstractSolrProcessorIT {
 
         notify.matches(5l, TimeUnit.SECONDS);
 
-        Thread.sleep(100);
-
         server.commit();
 
         makeIndexingMessage(unitObj, null, DELETE_SOLR_TREE);
         processor.process(exchange);
-
-        Thread.sleep(100);
 
         server.commit();
 
@@ -303,7 +298,7 @@ public class SolrUpdateProcessorIT extends AbstractSolrProcessorIT {
         setCollectionSupplementalInformationFilter.setCollectionFilters(file.getAbsolutePath());
 
         InputStream modsStream = streamResource("/datastreams/modsWithRla.xml");
-        updateDescriptionService.updateDescription(agent, collObj.getPid(), modsStream);
+        updateDescriptionService.updateDescription(new UpdateDescriptionRequest(agent, collObj, modsStream));
 
         indexObjectsInTripleStore();
 

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solrUpdate/SolrUpdateRouterTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/solrUpdate/SolrUpdateRouterTest.java
@@ -102,11 +102,12 @@ public class SolrUpdateRouterTest {
     @Test
     public void indexSingleObject() throws Exception {
         Document msg = makeIndexingOperationBody(USER, targetPid, null, IndexingActionType.ADD);
-        template.sendBodyAndHeaders(msg, null);
 
         NotifyBuilder notify = new NotifyBuilder(cdrServiceSolrUpdate)
-                .whenCompleted(2)
+                .whenCompleted(1)
                 .create();
+
+        template.sendBodyAndHeaders(msg, null);
 
         notify.matches(5l, TimeUnit.SECONDS);
 
@@ -121,12 +122,13 @@ public class SolrUpdateRouterTest {
 
         Document msg = makeIndexingOperationBody(USER, targetPid, null, IndexingActionType.ADD);
         Document msg2 = makeIndexingOperationBody(USER, targetPid, null, IndexingActionType.UPDATE_DESCRIPTION);
-        template.sendBodyAndHeaders(msg, null);
-        template.sendBodyAndHeaders(msg2, null);
 
         NotifyBuilder notify = new NotifyBuilder(cdrServiceSolrUpdate)
-                .whenCompleted(3)
+                .whenCompleted(2)
                 .create();
+
+        template.sendBodyAndHeaders(msg, null);
+        template.sendBodyAndHeaders(msg2, null);
 
         notify.matches(5l, TimeUnit.SECONDS);
 
@@ -141,13 +143,14 @@ public class SolrUpdateRouterTest {
         Document msg1 = makeIndexingOperationBody(USER, targetPid, null, IndexingActionType.ADD);
         Document msg2 = makeIndexingOperationBody(USER, targetPid2, null, IndexingActionType.UPDATE_DESCRIPTION);
         Document msg3 = makeIndexingOperationBody(USER, targetPid, null, IndexingActionType.UPDATE_ACCESS);
+
+        NotifyBuilder notify = new NotifyBuilder(cdrServiceSolrUpdate)
+                .whenCompleted(3)
+                .create();
+
         template.sendBodyAndHeaders(msg1, null);
         template.sendBodyAndHeaders(msg2, null);
         template.sendBodyAndHeaders(msg3, null);
-
-        NotifyBuilder notify = new NotifyBuilder(cdrServiceSolrUpdate)
-                .whenCompleted(4)
-                .create();
 
         notify.matches(5l, TimeUnit.SECONDS);
 
@@ -162,11 +165,12 @@ public class SolrUpdateRouterTest {
     public void indexLarge() throws Exception {
         Document msg = makeIndexingOperationBody(USER, targetPid, Arrays.asList(targetPid),
                 IndexingActionType.UPDATE_ACCESS_TREE);
-        template.sendBodyAndHeaders(msg, null);
 
         NotifyBuilder notify = new NotifyBuilder(cdrServiceSolrUpdate)
                 .whenCompleted(1)
                 .create();
+
+        template.sendBodyAndHeaders(msg, null);
 
         notify.matches(5l, TimeUnit.SECONDS);
 
@@ -183,13 +187,13 @@ public class SolrUpdateRouterTest {
                 IndexingActionType.ADD_SET_TO_PARENT);
         Document msg3 = makeIndexingOperationBody(USER, targetPid2, null, IndexingActionType.ADD);
 
-        template.sendBodyAndHeaders(msg1, null);
-        template.sendBodyAndHeaders(msg2, null);
-        template.sendBodyAndHeaders(msg3, null);
-
         NotifyBuilder notify = new NotifyBuilder(cdrServiceSolrUpdate)
                 .whenCompleted(3)
                 .create();
+
+        template.sendBodyAndHeaders(msg1, null);
+        template.sendBodyAndHeaders(msg2, null);
+        template.sendBodyAndHeaders(msg3, null);
 
         notify.matches(5l, TimeUnit.SECONDS);
 

--- a/services-camel/src/test/java/edu/unc/lib/dl/services/camel/util/CacheInvalidatingProcessorTest.java
+++ b/services-camel/src/test/java/edu/unc/lib/dl/services/camel/util/CacheInvalidatingProcessorTest.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.services.camel.util;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import edu.unc.lib.dl.acl.fcrepo4.ObjectAclFactory;
+import edu.unc.lib.dl.fcrepo4.FcrepoJmsConstants;
+import edu.unc.lib.dl.fcrepo4.PIDs;
+import edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader;
+import edu.unc.lib.dl.fedora.PID;
+import edu.unc.lib.dl.fedora.PIDConstants;
+import edu.unc.lib.dl.test.TestHelper;
+
+/**
+ * @author bbpennel
+ */
+public class CacheInvalidatingProcessorTest {
+    private static final String FEDORA_BASE = "http://example.com/rest/";
+    private static final String PID_UUID = "de75d811-9e0f-4b1f-8631-2060ab3580cc";
+    private static final String PID_PATH = "/de/75/d8/11/" + PID_UUID;
+
+    @Mock
+    private RepositoryObjectLoader repoObjLoader;
+    @Mock
+    private ObjectAclFactory objectAclFactory;
+
+    private CacheInvalidatingProcessor processor;
+
+    @Before
+    public void init() throws Exception {
+        initMocks(this);
+        TestHelper.setContentBase(FEDORA_BASE);
+        processor = new CacheInvalidatingProcessor();
+        processor.setRepositoryObjectLoader(repoObjLoader);
+        processor.setObjectAclFactory(objectAclFactory);
+    }
+
+    @Test
+    public void invalidatesContentPidTest() throws Exception {
+        String objPath = PIDConstants.CONTENT_QUALIFIER + PID_PATH;
+        Exchange exchange = mockExchange(objPath);
+
+        processor.process(exchange);
+
+        PID pid = PIDs.get(FEDORA_BASE + objPath);
+        verify(repoObjLoader).invalidate(pid);
+        verify(objectAclFactory).invalidate(pid);
+    }
+
+    @Test
+    public void ignoresDepositPidTest() throws Exception {
+        String objPath = PIDConstants.DEPOSITS_QUALIFIER + PID_PATH;
+        Exchange exchange = mockExchange(objPath);
+
+        processor.process(exchange);
+
+        verify(repoObjLoader, never()).invalidate(any(PID.class));
+        verify(objectAclFactory, never()).invalidate(any(PID.class));
+    }
+
+    @Test
+    public void ignoresInvalidPidTest() throws Exception {
+        String objPath = "/not/a/pid/okay";
+        Exchange exchange = mockExchange(objPath);
+
+        processor.process(exchange);
+
+        verify(repoObjLoader, never()).invalidate(any(PID.class));
+        verify(objectAclFactory, never()).invalidate(any(PID.class));
+    }
+
+    private Exchange mockExchange(String rescPath) {
+        Exchange exchange = mock(Exchange.class);
+        Message message = mock(Message.class);
+        when(exchange.getIn()).thenReturn(message);
+
+        when(message.getHeader(eq(FcrepoJmsConstants.BASE_URL)))
+                .thenReturn(FEDORA_BASE);
+        when(message.getHeader(eq(FcrepoJmsConstants.IDENTIFIER)))
+                .thenReturn(rescPath);
+
+        return exchange;
+    }
+ }

--- a/services-camel/src/test/resources/cdr-event-routing-it-config.properties
+++ b/services-camel/src/test/resources/cdr-event-routing-it-config.properties
@@ -43,11 +43,7 @@ cdr.stream.camel=activemq://activemq:queue:repository.events
 cdr.solrupdate.stream=activemq:queue:repository.solrupdate
 cdr.solrupdate.stream.camel=activemq://activemq:queue:repository.solrupdate
 
-cdr.solrupdate.small.dest=direct:solr.update.small
-cdr.solrupdate.small.consumer=direct:solr.update.small
-
-cdr.solrupdate.large.dest=direct:solr.update.large
-cdr.solrupdate.large.consumer=direct:solr.update.large
+cdr.solrupdate.large.camel=direct:solr.update.large
 
 # The base URL of the triplestore being used.
 triplestore.baseUrl=http://localhost:8080/fuseki/test/update

--- a/services-camel/src/test/resources/cdr-event-routing-it-config.properties
+++ b/services-camel/src/test/resources/cdr-event-routing-it-config.properties
@@ -44,6 +44,7 @@ cdr.solrupdate.stream=activemq:queue:repository.solrupdate
 cdr.solrupdate.stream.camel=activemq://activemq:queue:repository.solrupdate
 
 cdr.solrupdate.large.camel=direct:solr.update.large
+cdr.solrupdate.priority.low.camel=direct:solr.update.priority.low
 
 # The base URL of the triplestore being used.
 triplestore.baseUrl=http://localhost:8080/fuseki/test/update

--- a/services-camel/src/test/resources/cdr-event-routing-it-context.xml
+++ b/services-camel/src/test/resources/cdr-event-routing-it-context.xml
@@ -68,6 +68,10 @@
     
     <bean id="solrUpdatePreprocessor" class="edu.unc.lib.dl.services.camel.solrUpdate.SolrUpdatePreprocessor">
     </bean>
+    
+    <bean id="cacheInvalidatingProcessor" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.services.camel.util.CacheInvalidatingProcessor" />
+    </bean>
 
     <camel:camelContext id="cdrServiceCdrEvents">
         <camel:package>edu.unc.lib.dl.services.camel.cdrEvents</camel:package>

--- a/services-camel/src/test/resources/metaservices-context.xml
+++ b/services-camel/src/test/resources/metaservices-context.xml
@@ -32,6 +32,10 @@
     <bean id="nonBinaryEnhancementProcessor" class="org.mockito.Mockito" factory-method="mock">
         <constructor-arg value="edu.unc.lib.dl.services.camel.NonBinaryEnhancementProcessor" />
     </bean>
+    
+    <bean id="cacheInvalidatingProcessor" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.services.camel.util.CacheInvalidatingProcessor" />
+    </bean>
 
     <camel:camelContext id="CdrMetaServicesRouter">
         <camel:package>edu.unc.lib.dl.services.camel.routing</camel:package>

--- a/services-camel/src/test/resources/solr-indexing-it-context.xml
+++ b/services-camel/src/test/resources/solr-indexing-it-context.xml
@@ -36,7 +36,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="100" />
         <property name="cacheTimeToLive" value="100" />
-        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
     </bean>
     
     <bean id="inheritedPermissionEvaluator" class="edu.unc.lib.dl.acl.fcrepo4.InheritedPermissionEvaluator">

--- a/services-camel/src/test/resources/solr-update-config.properties
+++ b/services-camel/src/test/resources/solr-update-config.properties
@@ -10,3 +10,4 @@ cdr.solrupdate.stream=direct:start
 cdr.solrupdate.stream.camel=direct:start
 
 cdr.solrupdate.large.camel=direct:solr.update.large
+cdr.solrupdate.priority.low.camel=direct:solr.update.priority.low

--- a/services-camel/src/test/resources/solr-update-config.properties
+++ b/services-camel/src/test/resources/solr-update-config.properties
@@ -9,8 +9,4 @@ cdr.enhancement.solr.error.backOffMultiplier=1.2
 cdr.solrupdate.stream=direct:start
 cdr.solrupdate.stream.camel=direct:start
 
-cdr.solrupdate.small.dest=sjms:solr.update.small?transacted=true
-cdr.solrupdate.small.consumer=sjms-batch:solr.update.small?completionTimeout=100&completionSize=5&consumerCount=1&aggregationStrategy=#bodyListAggregationStrategy&connectionFactory=jmsFactory
-
-cdr.solrupdate.large.dest=activemq:queue:solr.update.large
-cdr.solrupdate.large.consumer=activemq://activemq:queue:solr.update.large?transacted=true
+cdr.solrupdate.large.camel=direct:solr.update.large

--- a/services-camel/src/test/resources/solr-update-context.xml
+++ b/services-camel/src/test/resources/solr-update-context.xml
@@ -27,6 +27,10 @@
         <constructor-arg ref="solrUpdatePreprocessorReal" />
     </bean>
     
+    <bean id="cacheInvalidatingProcessor" class="org.mockito.Mockito" factory-method="mock">
+        <constructor-arg value="edu.unc.lib.dl.services.camel.util.CacheInvalidatingProcessor" />
+    </bean>
+    
     <bean id="solrUpdatePreprocessorReal" class="edu.unc.lib.dl.services.camel.solrUpdate.SolrUpdatePreprocessor">
     </bean>
     

--- a/services-camel/src/test/resources/solr-update-processor-it-context.xml
+++ b/services-camel/src/test/resources/solr-update-processor-it-context.xml
@@ -167,6 +167,11 @@
         <property name="solrIndexingActionMap" ref="solrIndexingActionMap"/>
     </bean>
     
+    <bean id="cacheInvalidatingProcessor" class="edu.unc.lib.dl.services.camel.util.CacheInvalidatingProcessor">
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader"/>
+        <property name="objectAclFactory" ref="objectAclFactory"/>
+    </bean>
+    
     <bean id="solrUpdatePreprocessor" class="edu.unc.lib.dl.services.camel.solrUpdate.SolrUpdatePreprocessor">
     </bean>
     

--- a/services-camel/src/test/resources/spring-test/acl-service-context.xml
+++ b/services-camel/src/test/resources/spring-test/acl-service-context.xml
@@ -26,7 +26,7 @@
           init-method="init">
         <property name="cacheMaxSize" value="0" />
         <property name="cacheTimeToLive" value="0" />
-        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
     </bean>
 
     <bean id="contentPathFactory" class="edu.unc.lib.dl.fedora.ContentPathFactory"

--- a/services-camel/src/test/resources/spring-test/cdr-client-container.xml
+++ b/services-camel/src/test/resources/spring-test/cdr-client-container.xml
@@ -39,7 +39,7 @@
     <bean id="repositoryObjectFactory" class="edu.unc.lib.dl.fcrepo4.RepositoryObjectFactory">
         <property name="client" ref="fcrepoClient" />
         <property name="ldpFactory" ref="ldpContainerFactory" />
-        <property name="repositoryObjectDriver" ref="repositoryObjectDriver" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
         <property name="pidMinter" ref="repositoryPIDMinter" />
         <property name="sparqlUpdateService" ref="fedoraSparqlUpdateService" />
     </bean>

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/processing/AddContainerService.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/processing/AddContainerService.java
@@ -61,6 +61,7 @@ import edu.unc.lib.dl.persist.api.storage.StorageLocationManager;
 import edu.unc.lib.dl.persist.services.acl.PatronAccessAssignmentService;
 import edu.unc.lib.dl.persist.services.acl.PatronAccessDetails;
 import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService;
+import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService.UpdateDescriptionRequest;
 import edu.unc.lib.dl.rdf.Cdr;
 import edu.unc.lib.dl.rdf.DcElements;
 import edu.unc.lib.dl.rdf.Premis;
@@ -192,8 +193,8 @@ public class AddContainerService {
 
         String modsString = new XMLOutputter(getPrettyFormat()).outputString(mods.getDocument());
 
-        updateDescService.updateDescription(addRequest.getAgent(), containerPid,
-                IOUtils.toInputStream(modsString, StandardCharsets.UTF_8));
+        updateDescService.updateDescription(new UpdateDescriptionRequest(addRequest.getAgent(), containerPid,
+                IOUtils.toInputStream(modsString, StandardCharsets.UTF_8)));
     }
 
     /**

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/processing/SetAsPrimaryObjectService.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/processing/SetAsPrimaryObjectService.java
@@ -74,7 +74,7 @@ public class SetAsPrimaryObjectService {
             }
             WorkObject work = (WorkObject) parent;
             work.setPrimaryObject(fileObjPid);
-            work.refresh();
+            work.shouldRefresh();
 
             // Send message that the action completed
             operationsMessageSender.sendSetAsPrimaryObjectOperation(agent.getUsername(),
@@ -117,7 +117,7 @@ public class SetAsPrimaryObjectService {
                 updated.add(previousPrimary.getPid());
 
                 work.clearPrimaryObject();
-                work.refresh();
+                work.shouldRefresh();
             }
 
             // Send message that the action completed

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/processing/SetAsPrimaryObjectService.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/processing/SetAsPrimaryObjectService.java
@@ -74,6 +74,7 @@ public class SetAsPrimaryObjectService {
             }
             WorkObject work = (WorkObject) parent;
             work.setPrimaryObject(fileObjPid);
+            work.refresh();
 
             // Send message that the action completed
             operationsMessageSender.sendSetAsPrimaryObjectOperation(agent.getUsername(),
@@ -116,6 +117,7 @@ public class SetAsPrimaryObjectService {
                 updated.add(previousPrimary.getPid());
 
                 work.clearPrimaryObject();
+                work.refresh();
             }
 
             // Send message that the action completed

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/AccessControlRetrievalController.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/AccessControlRetrievalController.java
@@ -73,7 +73,7 @@ public class AccessControlRetrievalController {
     @Autowired
     private InheritedAclFactory inheritedAclFactory;
     @Autowired
-    private RepositoryObjectLoader repoObjLoader;
+    private RepositoryObjectLoader repositoryObjectLoader;
     @Autowired
     private PatronPrincipalProvider patronPrincipalProvider;
 
@@ -87,7 +87,7 @@ public class AccessControlRetrievalController {
         aclService.assertHasAccess("Insufficient permissions to retrieve staff roles for " + id,
                 pid, agent.getPrincipals(), Permission.viewHidden);
 
-        RepositoryObject repoObj = repoObjLoader.getRepositoryObject(pid);
+        RepositoryObject repoObj = repositoryObjectLoader.getRepositoryObject(pid);
 
         Map<String, Object> result = new HashMap<>();
         List<RoleAssignment> inherited = null;
@@ -143,7 +143,7 @@ public class AccessControlRetrievalController {
         aclService.assertHasAccess("Insufficient permissions to retrieve patron access for " + id,
                 pid, agent.getPrincipals(), Permission.viewHidden);
 
-        RepositoryObject repoObj = repoObjLoader.getRepositoryObject(pid);
+        RepositoryObject repoObj = repositoryObjectLoader.getRepositoryObject(pid);
 
         Map<String, Object> result = new HashMap<>();
 

--- a/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/modify/UpdateDescriptionController.java
+++ b/services/src/main/java/edu/unc/lib/dl/cdr/services/rest/modify/UpdateDescriptionController.java
@@ -36,6 +36,7 @@ import edu.unc.lib.dl.acl.util.AgentPrincipals;
 import edu.unc.lib.dl.fcrepo4.PIDs;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService;
+import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService.UpdateDescriptionRequest;
 import edu.unc.lib.dl.validation.MetadataValidationException;
 
 /**
@@ -66,7 +67,7 @@ public class UpdateDescriptionController {
 
         AgentPrincipals agent = AgentPrincipals.createFromThread();
         try (InputStream modsStream = request.getInputStream()) {
-            updateService.updateDescription(agent, pid, modsStream);
+            updateService.updateDescription(new UpdateDescriptionRequest(agent, pid, modsStream));
         } catch (MetadataValidationException e) {
             if (e.getMessage() != null) {
                 result.put("error", e.getMessage());

--- a/services/src/main/webapp/WEB-INF/access-fedora-context.xml
+++ b/services/src/main/webapp/WEB-INF/access-fedora-context.xml
@@ -114,7 +114,7 @@
         <property name="client" ref="fcrepoClient" />
         <property name="ldpFactory" ref="ldpContainerFactory" />
         <property name="pidMinter" ref="pidMinter" />
-        <property name="repositoryObjectDriver" ref="repositoryObjectDriver" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
         <property name="sparqlUpdateService" ref="fedoraSparqlUpdateService" />
     </bean>
     

--- a/services/src/main/webapp/WEB-INF/access-fedora-context.xml
+++ b/services/src/main/webapp/WEB-INF/access-fedora-context.xml
@@ -29,7 +29,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="${cache.objectAcls.maxSize}" />
         <property name="cacheTimeToLive" value="${cache.objectAcls.timeToLive}" />
-        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
     </bean>
     
     <bean id="inheritedAclFactory" class="edu.unc.lib.dl.acl.fcrepo4.InheritedAclFactory">
@@ -42,11 +42,17 @@
         <property name="objectAclFactory" ref="objectAclFactory" />
     </bean>
     
+    <bean id="repositoryObjectLoaderNoCache" class="edu.unc.lib.dl.fcrepo4.RepositoryObjectLoader" init-method="init">
+        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
+        <property name="cacheTimeToLive" value="0" />
+        <property name="cacheMaxSize" value="0" />
+    </bean>
+    
     <bean id="uncachedObjectAclFactory" class="edu.unc.lib.dl.acl.fcrepo4.ObjectAclFactory"
             init-method="init">
         <property name="cacheMaxSize" value="0" />
         <property name="cacheTimeToLive" value="0" />
-        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoaderNoCache" />
     </bean>
     
     <bean id="uncachedInheritedAclFactory" class="edu.unc.lib.dl.acl.fcrepo4.InheritedAclFactory">

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/EditTitleIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/EditTitleIT.java
@@ -77,6 +77,7 @@ public class EditTitleIT extends AbstractAPIIT {
                 .andExpect(status().is2xxSuccessful())
                 .andReturn();
 
+        work.refresh();
         // Verify response from api
         Map<String, Object> respMap = getMapFromResponse(result);
         assertEquals(pid.getUUID(), respMap.get("pid"));
@@ -95,6 +96,7 @@ public class EditTitleIT extends AbstractAPIIT {
                 .andExpect(status().is2xxSuccessful())
                 .andReturn();
 
+        work.refresh();
         // Verify response from api
         Map<String, Object> respMap = getMapFromResponse(result);
         assertEquals(pid.getUUID(), respMap.get("pid"));
@@ -123,6 +125,7 @@ public class EditTitleIT extends AbstractAPIIT {
                 .andExpect(status().is2xxSuccessful())
                 .andReturn();
 
+        work.refresh();
         // Verify response from api
         Map<String, Object> respMap = getMapFromResponse(result);
         assertEquals(pid.getUUID(), respMap.get("pid"));

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/EditTitleIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/EditTitleIT.java
@@ -77,7 +77,7 @@ public class EditTitleIT extends AbstractAPIIT {
                 .andExpect(status().is2xxSuccessful())
                 .andReturn();
 
-        work.refresh();
+        work.shouldRefresh();
         // Verify response from api
         Map<String, Object> respMap = getMapFromResponse(result);
         assertEquals(pid.getUUID(), respMap.get("pid"));
@@ -96,7 +96,7 @@ public class EditTitleIT extends AbstractAPIIT {
                 .andExpect(status().is2xxSuccessful())
                 .andReturn();
 
-        work.refresh();
+        work.shouldRefresh();
         // Verify response from api
         Map<String, Object> respMap = getMapFromResponse(result);
         assertEquals(pid.getUUID(), respMap.get("pid"));
@@ -125,7 +125,7 @@ public class EditTitleIT extends AbstractAPIIT {
                 .andExpect(status().is2xxSuccessful())
                 .andReturn();
 
-        work.refresh();
+        work.shouldRefresh();
         // Verify response from api
         Map<String, Object> respMap = getMapFromResponse(result);
         assertEquals(pid.getUUID(), respMap.get("pid"));

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/EditTitleIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/EditTitleIT.java
@@ -50,6 +50,7 @@ import edu.unc.lib.dl.fcrepo4.BinaryObject;
 import edu.unc.lib.dl.fcrepo4.WorkObject;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService;
+import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService.UpdateDescriptionRequest;
 
 /**
  *
@@ -113,7 +114,8 @@ public class EditTitleIT extends AbstractAPIIT {
                         .addContent(new Element("title", MODS_V3_NS).setText(oldTitle))));
 
         InputStream modsStream = documentToInputStream(document);
-        updateDescriptionService.updateDescription(mock(AgentPrincipals.class), pid, modsStream);
+        updateDescriptionService.updateDescription(new UpdateDescriptionRequest(
+                mock(AgentPrincipals.class), pid, modsStream));
 
         String newTitle = "new_work_title";
         MvcResult result = mvc.perform(put("/edit/title/" + pid.getUUID())

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/ExportCsvIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/ExportCsvIT.java
@@ -76,6 +76,7 @@ import edu.unc.lib.dl.fcrepo4.WorkObject;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.persist.services.delete.MarkForDeletionJob;
 import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService;
+import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService.UpdateDescriptionRequest;
 import edu.unc.lib.dl.search.solr.service.ChildrenCountService;
 import edu.unc.lib.dl.search.solr.service.SolrSearchService;
 import edu.unc.lib.dl.sparql.FedoraSparqlUpdateService;
@@ -218,8 +219,10 @@ public class ExportCsvIT extends AbstractAPIIT {
         PID workPid = pidList.get("workPid");
         PID filePid = pidList.get("filePid");
 
-        updateDescService.updateDescription(getAgentPrincipals(), folderPid, Files.newInputStream(MODS_PATH_1));
-        updateDescService.updateDescription(getAgentPrincipals(), workPid, Files.newInputStream(MODS_PATH_2));
+        updateDescService.updateDescription(new UpdateDescriptionRequest(
+                getAgentPrincipals(), folderPid, Files.newInputStream(MODS_PATH_1)));
+        updateDescService.updateDescription(new UpdateDescriptionRequest(
+                getAgentPrincipals(), workPid, Files.newInputStream(MODS_PATH_2)));
 
         treeIndexer.indexAll(baseAddress);
         solrIndexer.index(rootObj.getPid(), unitObj.getPid(), collObj.getPid(), folderPid,

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/ExportXMLIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/ExportXMLIT.java
@@ -41,7 +41,6 @@ import java.util.Map;
 import javax.mail.internet.MimeMessage;
 import javax.ws.rs.core.MediaType;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -52,6 +51,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.ContextHierarchy;
 import org.springframework.test.web.servlet.MvcResult;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import edu.unc.lib.dl.acl.util.AccessGroupSet;
@@ -61,6 +61,7 @@ import edu.unc.lib.dl.cdr.services.rest.modify.ExportXMLController.XMLExportRequ
 import edu.unc.lib.dl.fcrepo4.ContentObject;
 import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService;
+import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService.UpdateDescriptionRequest;
 import edu.unc.lib.dl.search.solr.model.BriefObjectMetadataBean;
 import edu.unc.lib.dl.search.solr.model.SearchRequest;
 import edu.unc.lib.dl.search.solr.model.SearchResultResponse;
@@ -192,8 +193,10 @@ public class ExportXMLIT extends AbstractAPIIT {
     private List<String> createObjects() throws Exception {
         ContentObject folder = repositoryObjectFactory.createFolderObject(null);
         ContentObject work = repositoryObjectFactory.createWorkObject(null);
-        updateDescriptionService.updateDescription(agent, folder.getPid(), Files.newInputStream(MODS_PATH_1));
-        updateDescriptionService.updateDescription(agent, work.getPid(), Files.newInputStream(MODS_PATH_2));
+        updateDescriptionService.updateDescription(new UpdateDescriptionRequest(
+                agent, folder.getPid(), Files.newInputStream(MODS_PATH_1)));
+        updateDescriptionService.updateDescription(new UpdateDescriptionRequest(
+                agent, work.getPid(), Files.newInputStream(MODS_PATH_2)));
 
         String pid1 = folder.getPid().getRepositoryPath();
         String pid2 = work.getPid().getRepositoryPath();

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/SetAsPrimaryObjectIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/SetAsPrimaryObjectIT.java
@@ -183,11 +183,13 @@ public class SetAsPrimaryObjectIT extends AbstractAPIIT {
     }
 
     private void assertPrimaryObjectSet(WorkObject parent, FileObject fileObj) {
+        parent.refresh();
         assertNotNull(parent.getPrimaryObject());
         assertEquals(parent.getPrimaryObject().getPid(), fileObj.getPid());
     }
 
     private void assertPrimaryObjectNotSet(WorkObject parent) {
+        parent.refresh();
         assertNull(parent.getPrimaryObject());
     }
 

--- a/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/SetAsPrimaryObjectIT.java
+++ b/services/src/test/java/edu/unc/lib/dl/cdr/services/rest/modify/SetAsPrimaryObjectIT.java
@@ -183,13 +183,13 @@ public class SetAsPrimaryObjectIT extends AbstractAPIIT {
     }
 
     private void assertPrimaryObjectSet(WorkObject parent, FileObject fileObj) {
-        parent.refresh();
+        parent.shouldRefresh();
         assertNotNull(parent.getPrimaryObject());
         assertEquals(parent.getPrimaryObject().getPid(), fileObj.getPid());
     }
 
     private void assertPrimaryObjectNotSet(WorkObject parent) {
-        parent.refresh();
+        parent.shouldRefresh();
         assertNull(parent.getPrimaryObject());
     }
 

--- a/services/src/test/resources/spring-test/acl-service-context.xml
+++ b/services/src/test/resources/spring-test/acl-service-context.xml
@@ -31,7 +31,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="0" />
         <property name="cacheTimeToLive" value="0" />
-        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
     </bean>
     
     <bean id="contentPathFactory" class="edu.unc.lib.dl.fedora.ContentPathFactory"

--- a/services/src/test/resources/spring-test/cdr-client-container.xml
+++ b/services/src/test/resources/spring-test/cdr-client-container.xml
@@ -28,7 +28,7 @@
         <property name="client" ref="fcrepoClient" />
         <property name="ldpFactory" ref="ldpContainerFactory" />
         <property name="pidMinter" ref="repositoryPIDMinter" />
-        <property name="repositoryObjectDriver" ref="repositoryObjectDriver" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
         <property name="sparqlUpdateService" ref="fedoraSparqlUpdateService" />
     </bean>
     

--- a/services/src/test/resources/spring-test/solr-indexing-context.xml
+++ b/services/src/test/resources/spring-test/solr-indexing-context.xml
@@ -166,7 +166,7 @@
           init-method="init">
         <property name="cacheMaxSize" value="100" />
         <property name="cacheTimeToLive" value="100" />
-        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
     </bean>
 
     <bean id="childrenCountService" class="edu.unc.lib.dl.search.solr.service.ChildrenCountService">

--- a/services/src/test/resources/update-staff-it-servlet.xml
+++ b/services/src/test/resources/update-staff-it-servlet.xml
@@ -57,7 +57,7 @@
             init-method="init">
         <property name="cacheMaxSize" value="0" />
         <property name="cacheTimeToLive" value="0" />
-        <property name="repositoryObjectCacheLoader" ref="repositoryObjectCacheLoader" />
+        <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
     </bean>
     
     <bean id="inheritedAclFactory" class="edu.unc.lib.dl.acl.fcrepo4.InheritedAclFactory">

--- a/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/indexing/SolrUpdateDriver.java
+++ b/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/indexing/SolrUpdateDriver.java
@@ -25,7 +25,6 @@ import java.util.Map.Entry;
 
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
-import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.util.ClientUtils;
 import org.apache.solr.common.SolrInputDocument;
 import org.slf4j.Logger;
@@ -58,9 +57,13 @@ public class SolrUpdateDriver {
     public void init() {
         log.debug("Instantiating concurrent udpate solr server for " + solrSettings.getUrl());
 
-        solrClient = new HttpSolrClient.Builder(solrSettings.getUrl())
+        solrClient = new TolerantConcurrentUpdateSolrClient.Builder(solrSettings.getUrl())
+                .withThreadCount(updateThreads)
+                .withQueueSize(autoPushCount)
                 .build();
-        updateSolrClient = new HttpSolrClient.Builder(solrSettings.getUrl())
+        updateSolrClient = new TolerantConcurrentUpdateSolrClient.Builder(solrSettings.getUrl())
+                .withThreadCount(updateThreads)
+                .withQueueSize(autoPushCount)
                 .build();
     }
 

--- a/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/indexing/TolerantConcurrentUpdateSolrClient.java
+++ b/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/indexing/TolerantConcurrentUpdateSolrClient.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2008 The University of North Carolina at Chapel Hill
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.unc.lib.dl.data.ingest.solr.indexing;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.http.HttpResponse;
+import org.apache.solr.client.solrj.ResponseParser;
+import org.apache.solr.client.solrj.impl.BinaryResponseParser;
+import org.apache.solr.client.solrj.impl.ConcurrentUpdateSolrClient;
+import org.apache.solr.common.util.NamedList;
+import org.slf4j.Logger;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * ConcurrentUpdateSolrClient intended for use with an update endpoint with the
+ * TolerantUpdateProcessorFactory enabled as a updateRequestProcessorChain. This
+ * client will log errors found within partial success update responses.
+ *
+ * @author bbpennel
+ */
+public class TolerantConcurrentUpdateSolrClient extends ConcurrentUpdateSolrClient {
+    private static final long serialVersionUID = 1L;
+    private static final Logger log = getLogger(TolerantConcurrentUpdateSolrClient.class);
+
+    private ResponseParser respParser = new BinaryResponseParser();
+
+    /**
+     * @param builder
+     */
+    protected TolerantConcurrentUpdateSolrClient(Builder builder) {
+        super(builder);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void onSuccess(HttpResponse httpResp) {
+        try {
+            // With the tolerant processor enabled, a 200 response can list errors for records that failed to update
+            NamedList<Object> resp = respParser.processResponse(httpResp.getEntity().getContent(), "UTF-8");
+            NamedList<Object> headers = (NamedList<Object>) resp.get("responseHeader");
+            if (headers == null) {
+                return;
+            }
+            List<Object> errors = (List<Object>) headers.get("errors");
+            if (CollectionUtils.isEmpty(errors)) {
+                return;
+            }
+            for (Object error : errors) {
+                NamedList<Object> details = (NamedList<Object>) error;
+                log.error("Failed to commit solr update for {}: {}", details.get("id"), details.get("message"));
+            }
+        } catch (IOException e) {
+            log.error("Failed to parse success response", e);
+        }
+    }
+
+    // Extended so that it will build a TolerantConcurrentUpdateSolrClient
+    public static class Builder extends ConcurrentUpdateSolrClient.Builder {
+        /**
+         * @param baseSolrUrl
+         */
+        public Builder(String baseSolrUrl) {
+            super(baseSolrUrl);
+        }
+
+        @Override
+        public ConcurrentUpdateSolrClient build() {
+            if (baseSolrUrl == null) {
+              throw new IllegalArgumentException("Cannot create HttpSolrClient without a valid baseSolrUrl!");
+            }
+
+            return new TolerantConcurrentUpdateSolrClient(this);
+          }
+    }
+}

--- a/sword-server/src/main/java/edu/unc/lib/dl/cdr/sword/server/managers/ServiceDocumentManagerImpl.java
+++ b/sword-server/src/main/java/edu/unc/lib/dl/cdr/sword/server/managers/ServiceDocumentManagerImpl.java
@@ -60,7 +60,7 @@ public class ServiceDocumentManagerImpl extends AbstractFedoraManager implements
 
     private Collection<PackagingType> acceptedPackaging;
     @Autowired
-    private RepositoryObjectLoader repoObjLoader;
+    private RepositoryObjectLoader repositoryObjectLoader;
 
     @Override
     public ServiceDocument getServiceDocument(String sdUri, AuthCredentials auth, SwordConfiguration config)
@@ -124,7 +124,7 @@ public class ServiceDocumentManagerImpl extends AbstractFedoraManager implements
      */
     protected List<SwordCollection> getImmediateContainerChildren(PID pid, AuthCredentials auth,
             SwordConfigurationImpl config) throws IOException {
-        RepositoryObject repoObj = repoObjLoader.getRepositoryObject(pid);
+        RepositoryObject repoObj = repositoryObjectLoader.getRepositoryObject(pid);
         ContentContainerObject containerObj;
         if (repoObj instanceof ContentContainerObject) {
             containerObj = (ContentContainerObject) repoObj;


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3091

- Solr updates performed using a concurrent update client with additional logging to record on partial batch failures. Switch to config options for update client
- Object models are no longer always refreshed, instead a refresh must be requested or a new object should be retrieved.
    - Add cache invalidation step to camel processing so that longer cache TTLs can be used to decrease number of times objects are retrieved
    - Small solr updates no longer batched
- Refactor UpdateDescriptionService to take request objects
- Add flag for indexing messages and some operation messages to indicate what indexing priority to use. Send low priority indexing messages to a separate queue
- Trigger commit of jms session to prevent bulk xml operation from acculmulating all updates in a single session and sending all at once when the job finishs
- Skip unnecessary retrieval of patron roles for adminunits and root objects
- Fix incorrect test expectation to resolve flapping test, add short delays to ensure tests with 0 expected messages have time for the message to reach all routes
- Use repositoryObjectLoader to return copy of object from object factory for more consistent caching and management of objects, resolving some consistency issues when instances of objects come from different sources