### PR TITLE
BXC-3745 - Keyword searches breaking date created year retrieval

### DIFF
--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/MultiSelectFacetListService.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/MultiSelectFacetListService.java
@@ -151,6 +151,7 @@ public class MultiSelectFacetListService extends AbstractFacetListService {
         selectedState.setResultFields(Collections.singletonList(SearchFieldKey.DATE_CREATED_YEAR.name()));
         selectedState.setSortNormalOrder(false);
         selectedState.setSortType("dateCreated");
+        selectedState.setRollup(false);
 
         SearchRequest selectedRequest = new SearchRequest(
                 selectedState, originalRequest.getAccessGroups(), false);

--- a/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/MultiSelectFacetListServiceIT.java
+++ b/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/MultiSelectFacetListServiceIT.java
@@ -698,6 +698,15 @@ public class MultiSelectFacetListServiceIT extends BaseEmbeddedSolrTest {
         assertNull(result);
     }
 
+    @Test
+    public void getMinimumDateCreatedYearWithRollupEnabledTest() throws Exception {
+        SearchState searchState = new SearchState();
+        searchState.setRollup(true);
+        SearchRequest request = new SearchRequest(searchState, accessGroups);
+        String result = service.getMinimumDateCreatedYear(searchState, request);
+        assertEquals("2017", result);
+    }
+
     private SearchFacet getFacetByValue(FacetFieldObject ffo, String value) {
         return ffo.getValues().stream().filter(f -> f.getSearchValue().equals(value)).findFirst().orElse(null);
     }

--- a/web-access-app/src/main/java/edu/unc/lib/boxc/web/access/controllers/SearchActionController.java
+++ b/web-access-app/src/main/java/edu/unc/lib/boxc/web/access/controllers/SearchActionController.java
@@ -182,20 +182,19 @@ public class SearchActionController extends AbstractErrorHandlingSearchControlle
     private void retrieveFacets(SearchRequest searchRequest, SearchResultResponse resultResponse) {
         SearchState searchState = searchRequest.getSearchState();
         AccessGroupSet principals = searchRequest.getAccessGroups();
-        SearchRequest facetRequest = new SearchRequest(searchState, principals, true);
+        SearchState facetState = (SearchState) searchState.clone();
+        SearchRequest facetRequest = new SearchRequest(facetState, principals, true);
         facetRequest.setApplyCutoffs(false);
         if (resultResponse.getSelectedContainer() != null) {
-            SearchState facetState = (SearchState) searchState.clone();
             facetState.addFacet(resultResponse.getSelectedContainer().getPath());
-            facetRequest.setSearchState(facetState);
         }
 
         SearchResultResponse resultResponseFacets = multiSelectFacetListService.getFacetListResult(facetRequest);
         resultResponse.setFacetFields(resultResponseFacets.getFacetFields());
 
         // Get minimum year for date created "facet" search
-        if (facetRequest.getSearchState().getFacetsToRetrieve().contains(SearchFieldKey.DATE_CREATED_YEAR.name())) {
-            String minSearchYear = multiSelectFacetListService.getMinimumDateCreatedYear(searchState, searchRequest);
+        if (facetState.getFacetsToRetrieve().contains(SearchFieldKey.DATE_CREATED_YEAR.name())) {
+            String minSearchYear = multiSelectFacetListService.getMinimumDateCreatedYear(facetState, searchRequest);
             resultResponse.setMinimumDateCreatedYear(minSearchYear);
         }
     }


### PR DESCRIPTION
https://jira.lib.unc.edu/browse/BXC-3745

* Fix bug with MultiSelectFacetListService that is causing keyword searches to fail due to grouping being enabled, which changes the structure of the response