### PR TITLE
BXC-5624 - Fix concurrent deposit job processing

### DIFF
--- a/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/pipeline/JobCoordinator.java
+++ b/deposit-app/src/main/java/edu/unc/lib/boxc/deposit/pipeline/JobCoordinator.java
@@ -37,22 +37,23 @@ public class JobCoordinator implements MessageListener, ApplicationContextAware 
     private ApplicationContext applicationContext;
     private ActiveDepositsService activeDeposits;
     private JobStatusFactory jobStatusFactory;
-    private AtomicInteger activeJobCount = new AtomicInteger(0);
+    private final AtomicInteger activeJobCount = new AtomicInteger(0);
 
     @Override
     public void onMessage(Message message) {
-        // Check if queues are active, if not then do not acknowledge the message and stop processing
         if (!isAcceptingMessages()) {
             LOG.warn("Ignoring message due to pipeline state");
             return;
         }
 
         var jobMessage = loadJobMessage(message);
+        if (jobMessage == null) {
+            return;
+        }
         String depositId = jobMessage.getDepositId();
         String jobId = jobMessage.getJobId();
         if (!activeDeposits.isDepositActive(depositId) && !runnableWhenInactive(jobMessage)) {
             LOG.warn("Skipping job message {} for deposit {} because the deposit is not active", jobId, depositId);
-            acknowledgeMessage(message);
             return;
         }
 
@@ -78,7 +79,6 @@ public class JobCoordinator implements MessageListener, ApplicationContextAware 
             jobStatusFactory.failed(jobId);
             sendDepositOperationMessage(buildFailureMessage(jobMessage, e));
         } finally {
-            acknowledgeMessage(message);
             activeJobCount.decrementAndGet();
         }
     }
@@ -94,15 +94,6 @@ public class JobCoordinator implements MessageListener, ApplicationContextAware 
 
     private boolean runnableWhenInactive(DepositJobMessage jobMessage) {
         return CleanupDepositJob.class.getName().equals(jobMessage.getJobClassName());
-    }
-
-    private void acknowledgeMessage(Message message) {
-        try {
-            message.acknowledge();
-            LOG.debug("Acknowledged message {}", message.getJMSMessageID());
-        } catch (JMSException e) {
-            LOG.error("Error acknowledging message", e);
-        }
     }
 
     private DepositOperationMessage buildSuccessMessage(DepositJobMessage jobMessage) {
@@ -146,8 +137,8 @@ public class JobCoordinator implements MessageListener, ApplicationContextAware 
         try {
             return depositJobMessageService.fromJson(message);
         } catch (IOException | JMSException e) {
-            acknowledgeMessage(message);
-            throw new RuntimeException("Unable to load deposit job message", e);
+            LOG.error("Unable to read deposit job message from JMS", e);
+            return null;
         }
     }
 

--- a/deposit-app/src/main/webapp/WEB-INF/deposit-jobs-context.xml
+++ b/deposit-app/src/main/webapp/WEB-INF/deposit-jobs-context.xml
@@ -36,6 +36,11 @@
                 <property name="closeTimeout" value="15000" />
                 <property name="sendTimeout" value="10000" />
                 <property name="useAsyncSend" value="true" />
+                <property name="prefetchPolicy">
+                    <bean class="org.apache.activemq.ActiveMQPrefetchPolicy">
+                        <property name="queuePrefetch" value="0" />
+                    </bean>
+                </property>
             </bean>
         </property>
         <property name="maxConnections" value="10" />

--- a/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/pipeline/JobCoordinatorTest.java
+++ b/deposit-app/src/test/java/edu/unc/lib/boxc/deposit/pipeline/JobCoordinatorTest.java
@@ -2,7 +2,6 @@ package edu.unc.lib.boxc.deposit.pipeline;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -14,7 +13,6 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import edu.unc.lib.boxc.deposit.CleanupDepositJob;
 import edu.unc.lib.boxc.deposit.api.DepositOperation;
 import edu.unc.lib.boxc.deposit.api.RedisWorkerConstants.DepositPipelineState;
