### PR TITLE
BXC-4937 upgrade slf4j and logback

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,8 +94,8 @@
 
         <activemq.version>6.1.7</activemq.version>
 
-        <slf4j.version>1.7.36</slf4j.version>
-        <logback.version>1.2.13</logback.version>
+        <slf4j.version>2.0.17</slf4j.version>
+        <logback.version>1.5.18</logback.version>
 
         <iiif-apis.version>0.3.11</iiif-apis.version>
 
@@ -825,6 +825,12 @@
                 <artifactId>solr-core</artifactId>
                 <version>${solr.version}</version>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.logging.log4j</groupId>
+                        <artifactId>log4j-slf4j2-impl</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.solr</groupId>

--- a/services-camel-app/pom.xml
+++ b/services-camel-app/pom.xml
@@ -36,6 +36,16 @@
         <groupId>org.apache.camel.springboot</groupId>
         <artifactId>camel-spring-boot-xml-starter</artifactId>
         <version>${camel.version}</version>
+        <exclusions>
+            <exclusion>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-to-slf4j</artifactId>
+            </exclusion>
+            <exclusion>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jul-to-slf4j</artifactId>
+            </exclusion>
+        </exclusions>
     </dependency>
     <dependency>
         <groupId>org.apache.camel</groupId>
@@ -83,7 +93,7 @@
     <dependency>
         <groupId>jakarta.jms</groupId>
         <artifactId>jakarta.jms-api</artifactId>
-        <version>3.1.0</version>
+        <version>${jakarta.jms-api.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-4937](https://unclibrary.atlassian.net/browse/BXC-4937)

- upgrade slf4j to 2.0.17
- upgrade logback to 1.5.18
- add exclusions for `org.apache.logging.log4j:log4j-slf4j2-impl` and `org.slf4j:jul-to-slf4j` to remove "Multiple bindings were found on the class path" warnings