### PR TITLE
BXC-3225 - Virus max stream and filepath quoting

### DIFF
--- a/deposit/src/main/webapp/WEB-INF/deposit-jobs-context.xml
+++ b/deposit/src/main/webapp/WEB-INF/deposit-jobs-context.xml
@@ -197,6 +197,7 @@
         <constructor-arg type="java.lang.String" value="${clamd.host:localhost}" index="0" />
         <constructor-arg type="int" value="${clamd.port:3310}" index="1" />
         <constructor-arg type="int" value="${clamd.timeout:60000}" index="2" />
+        <property name="maxStreamSize" value="${clamd.maxStreamSize:64000000}" />
     </bean>
     
     <bean id="fileValidationExecutor" class="java.util.concurrent.Executors"


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3225

* Sets max stream size property for use during virus scanning when using INSTREAM
* Add quoting/escaping for file path to FITS command to allow for scanning of files containing spaces + unicode