### PR TITLE
Fix camel-services-app context file ref

### DIFF
--- a/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/pdf/PdfEnhancementsRouter.java
+++ b/services-camel-app/src/main/java/edu/unc/lib/boxc/services/camel/pdf/PdfEnhancementsRouter.java
@@ -36,7 +36,7 @@ public class PdfEnhancementsRouter extends RouteBuilder {
         this.aggregatePdfProcessor = aggregatePdfProcessor;
     }
 
-    @PropertyInject("cdr.enhancement.pdf.stream.camel")
+    @PropertyInject("cdr.aggregate.pdf.stream.camel")
     public void setAggregatePdfStreamCamel(String aggregatePdfStreamCamel) {
         this.aggregatePdfStreamCamel = aggregatePdfStreamCamel;
     }

--- a/services-camel-app/src/main/webapp/WEB-INF/service-context.xml
+++ b/services-camel-app/src/main/webapp/WEB-INF/service-context.xml
@@ -291,7 +291,7 @@
     <bean id="aggregatePdfService" class="edu.unc.lib.boxc.operations.impl.pdf.AggregatePdfService">
         <property name="tmpDir" value="${services.tempDirectory}" />
         <property name="repositoryObjectLoader" ref="repositoryObjectLoader" />
-        <property name="solrSearchService" ref="solrSearchService" />
+        <property name="solrSearchService" ref="queryLayer" />
     </bean>
 
     <bean id="aggregatePdfProcessor" class="edu.unc.lib.boxc.services.camel.pdf.AggregatePdfProcessor">

--- a/services-camel-app/src/test/resources/config.properties
+++ b/services-camel-app/src/test/resources/config.properties
@@ -57,6 +57,9 @@ cdr.destroy.derivatives.stream.camel=direct:index.start
 cdr.enhancement.stream=direct:repository.enhancements
 cdr.enhancement.stream.camel=direct:repository.enhancements
 
+cdr.aggregate.pdf.stream=direct:aggregate.pdf
+cdr.aggregate.pdf.stream.camel=direct:aggregate.pdf
+
 cdr.ordermembers.stream=direct:ordermembers
 cdr.ordermembers.stream.camel=direct:ordermembers
 
@@ -80,9 +83,6 @@ cdr.enhancement.video.stream.camel=direct:process.enhancement.video
 
 cdr.enhancement.audio.stream=direct:process.enhancement.audio
 cdr.enhancement.audio.stream.camel=direct:process.enhancement.audio
-
-cdr.enhancement.pdf.stream=direct:process.enhancement.pdf
-cdr.enhancement.pdf.stream.camel=direct:process.enhancement.pdf
 
 # The camel URI for handling reindexing events.
 triplestore.reindex.stream=activemq:queue:triplestore.reindex


### PR DESCRIPTION
Change ref to using the correct name for the solrSearchService in the camel project