### PR TITLE
BXC-5649 - Allow cleanup jobs to execute

### DIFF
--- a/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/http/DepositJobResubmitController.java
+++ b/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/http/DepositJobResubmitController.java
@@ -1,0 +1,140 @@
+package edu.unc.lib.boxc.deposit.http;
+
+import edu.unc.lib.boxc.deposit.impl.jms.DepositJobMessage;
+import edu.unc.lib.boxc.deposit.impl.jms.DepositJobMessageService;
+import edu.unc.lib.boxc.deposit.jms.DepositJobMessageFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Controller for resubmitting deposit jobs to the JMS queue.
+ * Intended for recovery scenarios where jobs were skipped due to bugs.
+ *
+ * @author bbpennel
+ */
+@Controller
+public class DepositJobResubmitController {
+    private static final Logger log = LoggerFactory.getLogger(DepositJobResubmitController.class);
+
+    @Autowired
+    private DepositJobMessageService depositJobMessageService;
+
+    /**
+     * Resubmit deposit jobs for a list of deposit IDs using the specified job class name.
+     * The job class name must be one of the valid deposit job classes.
+     *
+     * @param request object containing the list of deposit IDs and the job class name to submit
+     * @return response indicating how many messages were submitted, or an error if the job class is invalid
+     */
+    @RequestMapping(value = "/admin/resubmitDepositJobs", method = RequestMethod.POST)
+    public @ResponseBody ResponseEntity<ResubmitResponse> resubmitDepositJobs(
+            @RequestBody ResubmitRequest request) {
+        String jobClassName = request.getJobClassName();
+        List<String> depositIds = request.getDepositIds();
+
+        if (jobClassName == null || jobClassName.isBlank()) {
+            return ResponseEntity.badRequest()
+                    .body(new ResubmitResponse("jobClassName must be provided", 0));
+        }
+        if (!DepositJobMessageFactory.VALID_DEPOSIT_JOBS.contains(jobClassName)) {
+            return ResponseEntity.badRequest()
+                    .body(new ResubmitResponse("Invalid job class name: " + jobClassName, 0));
+        }
+        if (depositIds == null || depositIds.isEmpty()) {
+            return ResponseEntity.badRequest()
+                    .body(new ResubmitResponse("depositIds must be provided and non-empty", 0));
+        }
+
+        int submitted = 0;
+        for (String depositId : depositIds) {
+            if (depositId == null || depositId.isBlank()) {
+                log.warn("Skipping blank deposit ID in resubmit request");
+                continue;
+            }
+            var message = new DepositJobMessage();
+            message.setDepositId(depositId);
+            message.setJobClassName(jobClassName);
+            message.setUsername("admin");
+            message.setJobId(UUID.randomUUID().toString());
+            log.info("Resubmitting job {} for deposit {}", jobClassName, depositId);
+            depositJobMessageService.sendDepositJobMessage(message);
+            submitted++;
+        }
+
+        return new ResponseEntity<>(
+                new ResubmitResponse("Submitted " + submitted + " job message(s)", submitted),
+                HttpStatus.OK);
+    }
+
+    public void setDepositJobMessageService(DepositJobMessageService depositJobMessageService) {
+        this.depositJobMessageService = depositJobMessageService;
+    }
+
+    /**
+     * Request body for resubmitting deposit jobs
+     */
+    public static class ResubmitRequest {
+        private String jobClassName;
+        private List<String> depositIds;
+
+        public String getJobClassName() {
+            return jobClassName;
+        }
+
+        public void setJobClassName(String jobClassName) {
+            this.jobClassName = jobClassName;
+        }
+
+        public List<String> getDepositIds() {
+            return depositIds;
+        }
+
+        public void setDepositIds(List<String> depositIds) {
+            this.depositIds = depositIds;
+        }
+    }
+
+    /**
+     * Response body for the resubmit endpoint
+     */
+    public static class ResubmitResponse {
+        private String message;
+        private int submitted;
+
+        public ResubmitResponse() {
+        }
+
+        public ResubmitResponse(String message, int submitted) {
+            this.message = message;
+            this.submitted = submitted;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        public void setMessage(String message) {
+            this.message = message;
+        }
+
+        public int getSubmitted() {
+            return submitted;
+        }
+
+        public void setSubmitted(int submitted) {
+            this.submitted = submitted;
+        }
+    }
+}
+

--- a/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/jms/DepositJobMessageFactory.java
+++ b/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/jms/DepositJobMessageFactory.java
@@ -45,7 +45,7 @@ import java.util.stream.Stream;
  */
 public class DepositJobMessageFactory {
     private static final Logger LOG = LoggerFactory.getLogger(DepositJobMessageFactory.class);
-    private static final Set<String> VALID_DEPOSIT_JOBS = Stream.of(
+    public static final Set<String> VALID_DEPOSIT_JOBS = Stream.of(
             PackageIntegrityCheckJob.class,
             UnpackDepositJob.class,
             PreconstructedDepositJob.class,

--- a/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/pipeline/JobCoordinator.java
+++ b/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/pipeline/JobCoordinator.java
@@ -1,5 +1,6 @@
 package edu.unc.lib.boxc.deposit.pipeline;
 
+import edu.unc.lib.boxc.deposit.CleanupDepositJob;
 import edu.unc.lib.boxc.deposit.api.DepositOperation;
 import edu.unc.lib.boxc.deposit.api.RedisWorkerConstants.DepositPipelineState;
 import edu.unc.lib.boxc.deposit.impl.jms.DepositJobMessage;
@@ -49,7 +50,7 @@ public class JobCoordinator implements MessageListener, ApplicationContextAware 
         var jobMessage = loadJobMessage(message);
         String depositId = jobMessage.getDepositId();
         String jobId = jobMessage.getJobId();
-        if (!activeDeposits.isDepositActive(depositId)) {
+        if (!activeDeposits.isDepositActive(depositId) && !runnableWhenInactive(jobMessage)) {
             LOG.warn("Skipping job message {} for deposit {} because the deposit is not active", jobId, depositId);
             acknowledgeMessage(message);
             return;
@@ -89,6 +90,10 @@ public class JobCoordinator implements MessageListener, ApplicationContextAware 
     private boolean isAcceptingMessages() {
         var pipelineState = depositPipelineStatusFactory.getPipelineState();
         return DepositPipelineState.active.equals(pipelineState) || DepositPipelineState.starting.equals(pipelineState);
+    }
+
+    private boolean runnableWhenInactive(DepositJobMessage jobMessage) {
+        return CleanupDepositJob.class.getName().equals(jobMessage.getJobClassName());
     }
 
     private void acknowledgeMessage(Message message) {

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/http/DepositJobResubmitControllerTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/http/DepositJobResubmitControllerTest.java
@@ -1,0 +1,156 @@
+package edu.unc.lib.boxc.deposit.http;
+
+import edu.unc.lib.boxc.deposit.CleanupDepositJob;
+import edu.unc.lib.boxc.deposit.impl.jms.DepositJobMessage;
+import edu.unc.lib.boxc.deposit.impl.jms.DepositJobMessageService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * @author bbpennel
+ */
+public class DepositJobResubmitControllerTest {
+    private static final String CLEANUP_JOB = CleanupDepositJob.class.getName();
+    private static final String DEPOSIT_ID_1 = "a1b2c3d4-0000-0000-0000-000000000001";
+    private static final String DEPOSIT_ID_2 = "a1b2c3d4-0000-0000-0000-000000000002";
+
+    @InjectMocks
+    private DepositJobResubmitController controller;
+    @Mock
+    private DepositJobMessageService depositJobMessageService;
+    private MockMvc mvc;
+    private AutoCloseable closeable;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeEach
+    public void init() {
+        closeable = MockitoAnnotations.openMocks(this);
+        mvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        closeable.close();
+    }
+
+    @Test
+    public void resubmitSingleDepositTest() throws Exception {
+        MvcResult result = mvc.perform(post("/admin/resubmitDepositJobs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"jobClassName\":\"" + CLEANUP_JOB + "\",\"depositIds\":[\"" + DEPOSIT_ID_1 + "\"]}"))
+                .andExpect(status().isOk())
+                .andReturn();
+        var response = parseResponse(result);
+        assertEquals(1, response.getSubmitted());
+
+        var captor = ArgumentCaptor.forClass(DepositJobMessage.class);
+        verify(depositJobMessageService).sendDepositJobMessage(captor.capture());
+        var msg = captor.getValue();
+        assertEquals(DEPOSIT_ID_1, msg.getDepositId());
+        assertEquals(CLEANUP_JOB, msg.getJobClassName());
+    }
+
+    @Test
+    public void resubmitMultipleDepositsTest() throws Exception {
+        MvcResult result = mvc.perform(post("/admin/resubmitDepositJobs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"jobClassName\":\"" + CLEANUP_JOB + "\","
+                                + "\"depositIds\":[\"" + DEPOSIT_ID_1 + "\",\"" + DEPOSIT_ID_2 + "\"]}"))
+                .andExpect(status().isOk())
+                .andReturn();
+        assertEquals(2, parseResponse(result).getSubmitted());
+
+        var captor = ArgumentCaptor.forClass(DepositJobMessage.class);
+        verify(depositJobMessageService, times(2)).sendDepositJobMessage(captor.capture());
+        var msgs = captor.getAllValues();
+        assertEquals(List.of(DEPOSIT_ID_1, DEPOSIT_ID_2),
+                msgs.stream().map(DepositJobMessage::getDepositId).toList());
+        msgs.forEach(m -> assertEquals(CLEANUP_JOB, m.getJobClassName()));
+    }
+
+    @Test
+    public void resubmitInvalidJobClassTest() throws Exception {
+        MvcResult result = mvc.perform(post("/admin/resubmitDepositJobs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"jobClassName\":\"com.example.FakeJob\",\"depositIds\":[\"" + DEPOSIT_ID_1 + "\"]}"))
+                .andExpect(status().isBadRequest())
+                .andReturn();
+        assertEquals(0, parseResponse(result).getSubmitted());
+
+        verifyNoInteractions(depositJobMessageService);
+    }
+
+    @Test
+    public void resubmitMissingJobClassTest() throws Exception {
+        MvcResult result = mvc.perform(post("/admin/resubmitDepositJobs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"depositIds\":[\"" + DEPOSIT_ID_1 + "\"]}"))
+                .andExpect(status().isBadRequest())
+                .andReturn();
+        assertEquals(0, parseResponse(result).getSubmitted());
+
+        verifyNoInteractions(depositJobMessageService);
+    }
+
+    @Test
+    public void resubmitEmptyDepositIdsTest() throws Exception {
+        MvcResult result = mvc.perform(post("/admin/resubmitDepositJobs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"jobClassName\":\"" + CLEANUP_JOB + "\",\"depositIds\":[]}"))
+                .andExpect(status().isBadRequest())
+                .andReturn();
+        assertEquals(0, parseResponse(result).getSubmitted());
+
+        verifyNoInteractions(depositJobMessageService);
+    }
+
+    @Test
+    public void resubmitMissingDepositIdsTest() throws Exception {
+        MvcResult result = mvc.perform(post("/admin/resubmitDepositJobs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"jobClassName\":\"" + CLEANUP_JOB + "\"}"))
+                .andExpect(status().isBadRequest())
+                .andReturn();
+        assertEquals(0, parseResponse(result).getSubmitted());
+
+        verifyNoInteractions(depositJobMessageService);
+    }
+
+    @Test
+    public void resubmitSkipsBlankDepositIdTest() throws Exception {
+        MvcResult result = mvc.perform(post("/admin/resubmitDepositJobs")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"jobClassName\":\"" + CLEANUP_JOB + "\","
+                                + "\"depositIds\":[\"" + DEPOSIT_ID_1 + "\",\"\",\"" + DEPOSIT_ID_2 + "\"]}"))
+                .andExpect(status().isOk())
+                .andReturn();
+        assertEquals(2, parseResponse(result).getSubmitted());
+
+        verify(depositJobMessageService, times(2)).sendDepositJobMessage(
+                org.mockito.ArgumentMatchers.any(DepositJobMessage.class));
+    }
+
+    private DepositJobResubmitController.ResubmitResponse parseResponse(MvcResult result) throws Exception {
+        return mapper.readValue(result.getResponse().getContentAsString(),
+                DepositJobResubmitController.ResubmitResponse.class);
+    }
+}

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/pipeline/JobCoordinatorTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/pipeline/JobCoordinatorTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import edu.unc.lib.boxc.deposit.CleanupDepositJob;
 import edu.unc.lib.boxc.deposit.api.DepositOperation;
 import edu.unc.lib.boxc.deposit.api.RedisWorkerConstants.DepositPipelineState;
 import edu.unc.lib.boxc.deposit.impl.jms.DepositJobMessage;
@@ -245,6 +246,33 @@ public class JobCoordinatorTest {
         verify(jobRunnable, never()).run();
         verify(jobStatusFactory, never()).started(anyString(), anyString(), any());
         verify(jobStatusFactory, never()).completed(jobMessage.getJobId());
+    }
+
+    @Test
+    public void testDepositNotActiveForCleanupJob() throws Exception {
+        // Given an inactive deposit
+        when(activeDeposits.isDepositActive(DEPOSIT_ID)).thenReturn(false);
+        jobMessage.setJobClassName(CleanupDepositJob.class.getName());
+
+        // When a message is received
+        coordinator.onMessage(message);
+
+        // Then message should be acknowledged
+        verify(message).acknowledge();
+
+        // And job should be executed
+        verify(jobRunnable).run();
+
+        // And success message should be sent
+        ArgumentCaptor<DepositOperationMessage> messageCaptor = ArgumentCaptor.forClass(DepositOperationMessage.class);
+        verify(depositOperationMessageService).sendDepositOperationMessage(messageCaptor.capture());
+        DepositOperationMessage successMessage = messageCaptor.getValue();
+        assertEquals(DepositOperation.JOB_SUCCESS, successMessage.getAction());
+        assertEquals(JOB_ID, successMessage.getJobId());
+        assertEquals(DEPOSIT_ID, successMessage.getDepositId());
+        verify(jobStatusFactory).started(jobMessage.getJobId(), jobMessage.getDepositId(), jobRunnable.getClass());
+        verify(jobStatusFactory).completed(jobMessage.getJobId());
+        assertFalse(coordinator.hasActiveJobs());
     }
 
     @Test


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/BXC-5649

* Allow cleanup jobs to be executed after the deposit has become inactive due to having completed
* Adds API endpoint for submitting deposit jobs to support retriggering missed cleanup jobs