@@ -95,9 +93,6 @@ public class JobCoordinatorTest {
         // When the job runs successfully
         coordinator.onMessage(message);
 
-        // Then message should be acknowledged
-        verify(message).acknowledge();
-
         // And job should be executed
         verify(jobRunnable).run();
 
@@ -121,9 +116,6 @@ public class JobCoordinatorTest {
 
         // When the job is executed
         coordinator.onMessage(message);
-
-        // Then message should still be acknowledged
-        verify(message).acknowledge();
 
         // And failure message should be sent
         ArgumentCaptor<DepositOperationMessage> messageCaptor = ArgumentCaptor.forClass(DepositOperationMessage.class);
@@ -151,9 +143,6 @@ public class JobCoordinatorTest {
         // When the job is executed
         coordinator.onMessage(message);
 
-        // Then message should still be acknowledged
-        verify(message).acknowledge();
-
         // And failure message should be sent
         ArgumentCaptor<DepositOperationMessage> messageCaptor = ArgumentCaptor.forClass(DepositOperationMessage.class);
         verify(depositOperationMessageService).sendDepositOperationMessage(messageCaptor.capture());
@@ -180,9 +169,6 @@ public class JobCoordinatorTest {
         // When the job is executed
         coordinator.onMessage(message);
 
-        // Then message should still be acknowledged
-        verify(message).acknowledge();
-
         // And interrupt message should be sent
         ArgumentCaptor<DepositOperationMessage> messageCaptor = ArgumentCaptor.forClass(DepositOperationMessage.class);
         verify(depositOperationMessageService).sendDepositOperationMessage(messageCaptor.capture());
@@ -207,9 +193,6 @@ public class JobCoordinatorTest {
 
         coordinator.onMessage(message);
 
-        // Then message should be acknowledged
-        verify(message).acknowledge();
-
         // And job should be executed
         verify(jobRunnable).run();
 
@@ -227,7 +210,6 @@ public class JobCoordinatorTest {
 
         // Then no processing should occur
         verify(depositJobMessageService, never()).fromJson(any());
-        verify(message, never()).acknowledge();
         verify(jobRunnable, never()).run();
         verify(jobStatusFactory, never()).started(anyString(), anyString(), any());
         verify(jobStatusFactory, never()).completed(jobMessage.getJobId());
@@ -241,8 +223,6 @@ public class JobCoordinatorTest {
         // When a message is received
         coordinator.onMessage(message);
 
-        // Then message should be acknowledged but job shouldn't run
-        verify(message).acknowledge();
         verify(jobRunnable, never()).run();
         verify(jobStatusFactory, never()).started(anyString(), anyString(), any());
         verify(jobStatusFactory, never()).completed(jobMessage.getJobId());
@@ -256,9 +236,6 @@ public class JobCoordinatorTest {
 
         // When a message is received
         coordinator.onMessage(message);
-
-        // Then message should be acknowledged
-        verify(message).acknowledge();
 
         // And job should be executed
         verify(jobRunnable).run();
@@ -281,9 +258,8 @@ public class JobCoordinatorTest {
         when(depositJobMessageService.fromJson(message)).thenThrow(new IOException("Parse error"));
 
         // When a message is received
-        assertThrows(RuntimeException.class, () -> coordinator.onMessage(message));
+        coordinator.onMessage(message);
 
-        verify(message).acknowledge();
         // Then no job should run
         verify(jobRunnable, never()).run();
     }

--- a/deposit-utils/src/main/java/edu/unc/lib/boxc/deposit/impl/model/DepositModelManager.java
+++ b/deposit-utils/src/main/java/edu/unc/lib/boxc/deposit/impl/model/DepositModelManager.java
@@ -2,39 +2,21 @@ package edu.unc.lib.boxc.deposit.impl.model;
 
 import static org.apache.jena.rdf.model.ModelFactory.createDefaultModel;
 
-import java.io.ByteArrayOutputStream;
-import java.io.Closeable;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.Writer;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.Objects;
-
-import org.apache.commons.csv.CSVFormat;
-import org.apache.commons.csv.CSVPrinter;
+import edu.unc.lib.boxc.model.api.exceptions.RepositoryException;
+import edu.unc.lib.boxc.model.api.ids.PID;
 import org.apache.jena.query.Dataset;
-import org.apache.jena.query.Query;
-import org.apache.jena.query.QueryExecution;
-import org.apache.jena.query.QueryExecutionFactory;
-import org.apache.jena.query.QueryFactory;
-import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.ReadWrite;
-import org.apache.jena.query.ResultSet;
-import org.apache.jena.rdf.model.Bag;
 import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.tdb1.transaction.TDBTransactionException;
 import org.apache.jena.tdb2.TDB2Factory;
-import org.apache.jena.update.UpdateAction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import edu.unc.lib.boxc.deposit.api.exceptions.InterruptedRuntimeException;
-import edu.unc.lib.boxc.model.api.exceptions.RepositoryException;
-import edu.unc.lib.boxc.model.api.ids.PID;
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
 
 /**
  * Manager which provides access to a common deposit dataset used for
@@ -111,21 +93,13 @@ public class DepositModelManager implements Closeable {
         String depositUri = depositPid.getRepositoryPath();
 
         long start = System.currentTimeMillis();
-        try {
-            dataset.begin(ReadWrite.WRITE);
-            if (!dataset.containsNamedModel(depositUri)) {
-                dataset.addNamedModel(depositUri, createDefaultModel());
-            }
-            Model model = dataset.getNamedModel(depositUri);
-            log.debug("Created write model for {} in {}ms", depositUri, (System.currentTimeMillis() - start));
-            return model;
-        } catch (TDBTransactionException e) {
-            if (e.getCause() instanceof InterruptedException) {
-                throw new InterruptedRuntimeException("Interrupted while waiting for TDB write lock for deposit "
-                        + depositUri, e);
-            }
-            throw e;
+        dataset.begin(ReadWrite.WRITE);
+        if (!dataset.containsNamedModel(depositUri)) {
+            dataset.addNamedModel(depositUri, createDefaultModel());
         }
+        Model model = dataset.getNamedModel(depositUri);
+        log.debug("Created write model for {} in {}ms", depositUri, (System.currentTimeMillis() - start));
+        return model;
     }
 
     /**
@@ -138,18 +112,10 @@ public class DepositModelManager implements Closeable {
         long start = System.currentTimeMillis();
         String depositUri = depositPid.getRepositoryPath();
 
-        try {
-            dataset.begin(ReadWrite.READ);
-            Model model = dataset.getNamedModel(depositUri);
-            log.debug("Created read model for {} in {}ms", depositUri, (System.currentTimeMillis() - start));
-            return model;
-        } catch (TDBTransactionException e) {
-            if (e.getCause() instanceof InterruptedException) {
-                throw new InterruptedRuntimeException("Interrupted while waiting for TDB read lock for deposit "
-                        + depositUri, e);
-            }
-            throw e;
-        }
+        dataset.begin(ReadWrite.READ);
+        Model model = dataset.getNamedModel(depositUri);
+        log.debug("Created read model for {} in {}ms", depositUri, (System.currentTimeMillis() - start));
+        return model;
     }
 
     /**
@@ -170,96 +136,7 @@ public class DepositModelManager implements Closeable {
         log.info("Removing deposit model for {}", uri);
         dataset.removeNamedModel(uri);
         dataset.commit();
-    }
-
-    /**
-     * Add triples from the provided model to the deposit model
-     *
-     * @param depositPid pid of the deposit
-     * @param model
-     */
-    public synchronized void addTriples(PID depositPid, Model model) {
-        addTriples(depositPid, model, null, null);
-    }
-
-    /**
-     * Add triples from the provided model to the deposit model, inserting the
-     * new resource as the child of the provided parent
-     *
-     * @param depositPid pid of the deposit
-     * @param model
-     * @param newPid
-     * @param parentPid
-     */
-    public synchronized void addTriples(PID depositPid, Model model, PID newPid, PID parentPid) {
-        Model depositModel = getWriteModel(depositPid);
-        try {
-            // Insert reference from parent to new resource
-            if (newPid != null && parentPid != null) {
-                Resource newResc = model.getResource(newPid.getRepositoryPath());
-                Bag parentBag = depositModel.getBag(parentPid.getRepositoryPath());
-
-                parentBag.add(newResc);
-            }
-
-            log.debug("Adding triples to deposit model: {}", model);
-            depositModel.add(model);
-            dataset.commit();
-        } finally {
-            dataset.end();
-        }
-    }
-
-    /**
-     * Perform a sparql update against the deposit model
-     *
-     * @param depositPid pid of the deposit
-     * @param query sparql update query
-     */
-    public synchronized void performUpdate(PID depositPid, String query) {
-        Model depositModel = getWriteModel(depositPid);
-        try {
-            UpdateAction.parseExecute(query, depositModel);
-            dataset.commit();
-        } finally {
-            dataset.end();
-        }
-    }
-
-    /**
-     * Perform a sparql query against the deposit model
-     *
-     * @param depositPid pid of the deposit
-     * @param queryString sparql query
-     * @return results of the query, serialized as csv in an output stream
-     * @throws IOException
-     */
-    public synchronized String performQuery(PID depositPid, String queryString) throws IOException {
-        Model depositModel = getReadModel(depositPid);
-
-        Query query = QueryFactory.create(queryString);
-
-        ByteArrayOutputStream outStream = new ByteArrayOutputStream();
-
-        try (
-                QueryExecution qexec = QueryExecutionFactory.create(query, depositModel);
-                Writer writer = new PrintWriter(outStream);
-                CSVPrinter printer = new CSVPrinter(writer, CSVFormat.DEFAULT);
-                ) {
-            ResultSet results = qexec.execSelect();
-            List<String> varNames = results.getResultVars();
-
-            while (results.hasNext()) {
-                QuerySolution soln = results.nextSolution();
-
-                for (String varName : varNames) {
-                    printer.print(soln.get(varName));
-                }
-                printer.println();
-            }
-        }
-
-        return outStream.toString("UTF-8");
+        dataset.end();
     }
 
     /**
@@ -323,9 +200,5 @@ public class DepositModelManager implements Closeable {
         if (dataset.isInTransaction()) {
             dataset.end();
         }
-    }
-
-    public void setDepositsPath(Path depositsPath) {
-        this.tdbBasePath = depositsPath;
     }
 }

--- a/deposit-utils/src/test/java/edu/unc/lib/boxc/deposit/impl/model/DepositModelManagerTest.java
+++ b/deposit-utils/src/test/java/edu/unc/lib/boxc/deposit/impl/model/DepositModelManagerTest.java
@@ -1,0 +1,224 @@
+package edu.unc.lib.boxc.deposit.impl.model;
+
+import edu.unc.lib.boxc.model.api.ids.PID;
+import edu.unc.lib.boxc.model.fcrepo.ids.PIDs;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * @author bbpennel
+ */
+public class DepositModelManagerTest {
+    private static final String DEPOSIT_ID = "0f71ea28-b44e-41f4-a7d6-6666da8ad140";
+    private static final String DEPOSIT2_ID = "7ab3c4d5-1234-5678-abcd-ef0123456789";
+    private static final String SUBJECT_URI = "http://example.com/subject/1";
+    private static final String PROPERTY_URI = "http://example.com/prop/label";
+    private static final String VALUE = "test value";
+
+    @TempDir
+    public Path tmpFolder;
+
+    private DepositModelManager manager;
+    private PID depositPid;
+    private PID deposit2Pid;
+
+    @BeforeEach
+    void setUp() {
+        manager = DepositModelManager.inMemoryManager();
+        depositPid = PIDs.get(DEPOSIT_ID);
+        deposit2Pid = PIDs.get(DEPOSIT2_ID);
+    }
+
+    @AfterEach
+    void tearDown() {
+        manager.close();
+    }
+
+    @Test
+    void testGetWriteModel_WrittenDataPersistedAfterCommit() {
+        Model writeModel = manager.getWriteModel(depositPid);
+        assertNotNull(writeModel, "Write model should not be null");
+        addTriple(writeModel);
+        manager.commit();
+
+        Model readModel = manager.getReadModel(depositPid);
+        assertTrue(containsTriple(readModel), "Written triple should be readable after commit");
+        manager.end();
+    }
+
+    @Test
+    void testGetWriteModel_MultipleDepositsIndependent() {
+        Model model1 = manager.getWriteModel(depositPid);
+        addTriple(model1);
+        manager.commit();
+
+        Model readModel2 = manager.getReadModel(deposit2Pid);
+        assertFalse(containsTriple(readModel2), "Second deposit model should not contain data from first deposit");
+        manager.end();
+    }
+
+    @Test
+    void testGetReadModel_EmptyWhenNothingWritten() {
+        Model readModel = manager.getReadModel(depositPid);
+        assertNotNull(readModel, "Read model should not be null");
+        assertTrue(readModel.isEmpty(), "New deposit model should be empty");
+        manager.end();
+    }
+
+    @Test
+    void testCommitNoArgs_WhenNotInTransaction_DoesNotThrow() {
+        assertDoesNotThrow(() -> manager.commit(),
+                "commit() should not throw when not in a transaction");
+    }
+
+    @Test
+    void testCommitRunnable_PersistsChanges() {
+        // Establish the named model, then get a reference while in a READ tx
+        manager.getWriteModel(depositPid);
+        manager.commit();
+
+        // commit(Runnable) ends the read tx, starts write, runs runnable, commits, restarts read
+        Model readModel = manager.getReadModel(depositPid);
+        manager.commit(() -> addTriple(readModel));
+        assertTrue(containsTriple(readModel), "Data should be persisted after commit with runnable");
+        manager.end();
+
+        Model readModel2 = manager.getReadModel(depositPid);
+        assertTrue(containsTriple(readModel2), "Data should still be persisted in fresh model");
+        manager.end();
+    }
+
+    @Test
+    void testCommitRunnableNotInTx_PersistsChanges() {
+        // Establish the named model
+        manager.getWriteModel(depositPid);
+        manager.commit();
+
+        Model readModel = manager.getReadModel(depositPid);
+        manager.end(); // end the read tx so we're not in a transaction before calling commit
+
+        // commit(Runnable, false) does not assume or restore any surrounding transaction
+        manager.commit(() -> addTriple(readModel), false);
+
+        Model verifyModel = manager.getReadModel(depositPid);
+        assertTrue(containsTriple(verifyModel), "Data should be persisted after commit(Runnable, false)");
+        manager.end();
+    }
+
+    @Test
+    void testCommitOrAbortFalse_CommitsChanges() {
+        Model writeModel = manager.getWriteModel(depositPid);
+        addTriple(writeModel);
+        manager.commitOrAbort(false);
+
+        Model readModel = manager.getReadModel(depositPid);
+        assertTrue(containsTriple(readModel), "Data should be persisted when commitOrAbort is called with false");
+        manager.end();
+    }
+
+    @Test
+    void testCommitOrAbortTrue_AbortsChanges() {
+        Model writeModel = manager.getWriteModel(depositPid);
+        addTriple(writeModel);
+        manager.commitOrAbort(true);
+
+        Model readModel = manager.getReadModel(depositPid);
+        assertFalse(containsTriple(readModel), "Data should NOT be persisted when commitOrAbort is called with true");
+        manager.end();
+    }
+
+    @Test
+    void testEnd_WhenNotInTransaction_DoesNotThrow() {
+        assertDoesNotThrow(() -> manager.end(), "end() should not throw when not in a transaction");
+    }
+
+    @Test
+    void testEnd_EndsActiveTransaction() {
+        manager.getReadModel(depositPid);
+        manager.end();
+        // Should be able to start a fresh transaction after ending the previous one
+        assertDoesNotThrow(() -> {
+            manager.getReadModel(depositPid);
+            manager.end();
+        });
+    }
+
+    @Test
+    void testRemoveModel_ModelIsEmpty() {
+        Model writeModel = manager.getWriteModel(depositPid);
+        addTriple(writeModel);
+        manager.commit();
+
+        manager.removeModel(depositPid);
+
+        Model readModel = manager.getReadModel(depositPid);
+        assertFalse(containsTriple(readModel), "Model should be empty after removal");
+        manager.end();
+    }
+
+    @Test
+    void testRemoveModel_OtherModelsUnaffected() {
+        Model model1 = manager.getWriteModel(depositPid);
+        addTriple(model1);
+        manager.commit();
+
+        Model model2 = manager.getWriteModel(deposit2Pid);
+        addTriple(model2);
+        manager.commit();
+
+        manager.removeModel(depositPid);
+
+        Model readModel2 = manager.getReadModel(deposit2Pid);
+        assertTrue(containsTriple(readModel2), "Other deposit model should be unaffected by removal");
+        manager.end();
+    }
+
+    @Test
+    void testLoadDataset_PersistsDataAcrossReload() {
+        try (DepositModelManager diskManager = new DepositModelManager(tmpFolder)) {
+            Model writeModel = diskManager.getWriteModel(depositPid);
+            addTriple(writeModel);
+            diskManager.commit();
+        }
+
+        // Reload from the same path and verify data is still present
+        try (DepositModelManager reloadedManager = new DepositModelManager(tmpFolder)) {
+            reloadedManager.loadDataset();
+            Model readModel = reloadedManager.getReadModel(depositPid);
+            assertTrue(containsTriple(readModel), "Data written before reload should still be present after loadDataset");
+            reloadedManager.end();
+        }
+    }
+
+    @Test
+    void testLoadDataset_CreatesDirectoryIfAbsent() {
+        Path newDir = tmpFolder.resolve("new-dataset-dir");
+        try (DepositModelManager diskManager = new DepositModelManager(newDir)) {
+            assertTrue(newDir.toFile().exists(), "Dataset directory should be created by loadDataset");
+        }
+    }
+
+    private void addTriple(Model model) {
+        Resource subject = model.createResource(SUBJECT_URI);
+        Property property = model.createProperty(PROPERTY_URI);
+        subject.addProperty(property, VALUE);
+    }
+
+    private boolean containsTriple(Model model) {
+        Resource subject = model.createResource(SUBJECT_URI);
+        Property property = model.createProperty(PROPERTY_URI);
+        return model.contains(subject, property, VALUE);
+    }
+}


### PR DESCRIPTION
https://unclibrary.atlassian.net/browse/BXC-5624

* Set prefetch to 0, otherwise the jobCoordinator threads will grab jobs even when they are active and there are other threads sitting idle. This effectively prevented concurrent processing when multiple deposits were active, resulting in the deposits taking turns running jobs since one of the 4 threads was grabbing all the jobs.
* Removed message acknowledgement, this is a no-op for transacted message listeners. When there is a serialization error, do not throw exception as this would actually cause the corrupted message to get requeued
* Cleanup dead and outdated code from DepositModelManager that were leftover from the tdb1 days. Add a test for it