### PR TITLE
BXC-3176 - Updates to support migration SIP generation

### DIFF
--- a/auth-api/src/main/java/edu/unc/lib/boxc/auth/api/services/DatastreamPermissionUtil.java
+++ b/auth-api/src/main/java/edu/unc/lib/boxc/auth/api/services/DatastreamPermissionUtil.java
@@ -38,6 +38,7 @@ public class DatastreamPermissionUtil {
         DS_PERMISSION_MAP = new EnumMap<>(DatastreamType.class);
         DS_PERMISSION_MAP.put(DatastreamType.FULLTEXT_EXTRACTION, Permission.viewHidden);
         DS_PERMISSION_MAP.put(DatastreamType.JP2_ACCESS_COPY, Permission.viewAccessCopies);
+        DS_PERMISSION_MAP.put(DatastreamType.ACCESS_COPY, Permission.viewAccessCopies);
         DS_PERMISSION_MAP.put(DatastreamType.MD_DESCRIPTIVE, Permission.viewMetadata);
         DS_PERMISSION_MAP.put(DatastreamType.MD_DESCRIPTIVE_HISTORY, Permission.viewHidden);
         DS_PERMISSION_MAP.put(DatastreamType.MD_EVENTS, Permission.viewHidden);

--- a/deposit-utils/src/main/java/edu/unc/lib/boxc/deposit/impl/model/DepositDirectoryManager.java
+++ b/deposit-utils/src/main/java/edu/unc/lib/boxc/deposit/impl/model/DepositDirectoryManager.java
@@ -96,7 +96,7 @@ public class DepositDirectoryManager {
      * @param modsEl
      */
     public void writeMods(PID pid, Element modsEl) {
-        Path modsPath = makeMetadataFilePath(descriptionDir, pid, ".xml");
+        Path modsPath = getModsPath(pid);
 
         try (OutputStream fos = newOutputStream(modsPath)) {
             // Make a new document for just the MODS, which should add in the xml declaration
@@ -106,6 +106,14 @@ public class DepositDirectoryManager {
         } catch (IOException e) {
             throw new RepositoryException("Unable to write MODS for " + pid.getId(), e);
         }
+    }
+
+    /**
+     * @param pid
+     * @return get the path to where the MODS file for the given PID should be located
+     */
+    public Path getModsPath(PID pid) {
+        return makeMetadataFilePath(descriptionDir, pid, ".xml");
     }
 
     public Path writeHistoryFile(PID pid, DatastreamType type, InputStream historyStream) {

--- a/deposit-utils/src/main/java/edu/unc/lib/boxc/deposit/impl/model/DepositModelHelpers.java
+++ b/deposit-utils/src/main/java/edu/unc/lib/boxc/deposit/impl/model/DepositModelHelpers.java
@@ -68,6 +68,9 @@ public class DepositModelHelpers {
             PID fitsPid = DatastreamPids.getTechnicalMetadataPid(parentPid);
             dsPid = DatastreamPids.getDatastreamHistoryPid(fitsPid);
             break;
+        case ACCESS_COPY:
+            dsPid = DatastreamPids.getAccessCopyPid(parentPid);
+            break;
         default:
             throw new RepositoryException("Cannot add datastream of type " + type.name());
         }
@@ -95,6 +98,8 @@ public class DepositModelHelpers {
             return CdrDeposit.hasDatastreamDescriptiveHistory;
         case TECHNICAL_METADATA_HISTORY:
             return CdrDeposit.hasDatastreamFitsHistory;
+        case ACCESS_COPY:
+            return CdrDeposit.hasDatastreamAccessCopy;
         default:
             throw new RepositoryException("Cannot add datastream of type " + type.name());
         }

--- a/model-api/src/main/java/edu/unc/lib/boxc/model/api/DatastreamType.java
+++ b/model-api/src/main/java/edu/unc/lib/boxc/model/api/DatastreamType.java
@@ -27,6 +27,7 @@ import static edu.unc.lib.boxc.model.api.ids.RepositoryPathConstants.METADATA_CO
  *
  */
 public enum DatastreamType {
+    ACCESS_COPY("access_copy", "application/octet-stream", ".access", null, EXTERNAL),
     FULLTEXT_EXTRACTION("fulltext", "text/plain", "txt", null, EXTERNAL),
     JP2_ACCESS_COPY("jp2", "image/jp2", "jp2", null, EXTERNAL),
     MD_DESCRIPTIVE("md_descriptive", "text/xml", "xml", METADATA_CONTAINER, INTERNAL),

--- a/model-api/src/main/java/edu/unc/lib/boxc/model/api/rdf/CdrDeposit.java
+++ b/model-api/src/main/java/edu/unc/lib/boxc/model/api/rdf/CdrDeposit.java
@@ -96,6 +96,10 @@ public class CdrDeposit {
     public static final Property hasDatastreamOriginal = createProperty(
             "http://cdr.unc.edu/definitions/deposit#hasDatastreamOriginal" );
 
+    /** Link to access copy binary resource */
+    public static final Property hasDatastreamAccessCopy = createProperty(
+            "http://cdr.unc.edu/definitions/deposit#hasDatastreamAccessCopy" );
+
     /** Link to FITS binary resource */
     public static final Property hasDatastreamFits = createProperty(
             "http://cdr.unc.edu/definitions/deposit#hasDatastreamFits" );

--- a/model-fcrepo/src/main/java/edu/unc/lib/boxc/model/fcrepo/ids/DatastreamPids.java
+++ b/model-fcrepo/src/main/java/edu/unc/lib/boxc/model/fcrepo/ids/DatastreamPids.java
@@ -15,6 +15,7 @@
  */
 package edu.unc.lib.boxc.model.fcrepo.ids;
 
+import static edu.unc.lib.boxc.model.api.DatastreamType.ACCESS_COPY;
 import static edu.unc.lib.boxc.model.api.DatastreamType.MD_DESCRIPTIVE;
 import static edu.unc.lib.boxc.model.api.DatastreamType.MD_EVENTS;
 import static edu.unc.lib.boxc.model.api.DatastreamType.ORIGINAL_FILE;
@@ -61,6 +62,11 @@ public class DatastreamPids {
 
     public static PID getDepositManifestPid(PID pid, String name) {
         String path = URIUtil.join(pid.getRepositoryPath(), DEPOSIT_MANIFEST_CONTAINER, name.toLowerCase());
+        return PIDs.get(path);
+    }
+
+    public static PID getAccessCopyPid(PID pid) {
+        String path = URIUtil.join(pid.getRepositoryPath(), DATA_FILE_FILESET, ACCESS_COPY.getId());
         return PIDs.get(path);
     }
 


### PR DESCRIPTION
This is a part of https://jira.lib.unc.edu/browse/BXC-3176 and needs to be merged before https://github.com/UNC-Libraries/cdm-to-boxc-migration-util/pull/6

* Add properties related to access copy datastreams.
* Expose method for getting path to mods file in deposit dir