### PR TITLE
BXC-3148 - Inherited patron restrictions tag

### DIFF
--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/acl/fcrepo4/InheritedAclFactory.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/acl/fcrepo4/InheritedAclFactory.java
@@ -17,7 +17,6 @@ package edu.unc.lib.dl.acl.fcrepo4;
 
 import static edu.unc.lib.dl.acl.util.EmbargoUtil.isEmbargoActive;
 import static edu.unc.lib.dl.acl.util.PrincipalClassifier.getPatronPrincipals;
-import static java.util.Arrays.asList;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -59,13 +58,6 @@ public class InheritedAclFactory implements AclFactory {
     private ObjectAclFactory objectAclFactory;
 
     private ContentPathFactory pathFactory;
-
-    private static final List<String> PATRON_ROLE_PRECEDENCE = asList(
-            UserRole.none.getPropertyString(),
-            UserRole.canViewMetadata.getPropertyString(),
-            UserRole.canViewAccessCopies.getPropertyString(),
-            UserRole.canViewOriginals.getPropertyString()
-            );
 
     private static final int EMBARGO_ROLE_PRECEDENCE = 1;
 
@@ -220,8 +212,8 @@ public class InheritedAclFactory implements AclFactory {
             }
 
             String inherited = inheritedRoles.iterator().next();
-            int inheritedIndex = PATRON_ROLE_PRECEDENCE.indexOf(inherited);
-            int objIndex = PATRON_ROLE_PRECEDENCE.indexOf(objRole);
+            int inheritedIndex = UserRole.PATRON_ROLE_PRECEDENCE.indexOf(inherited);
+            int objIndex = UserRole.PATRON_ROLE_PRECEDENCE.indexOf(objRole);
 
             if (objIndex < inheritedIndex) {
                 inheritedPrincRoles.put(patronPrincipal, objRoles);
@@ -266,7 +258,7 @@ public class InheritedAclFactory implements AclFactory {
             UserRole role = UserRole.getRoleByProperty(roleString);
 
             if (isEmbargoed) {
-                int objIndex = PATRON_ROLE_PRECEDENCE.indexOf(roleString);
+                int objIndex = UserRole.PATRON_ROLE_PRECEDENCE.indexOf(roleString);
                 if (objIndex > EMBARGO_ROLE_PRECEDENCE) {
                     role = UserRole.canViewMetadata;
                 }

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObject.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObject.java
@@ -180,6 +180,13 @@ public abstract class RepositoryObject {
     public abstract RepositoryObject getParent();
 
     /**
+     * @return pid of the parent of the current object
+     */
+    public PID getParentPid() {
+        return driver.getParentPid(this);
+    }
+
+    /**
      * Get the last modified date
      *
      * @return

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectDriver.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/RepositoryObjectDriver.java
@@ -261,26 +261,30 @@ public class RepositoryObjectDriver {
      * @throws ObjectTypeMismatchException thrown if object is not of a type eligible to have a parent.
      */
     public RepositoryObject getParentObject(RepositoryObject obj) {
-        PID parentPid = null;
+        PID parentPid = getParentPid(obj);
 
+        return repositoryObjectLoader.getRepositoryObject(parentPid);
+    }
+
+    /**
+     * Retrieves the PID of the parent of the provided object
+     * @param obj
+     * @return
+     */
+    public PID getParentPid(RepositoryObject obj) {
         if (obj instanceof BinaryObject) {
-            parentPid = fetchContainer(obj, PcdmModels.hasFile);
+            return fetchContainer(obj, PcdmModels.hasFile);
         } else if (obj instanceof ContentObject) {
             // For resources in the membership hierarchy, use reverse membership
             Statement memberOf = obj.getResource().getProperty(PcdmModels.memberOf);
             if (memberOf != null) {
-                parentPid = PIDs.get(memberOf.getObject().toString());
+                return PIDs.get(memberOf.getObject().toString());
             }
         } else {
             throw new ObjectTypeMismatchException("Unable to get parent object for " + obj.getPid()
                     + ", resources of type " + obj.getClass().getName() + " are not eligible.");
         }
-
-        if (parentPid == null) {
-            throw new OrphanedObjectException("Cannot find a parent container for object " + obj.getPid());
-        }
-
-        return repositoryObjectLoader.getRepositoryObject(parentPid);
+        throw new OrphanedObjectException("Cannot find a parent container for object " + obj.getPid());
     }
 
     /**

--- a/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/Tombstone.java
+++ b/fcrepo-clients/src/main/java/edu/unc/lib/dl/fcrepo4/Tombstone.java
@@ -45,4 +45,9 @@ public class Tombstone extends ContentObject {
         // tombstone is not in the hierarchy, so doesn't have a parent
         return null;
     }
+
+    @Override
+    public PID getParentPid() {
+        return null;
+    }
 }

--- a/fcrepo-clients/src/test/java/edu/unc/lib/dl/test/AclModelBuilder.java
+++ b/fcrepo-clients/src/test/java/edu/unc/lib/dl/test/AclModelBuilder.java
@@ -24,6 +24,7 @@ import org.apache.jena.rdf.model.Property;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.vocabulary.DC;
 
+import edu.unc.lib.dl.fedora.PID;
 import edu.unc.lib.dl.rdf.CdrAcl;
 
 /**
@@ -41,6 +42,12 @@ public class AclModelBuilder {
         model = createDefaultModel();
         resc = model.getResource("");
         resc.addProperty(DC.title, title);
+    }
+
+    public AclModelBuilder(PID pid) {
+        model = createDefaultModel();
+        resc = model.getResource(pid.getRepositoryPath());
+        resc.addProperty(DC.title, pid.getId());
     }
 
     public AclModelBuilder addUnitOwner(String princ) {
@@ -61,6 +68,10 @@ public class AclModelBuilder {
 
     public AclModelBuilder addCanViewMetadata(String princ) {
         return addProp(CdrAcl.canViewMetadata, princ);
+    }
+
+    public AclModelBuilder addCanViewAccessCopies(String princ) {
+        return addProp(CdrAcl.canViewAccessCopies, princ);
     }
 
     public AclModelBuilder addCanViewOriginals(String princ) {

--- a/security/src/main/java/edu/unc/lib/dl/acl/util/AccessPrincipalConstants.java
+++ b/security/src/main/java/edu/unc/lib/dl/acl/util/AccessPrincipalConstants.java
@@ -15,6 +15,9 @@
  */
 package edu.unc.lib.dl.acl.util;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 /**
@@ -28,6 +31,9 @@ public class AccessPrincipalConstants {
     public final static String PUBLIC_PRINC = "everyone";
     public final static String AUTHENTICATED_PRINC = "authenticated";
     public final static String USER_NAMESPACE = "unc:onyen:";
+    // common patron principals which are considered protected and present by default
+    public final static Set<String> PROTECTED_PATRON_PRINCIPALS = new HashSet<>(
+            Arrays.asList(PUBLIC_PRINC, AUTHENTICATED_PRINC));
     // Namespace prefix for special patron groups
     public final static String PATRON_NAMESPACE = "unc:patron:";
     public final static String IP_PRINC_NAMESPACE = PATRON_NAMESPACE + "ipp:";

--- a/security/src/main/java/edu/unc/lib/dl/acl/util/UserRole.java
+++ b/security/src/main/java/edu/unc/lib/dl/acl/util/UserRole.java
@@ -34,6 +34,7 @@ import static edu.unc.lib.dl.acl.util.Permission.viewAccessCopies;
 import static edu.unc.lib.dl.acl.util.Permission.viewHidden;
 import static edu.unc.lib.dl.acl.util.Permission.viewMetadata;
 import static edu.unc.lib.dl.acl.util.Permission.viewOriginal;
+import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
 
@@ -86,6 +87,13 @@ public enum UserRole {
             ingest, editDescription, bulkUpdateDescription, move, markForDeletion, markForDeletionUnit,
             changePatronAccess, editResourceType, destroy, destroyUnit, createCollection,
             createAdminUnit, assignStaffRoles, runEnhancements, reindex);
+
+    public static final List<String> PATRON_ROLE_PRECEDENCE = asList(
+            UserRole.none.getPropertyString(),
+            UserRole.canViewMetadata.getPropertyString(),
+            UserRole.canViewAccessCopies.getPropertyString(),
+            UserRole.canViewOriginals.getPropertyString()
+            );
 
     private URI uri;
     private String predicate;

--- a/solr-ingest/pom.xml
+++ b/solr-ingest/pom.xml
@@ -111,6 +111,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>edu.unc.lib.cdr</groupId>
+            <artifactId>fcrepo-clients</artifactId>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+        <dependency>
             <groupId>jaxen</groupId>
             <artifactId>jaxen</artifactId>
         </dependency>

--- a/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetAccessStatusFilter.java
+++ b/solr-ingest/src/main/java/edu/unc/lib/dl/data/ingest/solr/filter/SetAccessStatusFilter.java
@@ -22,13 +22,17 @@ import static edu.unc.lib.dl.acl.util.UserRole.canViewOriginals;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import edu.unc.lib.dl.acl.fcrepo4.InheritedAclFactory;
 import edu.unc.lib.dl.acl.fcrepo4.ObjectAclFactory;
+import edu.unc.lib.dl.acl.util.AccessPrincipalConstants;
 import edu.unc.lib.dl.acl.util.RoleAssignment;
 import edu.unc.lib.dl.acl.util.UserRole;
 import edu.unc.lib.dl.data.ingest.solr.exception.IndexingException;
@@ -79,7 +83,8 @@ public class SetAccessStatusFilter implements IndexDocumentFilter {
         PID pid = dip.getPid();
         List<String> status = new ArrayList<>();
 
-        if (inheritedAclFactory.isMarkedForDeletion(pid)) {
+        boolean isMarkedForDeletion = inheritedAclFactory.isMarkedForDeletion(pid);
+        if (isMarkedForDeletion) {
             status.add(FacetConstants.MARKED_FOR_DELETION);
         }
 
@@ -89,11 +94,15 @@ public class SetAccessStatusFilter implements IndexDocumentFilter {
         }
 
         Date objEmbargo = objAclFactory.getEmbargoUntil(pid);
-        Date parentEmbargo = inheritedAclFactory.getEmbargoUntil(pid);
-        if (isEmbargoActive(objEmbargo)) {
+        boolean isEmbargoed = isEmbargoActive(objEmbargo);
+        if (isEmbargoed) {
             status.add(FacetConstants.EMBARGOED);
-        } else if (isEmbargoActive(parentEmbargo)) {
-            status.add(FacetConstants.EMBARGOED_PARENT);
+        } else {
+            Date parentEmbargo = inheritedAclFactory.getEmbargoUntil(pid);
+            if (isEmbargoActive(parentEmbargo)) {
+                status.add(FacetConstants.EMBARGOED_PARENT);
+                isEmbargoed = true;
+            }
         }
 
         // Don't mark as public access if embargoes or deletion were present
@@ -102,7 +111,8 @@ public class SetAccessStatusFilter implements IndexDocumentFilter {
         List<RoleAssignment> inheritedAssignments = inheritedAclFactory.getPatronAccess(pid);
         List<RoleAssignment> objPatronRoles = objAclFactory.getPatronRoleAssignments(pid);
 
-        if (allPatronsRevoked(objPatronRoles)) {
+        boolean isDirectlyStaffOnly = allPatronsRevoked(objPatronRoles);
+        if (isDirectlyStaffOnly) {
             status.add(FacetConstants.STAFF_ONLY_ACCESS);
         } else if (!hasPatronAssignments(inheritedAssignments)) {
             status.add(FacetConstants.PARENT_HAS_STAFF_ONLY_ACCESS);
@@ -114,8 +124,60 @@ public class SetAccessStatusFilter implements IndexDocumentFilter {
         if (hasPatronSettings(objPatronRoles, isCollection)) {
             status.add(FacetConstants.PATRON_SETTINGS);
         }
+        if (!isCollection && !isMarkedForDeletion && !isDirectlyStaffOnly
+                && inheritingPatronRestrictions(objPatronRoles, inheritedAssignments, isEmbargoed)) {
+            status.add(FacetConstants.INHERITED_PATRON_RESTRICTIONS);
+        }
 
         return status;
+    }
+
+    private boolean inheritingPatronRestrictions(List<RoleAssignment> objRoles, List<RoleAssignment> inheritedRoles,
+            boolean isEmbargoed) {
+        // No roles defined any any level, so inheriting staff only
+        if (inheritedRoles.isEmpty() && objRoles.isEmpty()) {
+            return true;
+        }
+        UserRole maxInheritedRole = isEmbargoed ? UserRole.canViewMetadata : canViewOriginals;
+        Set<String> encounteredPrincipals = new HashSet<>();
+        // Determine if any inherited roles are more restrictive than direct object roles
+        for (RoleAssignment inherited: inheritedRoles) {
+            encounteredPrincipals.add(inherited.getPrincipal());
+            // Inherited role is maxed, so cannot be restricting
+            if (maxInheritedRole.equals(inherited.getRole())) {
+                continue;
+            }
+            Optional<RoleAssignment> objMatchOpt = objRoles.stream()
+                    .filter(o -> o.getPrincipal().equals(inherited.getPrincipal())).findFirst();
+            // No role defined for the principal at the object level, so the inherited role is restricting it
+            if (!objMatchOpt.isPresent()) {
+                return true;
+            }
+            // Check if the inherited role is lower precedence (more restrictive) than the direct role
+            UserRole objRole = objMatchOpt.get().getRole();
+            if (UserRole.PATRON_ROLE_PRECEDENCE.indexOf(inherited.getRole().getPropertyString())
+                    < UserRole.PATRON_ROLE_PRECEDENCE.indexOf(objRole.getPropertyString())) {
+                return true;
+            }
+        }
+        // Catch cases where role is not present in inherited set, but is present for object. This implies
+        // that the inherited permission is staff only, but the object is set to something less restrictive
+        for (RoleAssignment objRole: objRoles) {
+            encounteredPrincipals.add(objRole.getPrincipal());
+            // If object is set to none role, inherited can't be more restrictive
+            if (UserRole.none.equals(objRole.getRole())) {
+                continue;
+            }
+            // No inherited role for principal, which implies it is staff only and therefore restricting
+            if (inheritedRoles.stream().noneMatch(i -> i.getPrincipal().equals(objRole.getPrincipal()))) {
+                return true;
+            }
+        }
+        // Check if any protected patron principals are missing, indicating that they are restricted
+        if (!encounteredPrincipals.containsAll(AccessPrincipalConstants.PROTECTED_PATRON_PRINCIPALS)) {
+            return true;
+        }
+        return false;
     }
 
     private boolean hasPatronSettings(List<RoleAssignment> objPatronRoles, boolean isCollection) {

--- a/solr-ingest/src/test/java/edu/unc/lib/dl/data/ingest/solr/filter/SetAccessStatusFilterTest.java
+++ b/solr-ingest/src/test/java/edu/unc/lib/dl/data/ingest/solr/filter/SetAccessStatusFilterTest.java
@@ -110,7 +110,9 @@ public class SetAccessStatusFilterTest {
         when(dip.getPid()).thenReturn(pid);
         when(dip.getContentObject()).thenReturn(contentObj);
         when(contentObj.getPid()).thenReturn(pid);
+        when(contentObj.getParentPid()).thenReturn(parentPid);
         when(parentObj.getPid()).thenReturn(parentPid);
+        when(parentObj.getParentPid()).thenReturn(unitPid);
         when(unitObj.getPid()).thenReturn(unitPid);
         when(contentObj.getModel()).thenReturn(ModelFactory.createDefaultModel());
         when(parentObj.getModel()).thenReturn(ModelFactory.createDefaultModel());
@@ -159,7 +161,7 @@ public class SetAccessStatusFilterTest {
         assertTrue(listCaptor.getValue().contains(FacetConstants.EMBARGOED));
         assertFalse(listCaptor.getValue().contains(FacetConstants.EMBARGOED_PARENT));
         assertFalse(listCaptor.getValue().contains(FacetConstants.MARKED_FOR_DELETION));
-        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_RESTRICTIONS));
+        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_SETTINGS));
     }
 
     @Test
@@ -175,7 +177,7 @@ public class SetAccessStatusFilterTest {
         assertTrue(listCaptor.getValue().contains(FacetConstants.EMBARGOED_PARENT));
         assertFalse(listCaptor.getValue().contains(FacetConstants.EMBARGOED));
         assertFalse(listCaptor.getValue().contains(FacetConstants.PUBLIC_ACCESS));
-        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_RESTRICTIONS));
+        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_SETTINGS));
     }
 
     @Test
@@ -187,7 +189,7 @@ public class SetAccessStatusFilterTest {
 
         verify(idb).setStatus(listCaptor.capture());
         assertFalse(listCaptor.getValue().contains(FacetConstants.PATRON_SETTINGS));
-        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_RESTRICTIONS));
+        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_SETTINGS));
     }
 
     @Test
@@ -196,7 +198,7 @@ public class SetAccessStatusFilterTest {
 
         verify(idb).setStatus(listCaptor.capture());
         assertFalse(listCaptor.getValue().contains(FacetConstants.PATRON_SETTINGS));
-        assertTrue(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_RESTRICTIONS));
+        assertTrue(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_SETTINGS));
     }
 
     @Test
@@ -209,7 +211,7 @@ public class SetAccessStatusFilterTest {
 
         verify(idb).setStatus(listCaptor.capture());
         assertFalse(listCaptor.getValue().contains(FacetConstants.PATRON_SETTINGS));
-        assertTrue(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_RESTRICTIONS));
+        assertTrue(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_SETTINGS));
     }
 
     @Test
@@ -222,7 +224,7 @@ public class SetAccessStatusFilterTest {
 
         verify(idb).setStatus(listCaptor.capture());
         assertTrue(listCaptor.getValue().contains(FacetConstants.PATRON_SETTINGS));
-        assertTrue(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_RESTRICTIONS));
+        assertTrue(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_SETTINGS));
     }
 
     @Test
@@ -235,7 +237,7 @@ public class SetAccessStatusFilterTest {
 
         verify(idb).setStatus(listCaptor.capture());
         assertTrue(listCaptor.getValue().contains(FacetConstants.PATRON_SETTINGS));
-        assertTrue(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_RESTRICTIONS));
+        assertTrue(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_SETTINGS));
     }
 
     @Test
@@ -247,7 +249,7 @@ public class SetAccessStatusFilterTest {
 
         verify(idb).setStatus(listCaptor.capture());
         assertTrue(listCaptor.getValue().contains(FacetConstants.PATRON_SETTINGS));
-        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_RESTRICTIONS));
+        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_SETTINGS));
     }
 
     @Test
@@ -263,7 +265,7 @@ public class SetAccessStatusFilterTest {
 
         verify(idb).setStatus(listCaptor.capture());
         assertFalse(listCaptor.getValue().contains(FacetConstants.PATRON_SETTINGS));
-        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_RESTRICTIONS));
+        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_SETTINGS));
     }
 
     @Test
@@ -279,7 +281,7 @@ public class SetAccessStatusFilterTest {
 
         verify(idb).setStatus(listCaptor.capture());
         assertTrue(listCaptor.getValue().contains(FacetConstants.PATRON_SETTINGS));
-        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_RESTRICTIONS));
+        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_SETTINGS));
     }
 
     @Test
@@ -295,7 +297,7 @@ public class SetAccessStatusFilterTest {
 
         verify(idb).setStatus(listCaptor.capture());
         assertTrue(listCaptor.getValue().contains(FacetConstants.PATRON_SETTINGS));
-        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_RESTRICTIONS));
+        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_SETTINGS));
     }
 
     @Test
@@ -312,7 +314,7 @@ public class SetAccessStatusFilterTest {
         verify(idb).setStatus(listCaptor.capture());
         assertTrue(listCaptor.getValue().contains(FacetConstants.STAFF_ONLY_ACCESS));
         assertFalse(listCaptor.getValue().contains(FacetConstants.PUBLIC_ACCESS));
-        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_RESTRICTIONS));
+        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_SETTINGS));
     }
 
     @Test
@@ -329,7 +331,7 @@ public class SetAccessStatusFilterTest {
         verify(idb).setStatus(listCaptor.capture());
         assertTrue(listCaptor.getValue().contains(FacetConstants.PUBLIC_ACCESS));
         assertFalse(listCaptor.getValue().contains(FacetConstants.STAFF_ONLY_ACCESS));
-        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_RESTRICTIONS));
+        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_SETTINGS));
     }
 
     @Test
@@ -344,7 +346,7 @@ public class SetAccessStatusFilterTest {
         assertTrue(listCaptor.getValue().contains(FacetConstants.PUBLIC_ACCESS));
         assertFalse(listCaptor.getValue().contains(FacetConstants.PATRON_SETTINGS));
         assertFalse(listCaptor.getValue().contains(FacetConstants.STAFF_ONLY_ACCESS));
-        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_RESTRICTIONS));
+        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_SETTINGS));
     }
 
     @Test
@@ -362,7 +364,7 @@ public class SetAccessStatusFilterTest {
         assertFalse(listCaptor.getValue().contains(FacetConstants.PUBLIC_ACCESS));
         assertTrue(listCaptor.getValue().contains(FacetConstants.PATRON_SETTINGS));
         assertFalse(listCaptor.getValue().contains(FacetConstants.STAFF_ONLY_ACCESS));
-        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_RESTRICTIONS));
+        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_SETTINGS));
     }
 
     @Test
@@ -376,7 +378,7 @@ public class SetAccessStatusFilterTest {
         verify(idb).setStatus(listCaptor.capture());
         assertFalse(listCaptor.getValue().contains(FacetConstants.PUBLIC_ACCESS));
         assertFalse(listCaptor.getValue().contains(FacetConstants.STAFF_ONLY_ACCESS));
-        assertTrue(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_RESTRICTIONS));
+        assertTrue(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_SETTINGS));
     }
 
     @Test
@@ -393,7 +395,7 @@ public class SetAccessStatusFilterTest {
         verify(idb).setStatus(listCaptor.capture());
         assertFalse(listCaptor.getValue().contains(FacetConstants.PUBLIC_ACCESS));
         assertFalse(listCaptor.getValue().contains(FacetConstants.STAFF_ONLY_ACCESS));
-        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_RESTRICTIONS));
+        assertTrue(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_SETTINGS));
     }
 
     @Test
@@ -410,7 +412,7 @@ public class SetAccessStatusFilterTest {
         verify(idb).setStatus(listCaptor.capture());
         assertFalse(listCaptor.getValue().contains(FacetConstants.PUBLIC_ACCESS));
         assertFalse(listCaptor.getValue().contains(FacetConstants.STAFF_ONLY_ACCESS));
-        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_RESTRICTIONS));
+        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_SETTINGS));
     }
 
     @Test
@@ -424,7 +426,7 @@ public class SetAccessStatusFilterTest {
         verify(idb).setStatus(listCaptor.capture());
         assertFalse(listCaptor.getValue().contains(FacetConstants.PUBLIC_ACCESS));
         assertFalse(listCaptor.getValue().contains(FacetConstants.STAFF_ONLY_ACCESS));
-        assertTrue(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_RESTRICTIONS));
+        assertTrue(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_SETTINGS));
     }
 
     @Test
@@ -438,7 +440,7 @@ public class SetAccessStatusFilterTest {
         assertTrue(listCaptor.getValue().contains(FacetConstants.PARENT_HAS_STAFF_ONLY_ACCESS));
         assertFalse(listCaptor.getValue().contains(FacetConstants.PATRON_SETTINGS));
         assertFalse(listCaptor.getValue().contains(FacetConstants.STAFF_ONLY_ACCESS));
-        assertTrue(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_RESTRICTIONS));
+        assertTrue(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_SETTINGS));
     }
 
     @Test
@@ -455,7 +457,7 @@ public class SetAccessStatusFilterTest {
         assertTrue(listCaptor.getValue().contains(FacetConstants.PARENT_HAS_STAFF_ONLY_ACCESS));
         assertTrue(listCaptor.getValue().contains(FacetConstants.PATRON_SETTINGS));
         assertFalse(listCaptor.getValue().contains(FacetConstants.STAFF_ONLY_ACCESS));
-        assertTrue(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_RESTRICTIONS));
+        assertTrue(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_SETTINGS));
     }
 
     @Test
@@ -469,7 +471,7 @@ public class SetAccessStatusFilterTest {
         assertFalse(listCaptor.getValue().contains(FacetConstants.PUBLIC_ACCESS));
         assertFalse(listCaptor.getValue().contains(FacetConstants.EMBARGOED));
         assertFalse(listCaptor.getValue().contains(FacetConstants.MARKED_FOR_DELETION));
-        assertTrue(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_RESTRICTIONS));
+        assertTrue(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_SETTINGS));
     }
 
     @Test
@@ -486,7 +488,7 @@ public class SetAccessStatusFilterTest {
 
         verify(idb).setStatus(listCaptor.capture());
         assertTrue(listCaptor.getValue().contains(FacetConstants.PATRON_SETTINGS));
-        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_RESTRICTIONS));
+        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_SETTINGS));
     }
 
     @Test
@@ -505,7 +507,7 @@ public class SetAccessStatusFilterTest {
         List<String> status = listCaptor.getValue();
         assertTrue(status.contains(FacetConstants.PATRON_SETTINGS));
         assertFalse(status.contains(FacetConstants.STAFF_ONLY_ACCESS));
-        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_RESTRICTIONS));
+        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_SETTINGS));
     }
 
     @Test
@@ -523,7 +525,7 @@ public class SetAccessStatusFilterTest {
         List<String> status = listCaptor.getValue();
         assertTrue(status.contains(FacetConstants.PATRON_SETTINGS));
         assertFalse(status.contains(FacetConstants.STAFF_ONLY_ACCESS));
-        assertTrue(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_RESTRICTIONS));
+        assertTrue(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_SETTINGS));
     }
 
     @Test
@@ -545,7 +547,7 @@ public class SetAccessStatusFilterTest {
         List<String> status = listCaptor.getValue();
         assertTrue(status.contains(FacetConstants.PATRON_SETTINGS));
         assertTrue(status.contains(FacetConstants.STAFF_ONLY_ACCESS));
-        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_RESTRICTIONS));
+        assertTrue(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_SETTINGS));
     }
 
     @Test
@@ -568,7 +570,7 @@ public class SetAccessStatusFilterTest {
         List<String> status = listCaptor.getValue();
         assertTrue(status.contains(FacetConstants.PATRON_SETTINGS));
         assertTrue(status.contains(FacetConstants.STAFF_ONLY_ACCESS));
-        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_RESTRICTIONS));
+        assertTrue(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_SETTINGS));
     }
 
     @Test
@@ -591,7 +593,7 @@ public class SetAccessStatusFilterTest {
         List<String> status = listCaptor.getValue();
         assertTrue(status.contains(FacetConstants.PATRON_SETTINGS));
         assertFalse(status.contains(FacetConstants.STAFF_ONLY_ACCESS));
-        assertFalse(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_RESTRICTIONS));
+        assertTrue(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_SETTINGS));
     }
 
     @Test
@@ -612,7 +614,7 @@ public class SetAccessStatusFilterTest {
         List<String> status = listCaptor.getValue();
         assertTrue(status.contains(FacetConstants.PATRON_SETTINGS));
         assertFalse(status.contains(FacetConstants.STAFF_ONLY_ACCESS));
-        assertTrue(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_RESTRICTIONS));
+        assertTrue(listCaptor.getValue().contains(FacetConstants.INHERITED_PATRON_SETTINGS));
     }
 
     private void redefineContentObject(Class<? extends ContentObject> clazz) {

--- a/solr-search/src/main/java/edu/unc/lib/dl/search/solr/util/FacetConstants.java
+++ b/solr-search/src/main/java/edu/unc/lib/dl/search/solr/util/FacetConstants.java
@@ -33,6 +33,7 @@ public abstract class FacetConstants {
     public static final String NO_PRIMARY_OBJECT = "No Primary Object";
     public static final String PARENT_HAS_STAFF_ONLY_ACCESS = "Parent Has Staff-Only Access";
     public static final String PATRON_SETTINGS = "Patron Settings";
+    public static final String INHERITED_PATRON_RESTRICTIONS = "Inherited Patron Restrictions";
     public static final String PUBLIC_ACCESS = "Public Access";
     public static final String STAFF_ONLY_ACCESS = "Staff-Only Access";
 }

--- a/solr-search/src/main/java/edu/unc/lib/dl/search/solr/util/FacetConstants.java
+++ b/solr-search/src/main/java/edu/unc/lib/dl/search/solr/util/FacetConstants.java
@@ -33,7 +33,7 @@ public abstract class FacetConstants {
     public static final String NO_PRIMARY_OBJECT = "No Primary Object";
     public static final String PARENT_HAS_STAFF_ONLY_ACCESS = "Parent Has Staff-Only Access";
     public static final String PATRON_SETTINGS = "Patron Settings";
-    public static final String INHERITED_PATRON_RESTRICTIONS = "Inherited Patron Restrictions";
+    public static final String INHERITED_PATRON_SETTINGS = "Inherited Patron Settings";
     public static final String PUBLIC_ACCESS = "Public Access";
     public static final String STAFF_ONLY_ACCESS = "Staff-Only Access";
 }

--- a/static/js/admin/src/ResultObject.js
+++ b/static/js/admin/src/ResultObject.js
@@ -39,6 +39,8 @@ define('ResultObject', [ 'jquery', 'jquery-ui', 'underscore', 'ModalLoadingOverl
 					tagValue = 'deleted';
 				} else if (/staff-only/i.test(d)) {
 					tagValue = 'staff-only';
+				} else if(/inherited patron restrictions/i.test(d)) {
+					tagValue = 'inherited-settings';
 				} else {
 					tagValue = d.trim().toLowerCase()
 						.replace(/parent\s+is\s+/, '')
@@ -88,6 +90,9 @@ define('ResultObject', [ 'jquery', 'jquery-ui', 'underscore', 'ModalLoadingOverl
 				break;
 			case 'staff-only':
 				helpText = 'Only users with staff roles can access this object';
+				break;
+			case 'inherited-settings':
+				helpText = 'Patron access to this object is being restricted by inherited access settings';
 				break;
 			default:
 				helpText = '';

--- a/static/js/admin/src/ResultObject.js
+++ b/static/js/admin/src/ResultObject.js
@@ -39,7 +39,7 @@ define('ResultObject', [ 'jquery', 'jquery-ui', 'underscore', 'ModalLoadingOverl
 					tagValue = 'deleted';
 				} else if (/staff-only/i.test(d)) {
 					tagValue = 'staff-only';
-				} else if(/inherited patron restrictions/i.test(d)) {
+				} else if(/inherited patron settings/i.test(d)) {
 					tagValue = 'inherited-settings';
 				} else {
 					tagValue = d.trim().toLowerCase()
@@ -92,7 +92,7 @@ define('ResultObject', [ 'jquery', 'jquery-ui', 'underscore', 'ModalLoadingOverl
 				helpText = 'Only users with staff roles can access this object';
 				break;
 			case 'inherited-settings':
-				helpText = 'Patron access to this object is being restricted by inherited access settings';
+				helpText = 'Object is inheriting patron access settings which have been modified (typically they are more restrictive)';
 				break;
 			default:
 				helpText = '';


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3148

* Add tag and access status facet for objects which inherit patron access restrictions.
* Reworked access status filter to use real acl factories, as the mocked outcomes of some tests were not possible. 
* Move patron role precedence constant to location where it can be referenced more broadly, add more constants.