### PR TITLE
BXC-3109 - Filename space encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <grizzly.version>2.4.4</grizzly.version>
         <jersey.version>2.32</jersey.version>
         <mockito.version>1.10.19</mockito.version>
-        <fcrepo.client.version>0.4.0</fcrepo.client.version>
+        <fcrepo.client.version>5.0.0</fcrepo.client.version>
         <mock.server.version>5.4.1</mock.server.version>
         <powermock.version>1.7.4</powermock.version>
         <awaitility.version>4.0.3</awaitility.version>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3109
* Update fcrepo-java-client to 5.0.0 to pull in fix for encoding of spaces in filenames