### PR TITLE
BXC-3143 - Unicode filenames in file server deposits

### DIFF
--- a/deposit/src/main/java/edu/unc/lib/deposit/normalize/AbstractFileServerToBagJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/normalize/AbstractFileServerToBagJob.java
@@ -185,7 +185,7 @@ public abstract class AbstractFileServerToBagJob extends AbstractDepositJob {
 
         Bag currentNode = sourceBag;
 
-        for (int i = 1; i < pathSegments.length - 1; i++) {
+        for (int i = 1; i < pathSegments.length; i++) {
 
             String segment = pathSegments[i];
             String folderPath = StringUtils.join(Arrays.copyOfRange(pathSegments, 0, i + 1), "/");

--- a/deposit/src/main/java/edu/unc/lib/deposit/normalize/BagIt2N3BagJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/normalize/BagIt2N3BagJob.java
@@ -22,7 +22,6 @@ import static edu.unc.lib.dl.rdf.CdrDeposit.stagingLocation;
 import static gov.loc.repository.bagit.hash.StandardSupportedAlgorithms.MD5;
 import static gov.loc.repository.bagit.hash.StandardSupportedAlgorithms.SHA1;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
@@ -110,7 +109,7 @@ public class BagIt2N3BagJob extends AbstractFileServerToBagJob {
             // Turn the bag itself into the top level folder for this deposit
             org.apache.jena.rdf.model.Bag sourceBag;
             if (createParentFolder) {
-                sourceBag = getSourceBag(depositBag, new File(sourceUri));
+                sourceBag = getSourceBag(depositBag, sourceFile);
             } else {
                 sourceBag = depositBag;
             }
@@ -138,7 +137,7 @@ public class BagIt2N3BagJob extends AbstractFileServerToBagJob {
                     String filePath = relativePath.toString();
                     log.debug("Adding object {}: {}", i++, filePath);
 
-                    Resource originalResource = getFileResource(sourceBag, filePath);
+                    Resource originalResource = getFileResource(sourceBag, relativePath);
 
                     // add checksums
                     model.add(originalResource, checksumProperty, pathToChecksum.getValue());

--- a/deposit/src/test/java/edu/unc/lib/deposit/normalize/DirectoryToBagJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/normalize/DirectoryToBagJobTest.java
@@ -305,7 +305,7 @@ public class DirectoryToBagJobTest extends AbstractNormalizationJobTest {
 
         Resource originalResc = DepositModelHelpers.getDatastream(file);
         String tagPath = originalResc.getProperty(CdrDeposit.stagingLocation).getString();
-        assertTrue("Unexpected path " + tagPath, tagPath.endsWith("unicode_test/weird%F0%9F%91%BD.txt"));
+        assertTrue("Unexpected path " + tagPath, tagPath.endsWith("unicode_test/%F0%9F%91%BD_sightings/ufo.txt"));
     }
 
     private Resource getChildByLabel(Bag bagResc, String seekLabel) {


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3143

* File server deposits (Directory and Bagit) should now succeed when containing files or folders that have unicode characters in their filenames
* Switches to using NIO during deposit jobs and file transfers, as the older java.io utilities are not reliable with their encoding when listing file names
* During fits extract, use a symlink pointing to the file if its path contains any unicode characters, as the FITS webapp cannot access these files
* During virus scanning, scan by streaming content instead of by file path if the path contains any unicode, as clamd does not appear to work with these paths (regular clamscan does, clamdscan gives an unspecified error)