### PR TITLE
Machine generated field fixes

### DIFF
--- a/indexing-solr/src/test/resources/datastream/machineGeneratedDescriptionDefaults.json
+++ b/indexing-solr/src/test/resources/datastream/machineGeneratedDescriptionDefaults.json
@@ -4,7 +4,7 @@
   "result": {
     "alt_text": "Mountain landscape with snow-covered peaks",
     "full_description": "A scenic mountain landscape with snow-capped peaks rising above a forested valley",
-    "overall_risk_Score": 0,
+    "overall_risk_score": 0,
     "review_assessment": {
       "biased_language": "NO",
       "concerns_for_review": [],

--- a/search-api/src/main/java/edu/unc/lib/boxc/search/api/requests/SearchRequest.java
+++ b/search-api/src/main/java/edu/unc/lib/boxc/search/api/requests/SearchRequest.java
@@ -16,6 +16,7 @@ public class SearchRequest implements Serializable {
     protected SearchState searchState;
     private boolean retrieveFacets;
     private boolean applyCutoffs;
+    private boolean allowAnyResourceTypesInFacets = false;
     protected AccessGroupSet accessGroups;
     protected String rootId;
     protected PID rootPid;
@@ -85,4 +86,13 @@ public class SearchRequest implements Serializable {
     public void setRetrieveFacets(boolean retrieveFacets) {
         this.retrieveFacets = retrieveFacets;
     }
+
+    public boolean isAllowAnyResourceTypesInFacets() {
+        return allowAnyResourceTypesInFacets;
+    }
+
+    public void setAllowAnyResourceTypesInFacets(boolean include) {
+        this.allowAnyResourceTypesInFacets = include;
+    }
+
 }

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/AbstractFacetListService.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/AbstractFacetListService.java
@@ -38,10 +38,14 @@ public class AbstractFacetListService extends AbstractQueryService {
      * Set the resource types counted in the facets to exclude File objects
      * @param searchState
      */
-    protected void assignResourceTypes(SearchState searchState) {
+    protected void assignResourceTypes(SearchState searchState, SearchRequest searchRequest) {
         if (searchState.getResourceTypes() == null) {
             searchState.setResourceTypes(DEFAULT_RESOURCE_TYPES);
         } else {
+            // Skip filtering of resource types
+            if (searchRequest.isAllowAnyResourceTypesInFacets()) {
+                return;
+            }
             searchState.setResourceTypes(searchState.getResourceTypes().stream()
                     .filter(t -> !t.equals(ResourceType.File.name()))
                     .collect(Collectors.toList()));

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/FacetValuesService.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/FacetValuesService.java
@@ -33,7 +33,7 @@ public class FacetValuesService extends AbstractFacetListService {
         var facetSolrField = request.getFacetFieldKey().getSolrField();
 
         var searchState = request.getBaseSearchRequest().getSearchState();
-        assignResourceTypes(searchState);
+        assignResourceTypes(searchState, request.getBaseSearchRequest());
         addSelectedContainer(request.getBaseSearchRequest(), searchState);
         request.getBaseSearchRequest().setApplyCutoffs(false);
         // Remove any filters from the same facet being retrieved, so that all values from the facet are visible

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/MachineGeneratedContentService.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/MachineGeneratedContentService.java
@@ -24,7 +24,7 @@ public class MachineGeneratedContentService {
     private static final Logger log = LoggerFactory.getLogger(MachineGeneratedContentService.class);
 
     public static final String MG_DESCRIPTION_FIELD = "full_description";
-    public static final String MG_RISK_SCORE_FIELD = "overall_risk_Score";
+    public static final String MG_RISK_SCORE_FIELD = "overall_risk_score";
     public static final String MG_ALT_TEXT = "alt_text";
     public static final String MG_TRANSCRIPT_FIELD = "transcript";
     public static final String MG_SAFETY_ASSESS_FIELD = "safety_assessment";

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/MultiSelectFacetListService.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/MultiSelectFacetListService.java
@@ -66,7 +66,7 @@ public class MultiSelectFacetListService extends AbstractFacetListService {
 
         searchState.setRowsPerPage(0);
         // Set the resource types counted in the facets to exclude File objects
-        assignResourceTypes(searchState);
+        assignResourceTypes(searchState, searchRequest);
 
         // Perform base search with all filters applied, generating the base result response which will be returned.
         SearchResultResponse resultResponse = searchService.getSearchResults(facetRequest);

--- a/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/SearchResultResponseDecoratorService.java
+++ b/search-solr/src/main/java/edu/unc/lib/boxc/search/solr/services/SearchResultResponseDecoratorService.java
@@ -36,6 +36,7 @@ public class SearchResultResponseDecoratorService {
         SearchState facetState = (SearchState) searchState.clone();
         SearchRequest facetRequest = new SearchRequest(facetState, principals, true);
         facetRequest.setApplyCutoffs(false);
+        facetRequest.setAllowAnyResourceTypesInFacets(searchRequest.isAllowAnyResourceTypesInFacets());
         if (resultResponse.getSelectedContainer() != null) {
             facetState.addFacet(resultResponse.getSelectedContainer().getPath());
         }

--- a/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/MachineGeneratedContentServiceTest.java
+++ b/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/MachineGeneratedContentServiceTest.java
@@ -198,7 +198,7 @@ public class MachineGeneratedContentServiceTest {
 
     @Test
     public void extractRiskScore_missingField_returnsNull() throws Exception {
-        JsonNode node = buildNodeWithoutField(parseDefaultJson(), "overall_risk_Score");
+        JsonNode node = buildNodeWithoutField(parseDefaultJson(), "overall_risk_score");
         assertNull(service.extractRiskScore(node));
     }
 

--- a/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/MultiSelectFacetListServiceIT.java
+++ b/search-solr/src/test/java/edu/unc/lib/boxc/search/solr/services/MultiSelectFacetListServiceIT.java
@@ -642,6 +642,29 @@ public class MultiSelectFacetListServiceIT extends BaseEmbeddedSolrTest {
     }
 
     @Test
+    public void allowAnyResourceTypesInFacetsTest() throws Exception {
+        SearchState searchState = new SearchState();
+        searchState.setFacetsToRetrieve(Arrays.asList(PARENT_COLLECTION.name(), FILE_FORMAT_CATEGORY.name()));
+        // Explicitly include File in resource types
+        searchState.setResourceTypes(Arrays.asList(
+                ResourceType.AdminUnit.name(), ResourceType.Collection.name(),
+                ResourceType.Folder.name(), ResourceType.Work.name(), ResourceType.File.name()));
+
+        SearchRequest request = new SearchRequest(searchState, accessGroups);
+        request.setAllowAnyResourceTypesInFacets(true);
+        SearchResultResponse resp = service.getFacetListResult(request);
+
+        // File objects should now be counted: coll1 has folder1 + work1 + work2 + work1File1 + work1File2 + work2File1 = 6
+        assertFacetDisplayValueCount(resp, PARENT_COLLECTION, "Collection 1", testCorpus.coll1Pid.getId(), 6);
+        // coll2 has work3 + privateFolder + privateWork + work3File1 + privateWorkFile1 = 5
+        assertFacetDisplayValueCount(resp, PARENT_COLLECTION, "Collection 2", testCorpus.coll2Pid.getId(), 5);
+
+        // File format categories now include File objects, which have format properties
+        assertFacetValueCount(resp, FILE_FORMAT_CATEGORY, "Text", 5);
+        assertFacetValueCount(resp, FILE_FORMAT_CATEGORY, "Image", 4);
+    }
+
+    @Test
     public void noFacetsToRetrieveTest() throws Exception {
         SearchState searchState = new SearchState();
         searchState.setFacetsToRetrieve(Collections.emptyList());

--- a/search-solr/src/test/resources/datastream/machineGeneratedDescriptionDefaults.json
+++ b/search-solr/src/test/resources/datastream/machineGeneratedDescriptionDefaults.json
@@ -4,7 +4,7 @@
   "result": {
     "alt_text": "Mountain landscape with snow-covered peaks",
     "full_description": "A scenic mountain landscape with snow-capped peaks rising above a forested valley",
-    "overall_risk_Score": 0,
+    "overall_risk_score": 0,
     "review_assessment": {
       "biased_language": "NO",
       "concerns_for_review": [],
@@ -42,10 +42,12 @@
         ]
       },
       "text_characteristics": {
+        "language": "N/A",
         "legibility": "N/A",
         "text_present": "NO",
         "text_type": "N/A"
       },
+      "image_quality": "UNIMPAIRED",
       "violent_content": "NONE"
     },
     "transcript": "",

--- a/web-admin-app/src/main/java/edu/unc/lib/boxc/web/admin/controllers/processing/ChompbPreIngestService.java
+++ b/web-admin-app/src/main/java/edu/unc/lib/boxc/web/admin/controllers/processing/ChompbPreIngestService.java
@@ -93,7 +93,7 @@ public class ChompbPreIngestService {
             log.debug("Process exit code: {}", exitCode);
 
             if (exitCode != 0) {
-                throw new RepositoryException("Command exited with errors: " + command
+                throw new RepositoryException("Command exited with errors: " + Arrays.toString(command)
                         + "\n" + output + "\n" + exitCode);
             }
 

--- a/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/MachineGeneratedSearchController.java
+++ b/web-services-app/src/main/java/edu/unc/lib/boxc/web/services/rest/MachineGeneratedSearchController.java
@@ -64,6 +64,7 @@ public class MachineGeneratedSearchController extends AbstractSolrSearchControll
         SearchRequest searchRequest = generateSearchRequest(request);
         searchRequest.setRootPid(pid); // Only children of this object will be returned
         searchRequest.setApplyCutoffs(false); // Filters to all children, not just immediate
+        searchRequest.setAllowAnyResourceTypesInFacets(true);
 
         SearchState searchState = searchRequest.getSearchState();
         // filter to FileObjects

--- a/web-services-app/src/test/resources/datastream/machineGeneratedDescriptionDefaults.json
+++ b/web-services-app/src/test/resources/datastream/machineGeneratedDescriptionDefaults.json
@@ -4,7 +4,7 @@
   "result": {
     "alt_text": "Mountain landscape with snow-covered peaks",
     "full_description": "A scenic mountain landscape with snow-capped peaks rising above a forested valley",
-    "overall_risk_Score": 0,
+    "overall_risk_score": 0,
     "review_assessment": {
       "biased_language": "NO",
       "concerns_for_review": [],
@@ -42,10 +42,12 @@
         ]
       },
       "text_characteristics": {
+        "language": "N/A",
         "legibility": "N/A",
         "text_present": "NO",
         "text_type": "N/A"
       },
+      "image_quality": "UNIMPAIRED",
       "violent_content": "NONE"
     },
     "transcript": "",


### PR DESCRIPTION

* Fix the name of the overall_risk_score field to resolve indexing problem
* Allow file objects to be counted in facet lists when programmatically overridden
* Cleanup some incorrect newline characters and a log statement that didn't format correctly