### PR TITLE
BXC-3201 - Send MODS import emails to admin users

### DIFF
--- a/persistence/src/main/java/edu/unc/lib/dl/persist/services/importxml/ImportXMLJob.java
+++ b/persistence/src/main/java/edu/unc/lib/dl/persist/services/importxml/ImportXMLJob.java
@@ -313,14 +313,14 @@ public class ImportXMLJob implements Runnable {
 
                                 Attribute typeAttr = element.getAttributeByName(typeAttribute);
                                 if (typeAttr == null) {
-                                    failed.put(currentPid.getRepositoryPath(),
+                                    failed.put(currentPid.getQualifiedId(),
                                             "Invalid import data, missing type attribute on update");
                                 }
                                 if (MODS_TYPE.equals(typeAttr.getValue())) {
                                     currentDs = MODS_TYPE;
                                     log.debug("Starting MODS element for object {}", currentPid.getQualifiedId());
                                 } else {
-                                    failed.put(currentPid.getRepositoryPath(),
+                                    failed.put(currentPid.getQualifiedId(),
                                             "Invalid import data, unsupported type in update tag");
                                 }
 
@@ -372,22 +372,22 @@ public class ImportXMLJob implements Runnable {
                                             new UpdateDescriptionRequest(agent, currentPid, modsStream)
                                                 .withTransferSession(transferSession)
                                                 .withPriority(IndexingPriority.low));
-                                    updated.add(currentPid.getId());
+                                    updated.add(currentPid.getQualifiedId());
                                     log.debug("Finished updating object {} with id {}", objectCount, currentPid);
                                 } catch (AccessRestrictionException ex) {
-                                    failed.put(currentPid.getRepositoryPath(),
+                                    failed.put(currentPid.getQualifiedId(),
                                             "User doesn't have permission to update this object: " + ex.getMessage());
                                 } catch (MetadataValidationException ex) {
                                     log.debug("Validation failed for {}", currentPid, ex);
-                                    failed.put(currentPid.getRepositoryPath(),
+                                    failed.put(currentPid.getQualifiedId(),
                                             "MODS is not valid: " + ex.getDetailedMessage());
                                 } catch (IOException ex) {
-                                    failed.put(currentPid.getRepositoryPath(),
+                                    failed.put(currentPid.getQualifiedId(),
                                             "Error reading or converting MODS stream: " + ex.getMessage());
                                 } catch (NotFoundException ex) {
-                                    failed.put(currentPid.getRepositoryPath(), "Object not found");
+                                    failed.put(currentPid.getQualifiedId(), "Object not found");
                                 } catch (FedoraException ex) {
-                                    failed.put(currentPid.getRepositoryPath(),
+                                    failed.put(currentPid.getQualifiedId(),
                                             "Error retrieving object from Fedora: " + ex.getMessage());
                                 }
                             } else if (foundResumptionPoint) {

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/importxml/ImportXMLJobIT.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/importxml/ImportXMLJobIT.java
@@ -106,7 +106,8 @@ public class ImportXMLJobIT {
     @Mock
     private MimeMessage mimeMsg;
 
-    private String fromAddress = "admin@example.com";
+    private String fromAddress = "no-reply@example.com";
+    private String adminAddress = "admin@example.com";
 
     @Rule
     public final TemporaryFolder tmpFolder = new TemporaryFolder();
@@ -287,6 +288,7 @@ public class ImportXMLJobIT {
         job.setCompleteTemplate(completeTemplate);
         job.setFailedTemplate(failedTemplate);
         job.setFromAddress(fromAddress);
+        job.setAdminAddress(adminAddress);
         job.setMimeMessage(mimeMsg);
         job.setLocationManager(locationManager);
         job.setTransferService(transferService);

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/importxml/ImportXMLJobIT.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/importxml/ImportXMLJobIT.java
@@ -258,6 +258,22 @@ public class ImportXMLJobIT {
         assertEquals("The import file contains XML errors", job.getFailed().get(importFile.getAbsolutePath()));
     }
 
+    @Test
+    public void testObjectDoesNotExist() throws Exception {
+        PID workPid = PIDs.get(UUID.randomUUID().toString());
+
+        Document updateDoc = makeUpdateDocument();
+        addObjectUpdate(updateDoc, workPid, null)
+            .addContent(modsWithTitleAndDate(UPDATED_TITLE, UPDATED_DATE));
+        importFile = writeToFile(updateDoc);
+        createJob();
+
+        job.run();
+
+        verify(mailSender).send(any(MimeMessage.class));
+        assertEquals("Object not found", job.getFailed().get(workPid.getRepositoryPath()));
+    }
+
     private void assertModsUpdated(InputStream updatedMods) throws JDOMException, IOException {
         SAXBuilder builder = new SAXBuilder();
         Document doc = builder.build(updatedMods);

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/importxml/ImportXMLJobIT.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/importxml/ImportXMLJobIT.java
@@ -271,7 +271,7 @@ public class ImportXMLJobIT {
         job.run();
 
         verify(mailSender).send(any(MimeMessage.class));
-        assertEquals("Object not found", job.getFailed().get(workPid.getRepositoryPath()));
+        assertEquals("Object not found", job.getFailed().get(workPid.getQualifiedId()));
     }
 
     private void assertModsUpdated(InputStream updatedMods) throws JDOMException, IOException {

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/importxml/ImportXMLJobTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/importxml/ImportXMLJobTest.java
@@ -86,9 +86,9 @@ public class ImportXMLJobTest {
     private final static String UPDATED_TITLE = "Updated Work Title";
     private final static String ORIGINAL_DATE = "2017-10-09";
 
-    private static final String OBJ1_ID = "ae0091e0-192d-46f9-a8ad-8b0dc82f33ad";
-    private static final String OBJ2_ID = "b75e416f-0ca8-4138-94ca-0a99bbd8e710";
-    private static final String OBJ3_ID = "43dcb37a-27fc-425b-9c00-76cee952507c";
+    private static final String OBJ1_ID = "content/ae0091e0-192d-46f9-a8ad-8b0dc82f33ad";
+    private static final String OBJ2_ID = "content/b75e416f-0ca8-4138-94ca-0a99bbd8e710";
+    private static final String OBJ3_ID = "content/43dcb37a-27fc-425b-9c00-76cee952507c";
 
     private static final String USER_EMAIL = "user@example.com";
     private static final String FROM_EMAIL = "reply@example.com";
@@ -286,7 +286,7 @@ public class ImportXMLJobTest {
         Set<Entry<String, String>> failed = (Set<Entry<String, String>>) dataMap.get("failed");
         assertEquals(1, failed.size());
         Entry<String, String> failedEntry = failed.iterator().next();
-        assertEquals(PIDs.get(OBJ2_ID).getRepositoryPath(), failedEntry.getKey());
+        assertEquals(PIDs.get(OBJ2_ID).getQualifiedId(), failedEntry.getKey());
         assertTrue("Unexpected failure message: " + failedEntry.getValue(),
                 failedEntry.getValue().contains("User doesn't have permission"));
         assertEquals(1, dataMap.get("failedCount"));

--- a/persistence/src/test/java/edu/unc/lib/dl/persist/services/importxml/ImportXMLJobTest.java
+++ b/persistence/src/test/java/edu/unc/lib/dl/persist/services/importxml/ImportXMLJobTest.java
@@ -25,6 +25,10 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -35,6 +39,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import javax.mail.Address;
+import javax.mail.Message;
 import javax.mail.internet.MimeMessage;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventReader;
@@ -48,6 +54,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatcher;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -56,7 +63,9 @@ import org.springframework.mail.javamail.MimeMessageHelper;
 import com.samskivert.mustache.Template;
 
 import edu.unc.lib.boxc.model.api.ids.PID;
+import edu.unc.lib.boxc.model.api.objects.BinaryObject;
 import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import edu.unc.lib.dl.acl.exception.AccessRestrictionException;
 import edu.unc.lib.dl.acl.util.AgentPrincipals;
 import edu.unc.lib.dl.persist.api.storage.StorageLocation;
 import edu.unc.lib.dl.persist.api.storage.StorageLocationManager;
@@ -64,6 +73,7 @@ import edu.unc.lib.dl.persist.api.transfer.BinaryTransferService;
 import edu.unc.lib.dl.persist.api.transfer.BinaryTransferSession;
 import edu.unc.lib.dl.persist.api.transfer.MultiDestinationTransferSession;
 import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService;
+import edu.unc.lib.dl.persist.services.edit.UpdateDescriptionService.UpdateDescriptionRequest;
 
 /**
  *
@@ -79,6 +89,10 @@ public class ImportXMLJobTest {
     private static final String OBJ1_ID = "ae0091e0-192d-46f9-a8ad-8b0dc82f33ad";
     private static final String OBJ2_ID = "b75e416f-0ca8-4138-94ca-0a99bbd8e710";
     private static final String OBJ3_ID = "43dcb37a-27fc-425b-9c00-76cee952507c";
+
+    private static final String USER_EMAIL = "user@example.com";
+    private static final String FROM_EMAIL = "reply@example.com";
+    private static final String ADMIN_EMAIL = "admin@example.com";
 
     private ImportXMLJob job;
 
@@ -102,6 +116,8 @@ public class ImportXMLJobTest {
     private StorageLocationManager locationManager;
     @Mock
     private StorageLocation storageLocation;
+    @Captor
+    private ArgumentCaptor<Address> addressCaptor;
 
     @Mock
     private MimeMessage msg;
@@ -156,6 +172,8 @@ public class ImportXMLJobTest {
 
         verify(msg).setSubject(subjectCaptor.capture());
         assertEquals("DCR Metadata update failed", subjectCaptor.getValue());
+
+        assertAddressesSet(USER_EMAIL);
     }
 
     @SuppressWarnings("unchecked")
@@ -177,6 +195,8 @@ public class ImportXMLJobTest {
 
         verify(msg).setSubject(subjectCaptor.capture());
         assertEquals("DCR Metadata update failed", subjectCaptor.getValue());
+
+        assertAddressesSet(USER_EMAIL);
     }
 
     @SuppressWarnings("unchecked")
@@ -209,6 +229,8 @@ public class ImportXMLJobTest {
 
         verify(msg).setSubject(subjectCaptor.capture());
         assertEquals("DCR Metadata update failed", subjectCaptor.getValue());
+
+        assertAddressesSet(USER_EMAIL);
     }
 
     @SuppressWarnings("unchecked")
@@ -235,6 +257,44 @@ public class ImportXMLJobTest {
 
         verify(msg).setSubject(subjectCaptor.capture());
         assertTrue(subjectCaptor.getValue().startsWith("DCR Metadata update completed"));
+
+        assertAddressesSet(USER_EMAIL);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void partialSuccessfulJobTest() throws Exception {
+        when(updateService.updateDescription(any(UpdateDescriptionRequest.class)))
+                .thenReturn(mock(BinaryObject.class))
+                .thenThrow(new AccessRestrictionException());
+
+        File tempImportFile = createTempImportFile();
+        setupJob(tempImportFile);
+        when(completeTemplate.execute(anyObject())).thenReturn("success email text");
+        job.run();
+
+        verify(mailSender).send(msg);
+        verify(completeTemplate).execute(mapCaptor.capture());
+        Map<String, Object> dataMap = mapCaptor.getValue();
+        assertEquals(tempImportFile.getPath(), dataMap.get("fileName"));
+
+        List<String> updated = (List<String>) dataMap.get("updated");
+        assertEquals(1, updated.size());
+        assertTrue(updated.contains(OBJ1_ID));
+        assertEquals(1, dataMap.get("updatedCount"));
+
+        Set<Entry<String, String>> failed = (Set<Entry<String, String>>) dataMap.get("failed");
+        assertEquals(1, failed.size());
+        Entry<String, String> failedEntry = failed.iterator().next();
+        assertEquals(PIDs.get(OBJ2_ID).getRepositoryPath(), failedEntry.getKey());
+        assertTrue("Unexpected failure message: " + failedEntry.getValue(),
+                failedEntry.getValue().contains("User doesn't have permission"));
+        assertEquals(1, dataMap.get("failedCount"));
+
+        verify(msg).setSubject(subjectCaptor.capture());
+        assertTrue(subjectCaptor.getValue().startsWith("DCR Metadata update completed"));
+
+        assertAddressesSet(USER_EMAIL, ADMIN_EMAIL);
     }
 
     private File createTempImportFile() throws Exception {
@@ -248,13 +308,30 @@ public class ImportXMLJobTest {
         return writeToFile(updateDoc);
     }
 
+    private void assertAddressesSet(String... expectedAddresses) throws Exception {
+        verify(msg).setFrom(argThat(new ArgumentMatcher<Address>() {
+            @Override
+            public boolean matches(Object argument) {
+                Address address = (Address) argument;
+                return address.toString().equals(FROM_EMAIL);
+            }
+        }));
+        verify(msg, times(expectedAddresses.length))
+                .addRecipient(eq(Message.RecipientType.TO), addressCaptor.capture());
+        List<Address> toAddresses = addressCaptor.getAllValues();
+        for (String expectedAddress : expectedAddresses) {
+            assertTrue("Expected to address " + expectedAddress,
+                    toAddresses.stream().anyMatch(a -> a.toString().equals(expectedAddress)));
+        }
+    }
+
     private void setupJob(File importFile) {
-        String userEmail = "user@email.com";
-        ImportXMLRequest request = new ImportXMLRequest(userEmail, agent, importFile);
+        ImportXMLRequest request = new ImportXMLRequest(USER_EMAIL, agent, importFile);
         job = new ImportXMLJob(request);
         job.setCompleteTemplate(completeTemplate);
         job.setFailedTemplate(failedTemplate);
-        job.setFromAddress("admin@example.com");
+        job.setFromAddress(FROM_EMAIL);
+        job.setAdminAddress(ADMIN_EMAIL);
         job.setMailSender(mailSender);
         job.setUpdateService(updateService);
         job.setMimeMessage(msg);

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/importxml/ImportXMLProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/importxml/ImportXMLProcessor.java
@@ -46,6 +46,7 @@ public class ImportXMLProcessor implements Processor {
     private Template updateCompleteTemplate;
     private Template updateFailedTemplate;
     private String fromAddress;
+    private String adminAddress;
     private BinaryTransferService transferService;
     private StorageLocationManager locationManager;
 
@@ -91,6 +92,10 @@ public class ImportXMLProcessor implements Processor {
 
     public void setFromAddress(String fromAddress) {
         this.fromAddress = fromAddress;
+    }
+
+    public void setAdminAddress(String adminAddress) {
+        this.adminAddress = adminAddress;
     }
 
     public void setTransferService(BinaryTransferService transferService) {

--- a/services-camel/src/main/java/edu/unc/lib/dl/services/camel/importxml/ImportXMLProcessor.java
+++ b/services-camel/src/main/java/edu/unc/lib/dl/services/camel/importxml/ImportXMLProcessor.java
@@ -67,6 +67,7 @@ public class ImportXMLProcessor implements Processor {
         job.setCompleteTemplate(updateCompleteTemplate);
         job.setFailedTemplate(updateFailedTemplate);
         job.setFromAddress(fromAddress);
+        job.setAdminAddress(adminAddress);
         job.setLocationManager(locationManager);
         job.setMailSender(mailSender);
         job.setTransferService(transferService);

--- a/services-camel/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel/src/main/webapp/WEB-INF/service-context.xml
@@ -321,6 +321,10 @@
     <bean id="fromAddress" class="java.lang.String">
         <constructor-arg value="${repository.from.email}" />
     </bean>
+    
+    <bean id="adminAddress" class="java.lang.String">
+        <constructor-arg value="${administrator.email}" />
+    </bean>
 
     <bean id="mailSender" class="org.springframework.mail.javamail.JavaMailSenderImpl">
         <property name="host" value="${smtp.host:localhost}" />
@@ -397,6 +401,7 @@
         <property name="updateCompleteTemplate" ref="updateCompleteTemplate" />
         <property name="updateFailedTemplate" ref="updateFailedTemplate" />
         <property name="fromAddress" ref="fromAddress" />
+        <property name="adminAddress" ref="adminAddress" />
         <property name="transferService" ref="binaryTransferService" />
         <property name="locationManager" ref="storageLocationManager" />
     </bean>


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3201
* Separate admin email from reply email address for MODS imports, send MODS import emails to admin instead of reply email
* Improve error handling and consistency of messages