### PR TITLE
BXC-3206 - Bag Deposit too many file handles

### DIFF
--- a/deposit/src/main/java/edu/unc/lib/deposit/normalize/BagIt2N3BagJob.java
+++ b/deposit/src/main/java/edu/unc/lib/deposit/normalize/BagIt2N3BagJob.java
@@ -29,6 +29,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
@@ -67,6 +68,7 @@ import gov.loc.repository.bagit.verify.MandatoryVerifier;
 public class BagIt2N3BagJob extends AbstractFileServerToBagJob {
     private static final Logger log = LoggerFactory.getLogger(BagIt2N3BagJob.class);
     private BagReader reader = new BagReader();
+    private ExecutorService executorService;
 
     public BagIt2N3BagJob() {
         super();
@@ -95,7 +97,7 @@ public class BagIt2N3BagJob extends AbstractFileServerToBagJob {
             // Check that bag exists. Throws MissingBagitFileException
             MandatoryVerifier.checkBagitFileExists(bagReader.getRootDir(), bagReader.getVersion());
 
-            try (BagVerifier verifier = new BagVerifier()) {
+            try (BagVerifier verifier = new BagVerifier(executorService)) {
                 interruptJobIfStopped();
                 verifier.isComplete(bagReader, false);
                 interruptJobIfStopped();
@@ -171,5 +173,9 @@ public class BagIt2N3BagJob extends AbstractFileServerToBagJob {
         }
 
         commit(() -> depModel.add(model));
+    }
+
+    public void setExecutorService(ExecutorService executorService) {
+        this.executorService = executorService;
     }
 }

--- a/deposit/src/main/webapp/WEB-INF/deposit-jobs-context.xml
+++ b/deposit/src/main/webapp/WEB-INF/deposit-jobs-context.xml
@@ -148,8 +148,14 @@
         scope="prototype">
     </bean>
     
+    <bean id="bagitValidationExecutor" class="java.util.concurrent.Executors"
+            factory-method="newFixedThreadPool" destroy-method="shutdownNow">
+        <constructor-arg value="${job.bagitValidation.workers:50}"/>
+    </bean>
+    
     <bean id="BagIt2N3BagJob" class="edu.unc.lib.deposit.normalize.BagIt2N3BagJob"
         scope="prototype">
+        <property name="executorService" ref="bagitValidationExecutor" />
     </bean>
     
     <bean id="DirectoryToBagJob" class="edu.unc.lib.deposit.normalize.DirectoryToBagJob"

--- a/deposit/src/test/java/edu/unc/lib/deposit/normalize/BagIt2N3BagJobTest.java
+++ b/deposit/src/test/java/edu/unc/lib/deposit/normalize/BagIt2N3BagJobTest.java
@@ -30,6 +30,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 import org.apache.jena.rdf.model.Bag;
@@ -39,6 +41,7 @@ import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.rdf.model.Statement;
 import org.apache.jena.rdf.model.StmtIterator;
 import org.apache.jena.vocabulary.RDF;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -60,18 +63,27 @@ public class BagIt2N3BagJobTest extends AbstractNormalizationJobTest {
     @Captor
     private ArgumentCaptor<String> filePathCaptor;
 
+    private ExecutorService executorService;
+
     @Before
     public void setup() throws Exception {
         status = new HashMap<>();
         when(depositStatusFactory.get(anyString())).thenReturn(status);
 
+        executorService = Executors.newSingleThreadExecutor();
         job = new BagIt2N3BagJob();
         job.setDepositUUID(depositUUID);
         job.setDepositDirectory(depositDir);
+        job.setExecutorService(executorService);
         setField(job, "depositModelManager", depositModelManager);
         setField(job, "depositsDirectory", depositsDirectory);
         setField(job, "depositStatusFactory", depositStatusFactory);
         job.init();
+    }
+
+    @After
+    public void tearDownTest() throws Exception {
+        executorService.shutdown();
     }
 
     @Test


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3206

* Add executor service to limit the number of files the BagVerifier checks for at once, to prevent it from opening thousands of file handles simultaneously