### PR TITLE
BXC-5725 Modify BinaryTransferClient to allow keeping old versions

### DIFF
--- a/persistence/src/main/java/edu/unc/lib/boxc/persist/impl/transfer/FSToFSTransferClient.java
+++ b/persistence/src/main/java/edu/unc/lib/boxc/persist/impl/transfer/FSToFSTransferClient.java
@@ -45,6 +45,8 @@ public class FSToFSTransferClient implements BinaryTransferClient {
 
     private static final Logger log = LoggerFactory.getLogger(FSToFSTransferClient.class);
 
+    public enum TransferMode { REJECT_EXISTING, REPLACE_EXISTING, KEEP_EXISTING_VERSIONS }
+
     public FSToFSTransferClient(IngestSource source, StorageLocation destination) {
         this.source = source;
         this.destination = destination;
@@ -52,21 +54,26 @@ public class FSToFSTransferClient implements BinaryTransferClient {
 
     @Override
     public BinaryTransferOutcome transfer(PID binPid, URI sourceFileUri) {
-        return transfer(binPid, sourceFileUri, false);
+        return transfer(binPid, sourceFileUri, TransferMode.REJECT_EXISTING);
     }
 
     @Override
     public BinaryTransferOutcome transferReplaceExisting(PID binPid, URI sourceFileUri) {
-        return transfer(binPid, sourceFileUri, true);
+        return transfer(binPid, sourceFileUri, TransferMode.REPLACE_EXISTING);
     }
 
-    public BinaryTransferOutcome transfer(PID binPid, URI sourceFileUri, boolean allowOverwrite) {
+    @Override
+    public BinaryTransferOutcome transferVersion(PID binPid, URI sourceFileUri) {
+        return transfer(binPid, sourceFileUri, TransferMode.KEEP_EXISTING_VERSIONS);
+    }
+
+    protected BinaryTransferOutcome transfer(PID binPid, URI sourceFileUri, TransferMode transferMode) {
         String digest;
         URI destUri = destination.getNewStorageUri(binPid);
         Path destinationPath = Paths.get(destUri);
         log.debug("Transferring {} to {}", sourceFileUri, destUri);
 
-        if (!allowOverwrite && FileSystemTransferHelpers.versionsExist(destinationPath)) {
+        if (transferMode == TransferMode.REJECT_EXISTING && FileSystemTransferHelpers.versionsExist(destinationPath)) {
             throw new BinaryAlreadyExistsException("Failed to transfer " + sourceFileUri
                     + ", a binary already exists in " + destination.getId() + " at path " + destUri);
         }
@@ -75,7 +82,9 @@ public class FSToFSTransferClient implements BinaryTransferClient {
 
         Path parentPath = destinationPath.getParent();
         try {
-            cleanupThread = FileTransferHelpers.registerCleanup(destinationPath);
+            if (transferMode != TransferMode.KEEP_EXISTING_VERSIONS) {
+                cleanupThread = FileTransferHelpers.registerCleanup(destinationPath);
+            }
 
             // Fill in parent directories if they are not present
             Files.createDirectories(parentPath);
@@ -87,11 +96,17 @@ public class FSToFSTransferClient implements BinaryTransferClient {
         } catch (IOException e) {
             log.debug("Attempting to cleanup failed transfer of {} to {}",
                     sourceFileUri, destinationPath);
-            FileTransferHelpers.cleanupFile(destinationPath);
+
+            if (transferMode != TransferMode.KEEP_EXISTING_VERSIONS) {
+                FileTransferHelpers.cleanupFile(destinationPath);
+            }
+
             throw new BinaryTransferException("Failed to transfer " + sourceFileUri
                     + " to destination " + destination.getId(), e);
         } finally {
-            FileTransferHelpers.clearCleanupHook(cleanupThread);
+            if (transferMode != TransferMode.KEEP_EXISTING_VERSIONS) {
+                FileTransferHelpers.clearCleanupHook(cleanupThread);
+            }
         }
 
         log.debug("Finished transferring {} to {}", sourceFileUri, destUri);
@@ -146,41 +161,6 @@ public class FSToFSTransferClient implements BinaryTransferClient {
         Files.setLastModifiedTime(destPath, Files.getLastModifiedTime(srcPath));
 
         return digest;
-    }
-
-    /**
-     * Similar to transfer, but keeps old versions of original_files (no cleanup)
-     * @param binPid
-     * @param sourceFileUri
-     */
-    public BinaryTransferOutcome transferAndKeep(PID binPid, URI sourceFileUri) {
-        String digest;
-        URI destUri = destination.getNewStorageUri(binPid);
-        Path destinationPath = Paths.get(destUri);
-        log.debug("Transferring {} to {}", sourceFileUri, destUri);
-
-        Path parentPath = destinationPath.getParent();
-        try {
-            // Fill in parent directories if they are not present
-            Files.createDirectories(parentPath);
-
-            Path sourcePath = Paths.get(sourceFileUri);
-
-            // Using FileUtils.copyFile since it defers to FileChannel.transferFrom, which is interruptible
-            digest = copyFile(sourcePath, destinationPath);
-        } catch (IOException e) {
-            throw new BinaryTransferException("Failed to transfer " + sourceFileUri
-                    + " to destination " + destination.getId(), e);
-        }
-
-        log.debug("Finished transferring {} to {}", sourceFileUri, destUri);
-
-        return new BinaryTransferOutcomeImpl(binPid, destUri, destination.getId(), digest);
-    }
-
-    @Override
-    public BinaryTransferOutcome transferVersion(PID binPid, URI sourceFileUri) {
-        return transferAndKeep(binPid, sourceFileUri);
     }
 
     @Override

--- a/persistence/src/main/java/edu/unc/lib/boxc/persist/impl/transfer/FSToFSTransferClient.java
+++ b/persistence/src/main/java/edu/unc/lib/boxc/persist/impl/transfer/FSToFSTransferClient.java
@@ -148,9 +148,39 @@ public class FSToFSTransferClient implements BinaryTransferClient {
         return digest;
     }
 
+    /**
+     * Similar to transfer, but keeps old versions of original_files (no cleanup)
+     * @param binPid
+     * @param sourceFileUri
+     */
+    public BinaryTransferOutcome transferAndKeep(PID binPid, URI sourceFileUri) {
+        String digest;
+        URI destUri = destination.getNewStorageUri(binPid);
+        Path destinationPath = Paths.get(destUri);
+        log.debug("Transferring {} to {}", sourceFileUri, destUri);
+
+        Path parentPath = destinationPath.getParent();
+        try {
+            // Fill in parent directories if they are not present
+            Files.createDirectories(parentPath);
+
+            Path sourcePath = Paths.get(sourceFileUri);
+
+            // Using FileUtils.copyFile since it defers to FileChannel.transferFrom, which is interruptible
+            digest = copyFile(sourcePath, destinationPath);
+        } catch (IOException e) {
+            throw new BinaryTransferException("Failed to transfer " + sourceFileUri
+                    + " to destination " + destination.getId(), e);
+        }
+
+        log.debug("Finished transferring {} to {}", sourceFileUri, destUri);
+
+        return new BinaryTransferOutcomeImpl(binPid, destUri, destination.getId(), digest);
+    }
+
     @Override
     public BinaryTransferOutcome transferVersion(PID binPid, URI sourceFileUri) {
-        throw new NotImplementedException("Versioning not yet implemented");
+        return transferAndKeep(binPid, sourceFileUri);
     }
 
     @Override

--- a/persistence/src/main/java/edu/unc/lib/boxc/persist/impl/transfer/FSToPosixTransferClient.java
+++ b/persistence/src/main/java/edu/unc/lib/boxc/persist/impl/transfer/FSToPosixTransferClient.java
@@ -34,8 +34,8 @@ public class FSToPosixTransferClient extends FSToFSTransferClient {
     }
 
     @Override
-    public BinaryTransferOutcome transfer(PID binPid, URI sourceFileUri, boolean allowOverwrite) {
-        BinaryTransferOutcome outcome = super.transfer(binPid, sourceFileUri, allowOverwrite);
+    public BinaryTransferOutcome transfer(PID binPid, URI sourceFileUri, TransferMode transferMode) {
+        BinaryTransferOutcome outcome = super.transfer(binPid, sourceFileUri, transferMode);
         HashedPosixStorageLocation posixLoc = (HashedPosixStorageLocation) destination;
 
         if (posixLoc.getPermissions() != null) {

--- a/persistence/src/test/java/edu/unc/lib/boxc/persist/impl/transfer/BinaryTransferSessionImplTest.java
+++ b/persistence/src/test/java/edu/unc/lib/boxc/persist/impl/transfer/BinaryTransferSessionImplTest.java
@@ -183,16 +183,34 @@ public class BinaryTransferSessionImplTest extends AbstractBinaryTransferTest {
 
     @Test
     public void transferVersionFSToFS() throws Exception {
-        Assertions.assertThrows(NotImplementedException.class, () -> {
-            when(ingestSource.getStorageType()).thenReturn(FILESYSTEM);
-            when(storageLoc.getStorageType()).thenReturn(FILESYSTEM);
+        when(ingestSource.getStorageType()).thenReturn(FILESYSTEM);
+        when(storageLoc.getStorageType()).thenReturn(FILESYSTEM);
 
-            Path sourceFile = createSourceFile();
+        Path version1Path = storagePath.resolve(binPid.getComponentId() + "_v1");
+        Path version2Path = storagePath.resolve(binPid.getComponentId() + "_v2");
 
-            try (BinaryTransferSessionImpl session = new BinaryTransferSessionImpl(sourceManager, storageLoc, bts)) {
-                session.transferVersion(binPid, sourceFile.toUri());
-            }
-        });
+        when(storageLoc.getNewStorageUri(binPid)).thenReturn(version1Path.toUri(), version2Path.toUri());
+
+        Path sourceFile = createSourceFile();
+
+        try (BinaryTransferSessionImpl session = new BinaryTransferSessionImpl(sourceManager, storageLoc, bts)) {
+            // First transfer creates version 1
+            BinaryTransferOutcome outcome1 = session.transferVersion(binPid, sourceFile.toUri());
+            assertEquals(version1Path, Paths.get(outcome1.getDestinationUri()));
+            assertIsSourceFile(version1Path);
+
+            // Change source content for second version
+            createFile(sourceFile, "new content");
+
+            // Second transfer creates version 2
+            BinaryTransferOutcome outcome2 = session.transferVersion(binPid, sourceFile.toUri());
+            assertEquals(version2Path, Paths.get(outcome2.getDestinationUri()));
+            assertFileContent(version2Path, "new content");
+
+            // Old version should still be accessible and unchanged
+            assertTrue(Files.exists(version1Path), "Old version should still exist");
+            assertFileContent(version1Path, FILE_CONTENT);
+        }
     }
 
     @Test

--- a/persistence/src/test/java/edu/unc/lib/boxc/persist/impl/transfer/FSToFSTransferClientTest.java
+++ b/persistence/src/test/java/edu/unc/lib/boxc/persist/impl/transfer/FSToFSTransferClientTest.java
@@ -226,6 +226,14 @@ public class FSToFSTransferClientTest {
         assertEquals(FILE_CONTENT, FileUtils.readFileToString(newVersion.toFile(), "UTF-8"));
     }
 
+    @Test
+    public void transferVersionFileThatDoesNotExist() {
+        Assertions.assertThrows(BinaryTransferException.class, () -> {
+            Path sourceFile = sourcePath.resolve("nofilehere.txt");
+            client.transferVersion(binPid, sourceFile.toUri());
+        });
+    }
+
     // Verify that file larger than file transfer buffer size is transferred
     @Test
     public void transferLargeFile() throws Exception {

--- a/persistence/src/test/java/edu/unc/lib/boxc/persist/impl/transfer/FSToFSTransferClientTest.java
+++ b/persistence/src/test/java/edu/unc/lib/boxc/persist/impl/transfer/FSToFSTransferClientTest.java
@@ -4,6 +4,7 @@ import static edu.unc.lib.boxc.model.fcrepo.ids.DatastreamPids.getOriginalFilePi
 import static org.apache.commons.codec.binary.Hex.encodeHexString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -20,7 +21,6 @@ import java.time.Duration;
 
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.NotImplementedException;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -207,10 +207,23 @@ public class FSToFSTransferClientTest {
 
     @Test
     public void transferVersion() throws Exception {
-        Assertions.assertThrows(NotImplementedException.class, () -> {
-            Path sourceFile = createSourceFile();
-            client.transferVersion(binPid, sourceFile.toUri());
-        });
+        Path originalVersion = Paths.get(storageLoc.getNewStorageUri(binPid));
+        Files.createDirectories(originalVersion.getParent());
+        createFile(originalVersion, "old content");
+
+        Path sourceFile = createSourceFile();
+
+        BinaryTransferOutcome outcome = client.transferVersion(binPid, sourceFile.toUri());
+        Path newVersion = Paths.get(outcome.getDestinationUri());
+
+        assertIsSourceFile(outcome);
+        assertOutcome(outcome, FILE_CONTENT_SHA1);
+
+        assertTrue(Files.exists(originalVersion), "Old version should still exist");
+        assertTrue(Files.exists(newVersion), "New version should exist");
+        assertNotEquals(originalVersion, newVersion, "New version should be stored separately");
+        assertEquals("old content", FileUtils.readFileToString(originalVersion.toFile(), "UTF-8"));
+        assertEquals(FILE_CONTENT, FileUtils.readFileToString(newVersion.toFile(), "UTF-8"));
     }
 
     // Verify that file larger than file transfer buffer size is transferred


### PR DESCRIPTION
[https://unclibrary.atlassian.net/browse/BXC-5725](https://unclibrary.atlassian.net/browse/BXC-5725)

- add `transferAndKeep` method to keep old versions and use in `transferVersion`
- add test